### PR TITLE
fix(ci): add Clerk publishable key to canary and preflight workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -9,6 +9,7 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
 
 jobs:
   canary:

--- a/.github/workflows/frontend_preflight.yml
+++ b/.github/workflows/frontend_preflight.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Static Build Schema Validation
         working-directory: ./web
         env:
-          MOTHERDUCK_TOKEN: ${{ secrets.MOTHERDUCK_TOKEN }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
         run: npm run build


### PR DESCRIPTION
## Summary
- Adds `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` env var to the canary deploy workflow and frontend preflight build
- Replaces the unused `MOTHERDUCK_TOKEN` reference in the preflight workflow

## Why
After PR #117 fixed the Vercel `working-directory`, both workflows now reach the Next.js build step but fail with `@clerk/nextjs: Missing publishableKey`. Clerk requires the key at build time for static page generation.

## Test plan
- [ ] Canary Deploy passes
- [ ] Frontend Preflight Check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)