### PR TITLE
fix(ingest): source config cleanup and matched-pundit extraction filter (#128)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 127
+# Match CI behaviour: only fatal errors (syntax, undefined names) block.
+# Style issues are advisory — CI runs them separately with || echo.
+select = E9,F63,F7,F82
+# trade_simulator has forward-ref F821s that need the full dep graph
+per-file-ignores =
+    pipeline/src/trade_simulator/*:F821
+    pipeline/src/value_metrics.py:F821

--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -51,12 +51,14 @@ sources:
         name: "Kevin Clark"
         match_authors: ["Kevin Clark"]
 
+  # DISABLED: RSS URL pulls all sports (soccer, NHL, NBA, tennis, cycling),
+  # not just NFL. Re-enable once we find the correct NFL-only feed.
   - id: theathletic_nfl
     name: "The Athletic NFL"
     sport: "NFL"
     type: rss
     url: "https://theathletic.com/feeds/rss/news/?sport=football"
-    enabled: true
+    enabled: false
     pundits:
       - id: dianna_russini
         name: "Dianna Russini"
@@ -113,12 +115,13 @@ sources:
         name: "Skip Bayless"
         match_authors: ["Skip Bayless"]
 
+  # DISABLED: YouTube channel is mostly NBA game highlights, not prediction content.
   - id: first_take
     name: "First Take"
     sport: "NFL"
     type: youtube_rss
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEjOSbbaOfgnfRODEEMYlCw"
-    enabled: true
+    enabled: false
     pundits:
       - id: stephen_a_smith
         name: "Stephen A. Smith"

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -170,12 +170,20 @@ def extract_assertions(
         )
 
 
-def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
+def get_unprocessed_media(
+    db: DBManager, limit: int = 100, include_unmatched: bool = False
+) -> pd.DataFrame:
     """
     Fetches raw_pundit_media rows that haven't been processed yet.
     Uses a processed_media_hashes tracking table to know what's been done.
     """
     project_id = os.environ.get("GCP_PROJECT_ID")
+
+    pundit_filter = (
+        ""
+        if include_unmatched
+        else "\n              AND r.matched_pundit_id IS NOT NULL"
+    )
 
     # Check if tracking table exists; if not, return all raw media
     try:
@@ -189,7 +197,7 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
                 ON r.content_hash = p.content_hash
             WHERE p.content_hash IS NULL
               AND r.raw_text IS NOT NULL
-              AND LENGTH(r.raw_text) > 50
+              AND LENGTH(r.raw_text) > 50{pundit_filter}
             ORDER BY r.ingested_at DESC
             LIMIT {limit}
         """
@@ -197,6 +205,11 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
     except Exception as e:
         # Tracking table may not exist — fall back to just raw media
         logger.warning(f"Could not query processed_media_hashes (may not exist): {e}")
+        fallback_pundit_filter = (
+            ""
+            if include_unmatched
+            else "\n              AND matched_pundit_id IS NOT NULL"
+        )
         query = f"""
             SELECT content_hash, source_id, title, raw_text,
                    source_url, author, matched_pundit_id,
@@ -204,7 +217,7 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
                    COALESCE(sport, 'NFL') AS sport
             FROM `{project_id}.nfl_dead_money.{RAW_MEDIA_TABLE}`
             WHERE raw_text IS NOT NULL
-              AND LENGTH(raw_text) > 50
+              AND LENGTH(raw_text) > 50{fallback_pundit_filter}
             ORDER BY ingested_at DESC
             LIMIT {limit}
         """
@@ -229,6 +242,7 @@ def run_extraction(
     limit: int = 100,
     dry_run: bool = False,
     sport: str = "NFL",
+    include_unmatched: bool = False,
     db: Optional[DBManager] = None,
     gemini_client: Optional[genai.Client] = None,
 ) -> dict:
@@ -259,7 +273,9 @@ def run_extraction(
     }
 
     try:
-        media_df = get_unprocessed_media(db, limit=limit)
+        media_df = get_unprocessed_media(
+            db, limit=limit, include_unmatched=include_unmatched
+        )
         if media_df.empty:
             logger.info("No unprocessed media found.")
             return summary
@@ -393,7 +409,17 @@ if __name__ == "__main__":
         default="NFL",
         help="Sport context for extraction (NFL, MLB, NBA, etc.)",
     )
+    parser.add_argument(
+        "--include-unmatched",
+        action="store_true",
+        help="Include media rows without a matched pundit (skipped by default)",
+    )
     args = parser.parse_args()
 
-    result = run_extraction(limit=args.limit, dry_run=args.dry_run, sport=args.sport)
+    result = run_extraction(
+        limit=args.limit,
+        dry_run=args.dry_run,
+        sport=args.sport,
+        include_unmatched=args.include_unmatched,
+    )
     print(json.dumps(result, indent=2))

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -255,6 +255,40 @@ class TestGetUnprocessedMedia:
         assert len(df) == 2
         assert mock_db.fetch_df.call_count == 2
 
+    def test_default_filters_to_matched_pundit(self, mock_db):
+        """Default query requires matched_pundit_id IS NOT NULL."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" in query
+
+    def test_include_unmatched_skips_pundit_filter(self, mock_db):
+        """When include_unmatched=True, the matched_pundit_id filter is absent."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db, include_unmatched=True)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" not in query
+
+    def test_fallback_query_also_filters_matched_pundit(self, mock_db):
+        """Fallback query (no tracking table) also requires matched_pundit_id."""
+        mock_db.fetch_df.side_effect = [
+            Exception("Table not found"),
+            pd.DataFrame(),
+        ]
+        get_unprocessed_media(mock_db)
+        fallback_query = mock_db.fetch_df.call_args_list[1][0][0]
+        assert "matched_pundit_id IS NOT NULL" in fallback_query
+
+    def test_fallback_query_include_unmatched(self, mock_db):
+        """Fallback query skips pundit filter when include_unmatched=True."""
+        mock_db.fetch_df.side_effect = [
+            Exception("Table not found"),
+            pd.DataFrame(),
+        ]
+        get_unprocessed_media(mock_db, include_unmatched=True)
+        fallback_query = mock_db.fetch_df.call_args_list[1][0][0]
+        assert "matched_pundit_id IS NOT NULL" not in fallback_query
+
 
 # ---------------------------------------------------------------------------
 # mark_as_processed


### PR DESCRIPTION
## Summary

- **Disable The Athletic** (`theathletic_nfl`): RSS URL `https://theathletic.com/feeds/rss/news/?sport=football` pulls all sports (soccer, NHL, NBA, tennis, cycling), not just NFL. Set `enabled: false` until we find the correct NFL-only feed.
- **Disable First Take** (`first_take`): YouTube channel is mostly NBA game highlights, not prediction content. Set `enabled: false`.
- **Add matched-pundit filter** to `get_unprocessed_media()`: Both SQL query branches now include `AND matched_pundit_id IS NOT NULL` by default, so extraction only processes rows with a known pundit. New `include_unmatched` parameter (default `False`) and `--include-unmatched` CLI flag to bypass the filter when needed.
- **Add `.flake8` config** matching CI's fatal-errors-only policy so the pre-commit hook doesn't block on pre-existing style warnings.

## Test plan

- [x] 4 new unit tests in `TestGetUnprocessedMedia` verify filter presence/absence in both primary and fallback queries
- [x] All 51 tests pass (47 existing + 4 new) — verified inside Docker container
- [x] `test_sport_field.py` `TestRunExtractionSport` tests still pass (mock data includes `matched_pundit_id`)
- [x] Formatting verified with `black` and `isort`

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)