### PR TITLE
fix(ingest): disable noisy sources, add processed hash reset (#128)

### DIFF
--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -57,8 +57,10 @@ sources:
     name: "The Athletic NFL"
     sport: "NFL"
     type: rss
+    # Disabled: ?sport=football returns all sports (soccer, NHL, NBA, tennis, cycling).
+    # Re-enable once a working NFL-only feed URL is confirmed. (#128)
     url: "https://theathletic.com/feeds/rss/news/?sport=football"
-    enabled: true
+    enabled: false
     pundits:
       - id: dianna_russini
         name: "Dianna Russini"
@@ -121,8 +123,10 @@ sources:
     name: "First Take"
     sport: "NFL"
     type: youtube_rss
+    # Disabled: UCEjOSbbaOfgnfRODEEMYlCw is an NBA game highlights channel, not the
+    # First Take debate/opinion show. Re-enable with correct channel ID. (#128)
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEjOSbbaOfgnfRODEEMYlCw"
-    enabled: false  # NBA highlights, not NFL pundit content
+    enabled: false
     pundits:
       - id: stephen_a_smith
         name: "Stephen A. Smith"

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -27,6 +27,7 @@ from typing import Optional
 
 import pandas as pd
 from google import genai
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.genai import types
 
@@ -179,13 +180,13 @@ def get_unprocessed_media(
     """
     project_id = os.environ.get("GCP_PROJECT_ID")
 
-    pundit_filter = (
-        ""
-        if include_unmatched
-        else "\n              AND r.matched_pundit_id IS NOT NULL"
-    )
+    if include_unmatched:
+        pundit_filter = ""
+        fallback_pundit_filter = ""
+    else:
+        pundit_filter = "\n              AND r.matched_pundit_id IS NOT NULL"
+        fallback_pundit_filter = "\n              AND matched_pundit_id IS NOT NULL"
 
-    # Check if tracking table exists; if not, return all raw media
     try:
         query = f"""
             SELECT r.content_hash, r.source_id, r.title, r.raw_text,
@@ -202,14 +203,9 @@ def get_unprocessed_media(
             LIMIT {limit}
         """
         return db.fetch_df(query)
-    except Exception as e:
-        # Tracking table may not exist — fall back to just raw media
+    except NotFound as e:
+        # processed_media_hashes table doesn't exist yet — fall back to raw media only
         logger.warning(f"Could not query processed_media_hashes (may not exist): {e}")
-        fallback_pundit_filter = (
-            ""
-            if include_unmatched
-            else "\n              AND matched_pundit_id IS NOT NULL"
-        )
         query = f"""
             SELECT content_hash, source_id, title, raw_text,
                    source_url, author, matched_pundit_id,
@@ -236,6 +232,40 @@ def mark_as_processed(content_hashes: list[str], db: DBManager) -> None:
         }
     )
     db.append_dataframe_to_table(df, PROCESSED_TABLE)
+
+
+def reset_processed_hashes(db: DBManager, source_id: Optional[str] = None) -> int:
+    """
+    Clears processed_media_hashes so those items are re-extracted on the next run.
+
+    Args:
+        source_id: If set, only clear hashes for items from that source.
+                   If None, clears all processed hashes (full reset).
+    Returns:
+        Number of rows deleted.
+    """
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    if source_id:
+        query = f"""
+            DELETE FROM `{project_id}.nfl_dead_money.{PROCESSED_TABLE}` p
+            WHERE p.content_hash IN (
+                SELECT content_hash FROM `{project_id}.nfl_dead_money.{RAW_MEDIA_TABLE}`
+                WHERE source_id = '{source_id}'
+            )
+        """
+        logger.info(f"Clearing processed hashes for source_id={source_id!r}...")
+    else:
+        query = (
+            f"DELETE FROM `{project_id}.nfl_dead_money.{PROCESSED_TABLE}` WHERE TRUE"
+        )
+        logger.warning(
+            "Clearing ALL processed hashes — full re-extraction on next run."
+        )
+
+    result = db.execute(query)
+    rows_deleted = result.job.num_dml_affected_rows or 0
+    logger.info(f"Deleted {rows_deleted} rows from {PROCESSED_TABLE}.")
+    return rows_deleted
 
 
 def run_extraction(
@@ -414,12 +444,28 @@ if __name__ == "__main__":
         action="store_true",
         help="Include media rows without a matched pundit (skipped by default)",
     )
+    parser.add_argument(
+        "--reset-processed",
+        metavar="SOURCE_ID",
+        nargs="?",
+        const="__all__",
+        help=(
+            "Clear processed_media_hashes for SOURCE_ID (or all sources if omitted) "
+            "so those items are re-extracted on the next run. Exits after reset."
+        ),
+    )
     args = parser.parse_args()
 
-    result = run_extraction(
-        limit=args.limit,
-        dry_run=args.dry_run,
-        sport=args.sport,
-        include_unmatched=args.include_unmatched,
-    )
-    print(json.dumps(result, indent=2))
+    if args.reset_processed is not None:
+        db = DBManager()
+        source = None if args.reset_processed == "__all__" else args.reset_processed
+        deleted = reset_processed_hashes(db, source_id=source)
+        print(json.dumps({"reset": True, "rows_deleted": deleted}))
+    else:
+        result = run_extraction(
+            limit=args.limit,
+            dry_run=args.dry_run,
+            sport=args.sport,
+            include_unmatched=args.include_unmatched,
+        )
+        print(json.dumps(result, indent=2))

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -170,12 +170,20 @@ def extract_assertions(
         )
 
 
-def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
+def get_unprocessed_media(
+    db: DBManager, limit: int = 100, include_unmatched: bool = False
+) -> pd.DataFrame:
     """
     Fetches raw_pundit_media rows that haven't been processed yet.
     Uses a processed_media_hashes tracking table to know what's been done.
     """
     project_id = os.environ.get("GCP_PROJECT_ID")
+
+    pundit_filter = (
+        ""
+        if include_unmatched
+        else "\n              AND r.matched_pundit_id IS NOT NULL"
+    )
 
     # Check if tracking table exists; if not, return all raw media
     try:
@@ -189,7 +197,7 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
                 ON r.content_hash = p.content_hash
             WHERE p.content_hash IS NULL
               AND r.raw_text IS NOT NULL
-              AND LENGTH(r.raw_text) > 50
+              AND LENGTH(r.raw_text) > 50{pundit_filter}
             ORDER BY r.ingested_at DESC
             LIMIT {limit}
         """
@@ -197,6 +205,11 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
     except Exception as e:
         # Tracking table may not exist — fall back to just raw media
         logger.warning(f"Could not query processed_media_hashes (may not exist): {e}")
+        fallback_pundit_filter = (
+            ""
+            if include_unmatched
+            else "\n              AND matched_pundit_id IS NOT NULL"
+        )
         query = f"""
             SELECT content_hash, source_id, title, raw_text,
                    source_url, author, matched_pundit_id,
@@ -204,7 +217,7 @@ def get_unprocessed_media(db: DBManager, limit: int = 100) -> pd.DataFrame:
                    COALESCE(sport, 'NFL') AS sport
             FROM `{project_id}.nfl_dead_money.{RAW_MEDIA_TABLE}`
             WHERE raw_text IS NOT NULL
-              AND LENGTH(raw_text) > 50
+              AND LENGTH(raw_text) > 50{fallback_pundit_filter}
             ORDER BY ingested_at DESC
             LIMIT {limit}
         """
@@ -229,6 +242,7 @@ def run_extraction(
     limit: int = 100,
     dry_run: bool = False,
     sport: str = "NFL",
+    include_unmatched: bool = False,
     db: Optional[DBManager] = None,
     gemini_client: Optional[genai.Client] = None,
 ) -> dict:
@@ -259,7 +273,9 @@ def run_extraction(
     }
 
     try:
-        media_df = get_unprocessed_media(db, limit=limit)
+        media_df = get_unprocessed_media(
+            db, limit=limit, include_unmatched=include_unmatched
+        )
         if media_df.empty:
             logger.info("No unprocessed media found.")
             return summary
@@ -393,7 +409,17 @@ if __name__ == "__main__":
         default="NFL",
         help="Sport context for extraction (NFL, MLB, NBA, etc.)",
     )
+    parser.add_argument(
+        "--include-unmatched",
+        action="store_true",
+        help="Include media rows without a matched pundit (skipped by default)",
+    )
     args = parser.parse_args()
 
-    result = run_extraction(limit=args.limit, dry_run=args.dry_run, sport=args.sport)
+    result = run_extraction(
+        limit=args.limit,
+        dry_run=args.dry_run,
+        sport=args.sport,
+        include_unmatched=args.include_unmatched,
+    )
     print(json.dumps(result, indent=2))

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from google.api_core.exceptions import NotFound
 
 from src.assertion_extractor import (
     VALID_CATEGORIES,
@@ -17,6 +18,7 @@ from src.assertion_extractor import (
     extract_assertions,
     get_unprocessed_media,
     mark_as_processed,
+    reset_processed_hashes,
     run_extraction,
 )
 
@@ -248,7 +250,7 @@ class TestGetUnprocessedMedia:
 
     def test_falls_back_on_missing_tracking_table(self, mock_db):
         mock_db.fetch_df.side_effect = [
-            Exception("Table not found"),
+            NotFound("processed_media_hashes"),
             make_raw_media_df(2),
         ]
         df = get_unprocessed_media(mock_db)
@@ -272,7 +274,7 @@ class TestGetUnprocessedMedia:
     def test_fallback_query_also_filters_matched_pundit(self, mock_db):
         """Fallback query (no tracking table) also requires matched_pundit_id."""
         mock_db.fetch_df.side_effect = [
-            Exception("Table not found"),
+            NotFound("processed_media_hashes"),
             pd.DataFrame(),
         ]
         get_unprocessed_media(mock_db)
@@ -282,7 +284,7 @@ class TestGetUnprocessedMedia:
     def test_fallback_query_include_unmatched(self, mock_db):
         """Fallback query skips pundit filter when include_unmatched=True."""
         mock_db.fetch_df.side_effect = [
-            Exception("Table not found"),
+            NotFound("processed_media_hashes"),
             pd.DataFrame(),
         ]
         get_unprocessed_media(mock_db, include_unmatched=True)
@@ -308,6 +310,43 @@ class TestMarkAsProcessed:
     def test_no_op_on_empty_list(self, mock_db):
         mark_as_processed([], mock_db)
         mock_db.append_dataframe_to_table.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# reset_processed_hashes
+# ---------------------------------------------------------------------------
+
+
+class TestResetProcessedHashes:
+    def test_full_reset_executes_delete_all(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.job.num_dml_affected_rows = 5
+        mock_db.execute.return_value = mock_result
+
+        deleted = reset_processed_hashes(mock_db)
+
+        assert deleted == 5
+        query = mock_db.execute.call_args[0][0]
+        assert "DELETE FROM" in query
+        assert "WHERE TRUE" in query
+
+    def test_source_reset_filters_by_source_id(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.job.num_dml_affected_rows = 3
+        mock_db.execute.return_value = mock_result
+
+        deleted = reset_processed_hashes(mock_db, source_id="espn_nfl")
+
+        assert deleted == 3
+        query = mock_db.execute.call_args[0][0]
+        assert "source_id = 'espn_nfl'" in query
+
+    def test_handles_zero_rows(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.job.num_dml_affected_rows = None
+        mock_db.execute.return_value = mock_result
+
+        assert reset_processed_hashes(mock_db) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -255,6 +255,40 @@ class TestGetUnprocessedMedia:
         assert len(df) == 2
         assert mock_db.fetch_df.call_count == 2
 
+    def test_default_filters_to_matched_pundit(self, mock_db):
+        """Default query requires matched_pundit_id IS NOT NULL."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" in query
+
+    def test_include_unmatched_skips_pundit_filter(self, mock_db):
+        """When include_unmatched=True, the matched_pundit_id filter is absent."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db, include_unmatched=True)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" not in query
+
+    def test_fallback_query_also_filters_matched_pundit(self, mock_db):
+        """Fallback query (no tracking table) also requires matched_pundit_id."""
+        mock_db.fetch_df.side_effect = [
+            Exception("Table not found"),
+            pd.DataFrame(),
+        ]
+        get_unprocessed_media(mock_db)
+        fallback_query = mock_db.fetch_df.call_args_list[1][0][0]
+        assert "matched_pundit_id IS NOT NULL" in fallback_query
+
+    def test_fallback_query_include_unmatched(self, mock_db):
+        """Fallback query skips pundit filter when include_unmatched=True."""
+        mock_db.fetch_df.side_effect = [
+            Exception("Table not found"),
+            pd.DataFrame(),
+        ]
+        get_unprocessed_media(mock_db, include_unmatched=True)
+        fallback_query = mock_db.fetch_df.call_args_list[1][0][0]
+        assert "matched_pundit_id IS NOT NULL" not in fallback_query
+
 
 # ---------------------------------------------------------------------------
 # mark_as_processed


### PR DESCRIPTION
## Summary
- **Disable `theathletic_nfl`**: `?sport=football` returns all sports (soccer, NHL, NBA, tennis, cycling) — 50 rows, 0 NFL predictions. Re-enable once a working NFL-only feed URL is confirmed.
- **Disable `first_take`**: Channel `UCEjOSbbaOfgnfRODEEMYlCw` is an NBA game highlights channel, not the First Take debate show. Re-enable with correct channel ID.
- **Add `reset_processed_hashes()`**: New function + `--reset-processed [SOURCE_ID]` CLI flag to clear the `processed_media_hashes` tracking table so items can be re-extracted. Supports per-source or full reset. Addresses the 130-row failed Gemini run that marked everything as processed with 0 predictions.
- **Pundit-only filter**: `get_unprocessed_media` already filters `matched_pundit_id IS NOT NULL` by default, with `--include-unmatched` override. Tests confirm both paths.

## Test plan
- [x] 27 assertion extractor tests pass
- [x] 196/196 non-BQ tests pass in Docker

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)