### PR TITLE
feat(ingest): YouTube transcript fetcher for prediction extraction (#126)

### DIFF
--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -94,7 +94,7 @@ sources:
   - id: pat_mcafee_show
     name: "The Pat McAfee Show"
     sport: "NFL"
-    type: youtube_rss
+    type: youtube_transcript
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCxcTeAKWJca6XyJ37_ZoKIQ"
     enabled: true
     pundits:
@@ -105,7 +105,7 @@ sources:
   - id: undisputed
     name: "Undisputed"
     sport: "NFL"
-    type: youtube_rss
+    type: youtube_transcript
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCuF2PqOvMBKBVi9JvtC3GqA"
     enabled: true
     pundits:
@@ -118,7 +118,7 @@ sources:
     sport: "NFL"
     type: youtube_rss
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEjOSbbaOfgnfRODEEMYlCw"
-    enabled: true
+    enabled: false  # NBA highlights, not NFL pundit content
     pundits:
       - id: stephen_a_smith
         name: "Stephen A. Smith"

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -38,3 +38,4 @@ google-genai
 duckdb
 duckduckgo-search
 pydantic
+youtube-transcript-api

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -22,6 +22,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -34,6 +35,7 @@ import requests
 import yaml
 from bs4 import BeautifulSoup
 from google.cloud import bigquery
+from youtube_transcript_api import YouTubeTranscriptApi
 
 from src.db_manager import DBManager
 
@@ -230,9 +232,142 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
     return items
 
 
+TRANSCRIPT_CHUNK_SIZE = 3500
+
+
+def _chunk_transcript(text: str, max_chars: int = TRANSCRIPT_CHUNK_SIZE) -> list[str]:
+    """Split transcript text into chunks of ~max_chars, splitting at sentence boundaries."""
+    if len(text) <= max_chars:
+        return [text]
+
+    chunks = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= max_chars:
+            chunks.append(remaining)
+            break
+
+        # Find last sentence boundary within the limit
+        split_at = max_chars
+        # Look for sentence-ending punctuation followed by a space
+        last_sentence = -1
+        for match in re.finditer(r"[.!?]\s", remaining[:max_chars]):
+            last_sentence = match.end()
+
+        if last_sentence > 0:
+            split_at = last_sentence
+        else:
+            # Fall back to last space
+            last_space = remaining[:max_chars].rfind(" ")
+            if last_space > 0:
+                split_at = last_space + 1
+
+        chunks.append(remaining[:split_at].strip())
+        remaining = remaining[split_at:].strip()
+
+    return chunks
+
+
+def _extract_video_id(url: str) -> str | None:
+    """Extract video ID from a YouTube URL."""
+    match = re.search(r"[?&]v=([a-zA-Z0-9_-]{11})", url)
+    return match.group(1) if match else None
+
+
+def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
+    """
+    Fetches recent videos from a YouTube channel via RSS, then downloads
+    auto-generated transcripts for each video.
+    """
+    url = source["url"]
+    source_id = source["id"]
+    pundits = source.get("pundits", [])
+    sport = source.get("sport", "NFL")
+    max_items = defaults.get("max_items_per_feed", 50)
+
+    # Default pundit for YouTube channels (usually single-pundit channels)
+    default_pundit = pundits[0] if pundits else {}
+    author = default_pundit.get("name")
+    pundit_id = default_pundit.get("id")
+    pundit_name = default_pundit.get("name")
+
+    logger.info(f"Fetching YouTube transcripts: {source['name']} ({url})")
+    feed = feedparser.parse(url, request_headers={"User-Agent": "PunditLedger/1.0"})
+
+    if feed.bozo and not feed.entries:
+        raise ValueError(f"Feed parse error for {source_id}: {feed.bozo_exception}")
+
+    items = []
+    now = datetime.now(timezone.utc)
+
+    for entry in feed.entries[:max_items]:
+        title = entry.get("title", "")
+        link = entry.get("link", "")
+        if not link:
+            continue
+
+        video_id = _extract_video_id(link)
+        if not video_id:
+            logger.warning(f"[{source_id}] Could not extract video ID from {link}")
+            continue
+
+        # Parse published date
+        published = None
+        if hasattr(entry, "published_parsed") and entry.published_parsed:
+            try:
+                published = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+            except Exception:
+                pass
+
+        # Download transcript
+        try:
+            transcript_data = YouTubeTranscriptApi.get_transcript(video_id)
+            transcript_text = " ".join(segment["text"] for segment in transcript_data)
+        except Exception as e:
+            logger.warning(
+                f"[{source_id}] Transcript unavailable for {video_id} "
+                f"({title}): {e}"
+            )
+            continue
+
+        if not transcript_text.strip():
+            continue
+
+        # Chunk if needed
+        chunks = _chunk_transcript(transcript_text)
+
+        for i, chunk in enumerate(chunks):
+            is_chunked = len(chunks) > 1
+            chunk_suffix = f"|chunk_{i}" if is_chunked else ""
+            chunk_title = f"{title} (part {i + 1})" if is_chunked else title
+
+            content_hash = compute_content_hash(link + chunk_suffix)
+
+            items.append(
+                MediaItem(
+                    content_hash=content_hash,
+                    source_id=source_id,
+                    title=chunk_title,
+                    raw_text=chunk,
+                    source_url=link,
+                    author=author,
+                    matched_pundit_id=pundit_id,
+                    matched_pundit_name=pundit_name,
+                    published_at=published,
+                    ingested_at=now,
+                    content_type="transcript",
+                    fetch_source_type="youtube_transcript",
+                    sport=sport,
+                )
+            )
+
+    return items
+
+
 FETCHERS = {
     "rss": fetch_rss,
     "youtube_rss": fetch_rss,  # YouTube Atom feeds work with feedparser
+    "youtube_transcript": fetch_youtube_transcripts,
 }
 
 

--- a/pipeline/tests/test_youtube_transcript.py
+++ b/pipeline/tests/test_youtube_transcript.py
@@ -1,0 +1,312 @@
+"""
+Tests for YouTube transcript fetcher (Issue #126).
+Unit tests — no network access required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.media_ingestor import (
+    MediaItem,
+    _chunk_transcript,
+    _extract_video_id,
+    compute_content_hash,
+    fetch_youtube_transcripts,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+YOUTUBE_SOURCE = {
+    "id": "pat_mcafee_show",
+    "name": "The Pat McAfee Show",
+    "sport": "NFL",
+    "type": "youtube_transcript",
+    "url": (
+        "https://www.youtube.com/feeds/videos.xml"
+        "?channel_id=UCxcTeAKWJca6XyJ37_ZoKIQ"
+    ),
+    "enabled": True,
+    "pundits": [
+        {
+            "id": "pat_mcafee",
+            "name": "Pat McAfee",
+            "match_authors": ["Pat McAfee"],
+        }
+    ],
+}
+
+DEFAULTS = {
+    "fetch_timeout_seconds": 10,
+    "max_retries": 2,
+    "retry_backoff_seconds": 0,
+    "max_items_per_feed": 10,
+    "dedup_window_days": 7,
+}
+
+
+def _make_feed_entry(
+    title="Test Video",
+    link="https://www.youtube.com/watch?v=abc12345678",
+):
+    entry = MagicMock()
+    entry.get = lambda k, d=None: {"title": title, "link": link}.get(k, d)
+    entry.title = title
+    entry.link = link
+    entry.published_parsed = (2025, 9, 1, 12, 0, 0, 0, 0, 0)
+    return entry
+
+
+def _make_feed(entries):
+    feed = MagicMock()
+    feed.bozo = False
+    feed.entries = entries
+    return feed
+
+
+# ---------------------------------------------------------------------------
+# Video ID extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVideoId:
+    def test_standard_url(self):
+        assert (
+            _extract_video_id("https://www.youtube.com/watch?v=abc12345678")
+            == "abc12345678"
+        )
+
+    def test_url_with_extra_params(self):
+        assert (
+            _extract_video_id("https://www.youtube.com/watch?v=abc12345678&t=120")
+            == "abc12345678"
+        )
+
+    def test_no_video_id(self):
+        assert _extract_video_id("https://www.youtube.com/channel/UCxyz") is None
+
+    def test_short_id_rejected(self):
+        # Video IDs are exactly 11 characters
+        assert _extract_video_id("https://www.youtube.com/watch?v=short") is None
+
+
+# ---------------------------------------------------------------------------
+# Transcript chunking
+# ---------------------------------------------------------------------------
+
+
+class TestChunkTranscript:
+    def test_short_text_no_chunking(self):
+        text = "This is a short transcript."
+        chunks = _chunk_transcript(text, max_chars=3500)
+        assert len(chunks) == 1
+        assert chunks[0] == text
+
+    def test_long_text_chunked(self):
+        # Create text > 3500 chars
+        sentences = ["This is sentence number %d." % i for i in range(200)]
+        text = " ".join(sentences)
+        assert len(text) > 3500
+
+        chunks = _chunk_transcript(text, max_chars=3500)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk) <= 3500
+
+    def test_all_text_preserved(self):
+        sentences = ["Sentence %d is here." % i for i in range(200)]
+        text = " ".join(sentences)
+        chunks = _chunk_transcript(text, max_chars=3500)
+        # Rejoin and verify all content is present
+        rejoined = " ".join(chunks)
+        # All original sentences should appear
+        for s in sentences:
+            assert s in rejoined
+
+    def test_splits_at_sentence_boundary(self):
+        # Build text that forces a split
+        text = "First sentence. " * 100 + "Last sentence."
+        chunks = _chunk_transcript(text, max_chars=500)
+        assert len(chunks) > 1
+        # Each chunk should end at a sentence boundary (or be the last chunk)
+        for chunk in chunks[:-1]:
+            assert chunk.rstrip().endswith(".")
+
+    def test_exact_size_no_split(self):
+        text = "a" * 3500
+        chunks = _chunk_transcript(text, max_chars=3500)
+        assert len(chunks) == 1
+
+    def test_10000_chars_produces_multiple_chunks(self):
+        text = "Word. " * 2000  # ~12000 chars
+        chunks = _chunk_transcript(text, max_chars=3500)
+        assert len(chunks) >= 3
+
+
+# ---------------------------------------------------------------------------
+# fetch_youtube_transcripts
+# ---------------------------------------------------------------------------
+
+
+class TestFetchYoutubeTranscripts:
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_returns_media_items(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry()
+        mock_fp.parse.return_value = _make_feed([entry])
+        mock_yt_api.get_transcript.return_value = [
+            {"text": "Hello everyone", "start": 0.0, "duration": 2.0},
+            {"text": "welcome to the show", "start": 2.0, "duration": 3.0},
+        ]
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        assert len(items) == 1
+        assert isinstance(items[0], MediaItem)
+        assert items[0].source_id == "pat_mcafee_show"
+        assert items[0].content_type == "transcript"
+        assert items[0].fetch_source_type == "youtube_transcript"
+        assert items[0].raw_text == "Hello everyone welcome to the show"
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_pundit_fields_set_from_source(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry()
+        mock_fp.parse.return_value = _make_feed([entry])
+        mock_yt_api.get_transcript.return_value = [
+            {"text": "test content", "start": 0.0, "duration": 1.0},
+        ]
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        assert items[0].matched_pundit_id == "pat_mcafee"
+        assert items[0].matched_pundit_name == "Pat McAfee"
+        assert items[0].author == "Pat McAfee"
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_transcript_unavailable_skips_video(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry()
+        mock_fp.parse.return_value = _make_feed([entry])
+        mock_yt_api.get_transcript.side_effect = Exception("Subtitles disabled")
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        assert len(items) == 0
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_chunked_transcript_produces_multiple_items(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry(title="Long Video")
+        mock_fp.parse.return_value = _make_feed([entry])
+
+        # Generate a long transcript (~10000 chars)
+        segments = [
+            {"text": f"This is segment number {i}.", "start": float(i), "duration": 1.0}
+            for i in range(500)
+        ]
+        mock_yt_api.get_transcript.return_value = segments
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        assert len(items) > 1
+        # Check titles include part numbers
+        assert items[0].title == "Long Video (part 1)"
+        assert items[1].title == "Long Video (part 2)"
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_chunked_content_hash_includes_chunk_suffix(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry(title="Long Video")
+        mock_fp.parse.return_value = _make_feed([entry])
+
+        segments = [
+            {"text": f"This is segment number {i}.", "start": float(i), "duration": 1.0}
+            for i in range(500)
+        ]
+        mock_yt_api.get_transcript.return_value = segments
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        # All hashes should be unique
+        hashes = [item.content_hash for item in items]
+        assert len(hashes) == len(set(hashes))
+
+        # Verify chunk 0 hash uses chunk suffix
+        video_url = "https://www.youtube.com/watch?v=abc12345678"
+        expected_hash_0 = compute_content_hash(video_url + "|chunk_0")
+        assert items[0].content_hash == expected_hash_0
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_single_item_no_chunk_suffix(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry()
+        mock_fp.parse.return_value = _make_feed([entry])
+        mock_yt_api.get_transcript.return_value = [
+            {"text": "Short video.", "start": 0.0, "duration": 1.0},
+        ]
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        assert len(items) == 1
+        # No chunk suffix for single items
+        video_url = "https://www.youtube.com/watch?v=abc12345678"
+        expected_hash = compute_content_hash(video_url)
+        assert items[0].content_hash == expected_hash
+        assert items[0].title == "Test Video"  # no "(part 1)"
+
+    @patch("src.media_ingestor.feedparser")
+    def test_feed_parse_error_raises(self, mock_fp):
+        feed = _make_feed([])
+        feed.bozo = True
+        feed.bozo_exception = "XML parse error"
+        mock_fp.parse.return_value = feed
+
+        with pytest.raises(ValueError, match="Feed parse error"):
+            fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_sport_field_from_source(self, mock_fp, mock_yt_api):
+        entry = _make_feed_entry()
+        mock_fp.parse.return_value = _make_feed([entry])
+        mock_yt_api.get_transcript.return_value = [
+            {"text": "test", "start": 0.0, "duration": 1.0},
+        ]
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+        assert items[0].sport == "NFL"
+
+    @patch("src.media_ingestor.YouTubeTranscriptApi")
+    @patch("src.media_ingestor.feedparser")
+    def test_multiple_videos_some_without_transcripts(self, mock_fp, mock_yt_api):
+        entries = [
+            _make_feed_entry(
+                title="Video 1", link="https://www.youtube.com/watch?v=vid00000001"
+            ),
+            _make_feed_entry(
+                title="Video 2", link="https://www.youtube.com/watch?v=vid00000002"
+            ),
+            _make_feed_entry(
+                title="Video 3", link="https://www.youtube.com/watch?v=vid00000003"
+            ),
+        ]
+        mock_fp.parse.return_value = _make_feed(entries)
+
+        def side_effect(video_id):
+            if video_id == "vid00000002":
+                raise Exception("Subtitles disabled")
+            return [
+                {"text": f"Transcript for {video_id}", "start": 0.0, "duration": 1.0}
+            ]
+
+        mock_yt_api.get_transcript.side_effect = side_effect
+
+        items = fetch_youtube_transcripts(YOUTUBE_SOURCE, DEFAULTS)
+
+        # Video 2 should be skipped
+        assert len(items) == 2
+        assert "vid00000001" in items[0].raw_text
+        assert "vid00000003" in items[1].raw_text


### PR DESCRIPTION
## Summary
- Add `fetch_youtube_transcripts()` fetcher to `media_ingestor.py` that downloads auto-generated YouTube captions via `youtube-transcript-api`, chunks long transcripts at sentence boundaries (~3500 chars), and creates `MediaItem`s for the assertion extraction pipeline
- Convert `pat_mcafee_show` and `undisputed` sources from `youtube_rss` to `youtube_transcript` type in `media_sources.yaml`
- Disable `first_take` source (NBA highlights, not NFL pundit content)
- Add `youtube-transcript-api` to `pipeline/requirements.txt`
- Add 19 unit tests covering video ID extraction, transcript chunking, fetcher behavior, error handling, and pundit field mapping

## Test plan
- [x] All 19 new tests pass in Docker (`test_youtube_transcript.py`)
- [x] All 26 existing `test_media_ingestor.py` tests still pass
- [x] Formatted with black and isort
- [ ] CI pipeline passes

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)