### PR TITLE
feat(agents): worktree enforcement + atomic locks + merge queue CI

### DIFF
--- a/.agent/activity.log
+++ b/.agent/activity.log
@@ -1,0 +1,8 @@
+# Agent Activity Log — append-only coordination audit trail
+# Format: ISO_TIMESTAMP | AGENT_ID | ACTION | RESOURCE
+# Actions: CLAIM, RELEASE, STALE-CLAIM, CLEANUP
+# Resources: issue:<n>  pr:<n>  file:<path>  branch:<name>
+# Rotation: entries older than 7 days are pruned weekly via .agent/claim.sh
+#
+2026-04-08T03:03:50Z | agent-test | CLAIM | issue:test-coord
+2026-04-08T03:03:50Z | agent-test | RELEASE | issue:test-coord

--- a/.agent/claim.sh
+++ b/.agent/claim.sh
@@ -1,0 +1,296 @@
+#!/bin/bash
+# Agent coordination — race-condition safe via atomic mkdir locks
+#
+# POSIX guarantees mkdir is atomic: exactly one concurrent caller succeeds.
+# Two agents racing to claim the same resource cannot both win.
+#
+# Usage:
+#   .agent/claim.sh claim   <resource> <agent-id>   # claim; exits 1 if held
+#   .agent/claim.sh release <resource> <agent-id>   # release your lock
+#   .agent/claim.sh check   <resource>              # print owner or "free"
+#   .agent/claim.sh status                          # list all active locks
+#   .agent/claim.sh cleanup                         # remove locks older than STALE_MINUTES
+#
+# Resources use a namespace prefix:
+#   issue:<n>   pr:<n>   file:<path>   branch:<name>
+#
+# Environment overrides:
+#   STALE_MINUTES   — minutes before a lock is considered stale (default: 60)
+#   LOG_RETAIN_DAYS — days of history to keep in activity.log (default: 7)
+
+set -euo pipefail
+
+# ── worktree guard ────────────────────────────────────────────────────────────
+# claim/release in the main checkout is almost always a mistake — the lock
+# system exists precisely because agents share the main repo, but actual
+# work should happen in worktrees. Refuse unless explicitly overridden.
+if [ "${1:-}" != "status" ] && [ "${1:-}" != "check" ] && [ "${ALLOW_MAIN_CHECKOUT:-0}" != "1" ]; then
+    git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+    git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -n "$git_dir" ] && [ "$git_dir" = "$git_common_dir" ]; then
+        cat >&2 <<'WTMSG'
+✗ Refusing to claim/release from the main checkout.
+
+This is a coordination footgun: the locks live in the main repo, but the
+actual file edits should happen in an isolated worktree so concurrent agents
+do not step on each other.
+
+Move into a worktree first:
+  git worktree add .claude/worktrees/<name> -b <branch>
+  cd .claude/worktrees/<name>
+  .agent/claim.sh claim issue:<n> <agent-id>
+
+Override (not recommended) by setting:  ALLOW_MAIN_CHECKOUT=1
+WTMSG
+        exit 1
+    fi
+fi
+
+AGENT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOCKS_DIR="${AGENT_DIR}/locks"
+LOG="${AGENT_DIR}/activity.log"
+STATUS_FILE="${AGENT_DIR}/current.md"
+ROTATE_MARKER="${AGENT_DIR}/.last_rotate"
+
+STALE_MINUTES="${STALE_MINUTES:-60}"
+LOG_RETAIN_DAYS="${LOG_RETAIN_DAYS:-7}"
+
+mkdir -p "$LOCKS_DIR"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+resource_to_dir() { echo "$1" | sed 's|[:/]|_|g'; }
+ts()    { date -u +%Y-%m-%dT%H:%M:%SZ; }
+epoch() { date -u +%s; }
+
+log_action() {
+    local action="$1" resource="$2" agent="$3"
+    echo "$(ts) | ${agent} | ${action} | ${resource}" >> "$LOG"
+}
+
+# ── write_status ──────────────────────────────────────────────────────────────
+# Atomically regenerate current.md from the live locks directory.
+# mv is atomic on POSIX — readers always see a complete file.
+write_status() {
+    local now_epoch now_ts tmp
+    now_epoch=$(epoch)
+    now_ts=$(ts)
+    tmp="${STATUS_FILE}.tmp.$$"
+
+    {
+        echo "# Agent Coordination — Current Status"
+        echo "Last updated: ${now_ts}"
+        echo ""
+
+        local found=0
+        for lock_dir in "${LOCKS_DIR}"/*/; do
+            [ -d "$lock_dir" ] || continue
+            [ -f "${lock_dir}/owner" ] || continue
+            if [ "$found" -eq 0 ]; then
+                printf '%-50s  %-32s  %s\n' "RESOURCE" "AGENT" "AGE"
+                printf '%-50s  %-32s  %s\n' \
+                    "--------------------------------------------------" \
+                    "--------------------------------" "-------"
+            fi
+            found=1
+            local lock_epoch lock_agent resource age_secs note=""
+            lock_epoch=$(grep '^EPOCH=' "${lock_dir}/owner" | cut -d= -f2)
+            lock_agent=$(grep '^AGENT=' "${lock_dir}/owner" | cut -d= -f2)
+            resource=$(grep  '^RESOURCE=' "${lock_dir}/owner" | cut -d= -f2)
+            age_secs=$(( now_epoch - lock_epoch ))
+            [ "$age_secs" -ge $(( STALE_MINUTES * 60 )) ] && note="  *** STALE ***"
+            printf '%-50s  %-32s  %ds%s\n' "$resource" "$lock_agent" "$age_secs" "$note"
+        done
+
+        [ "$found" -eq 0 ] && echo "(no active locks)"
+    } > "$tmp"
+
+    mv "$tmp" "$STATUS_FILE"
+}
+
+# ── rotate_log ────────────────────────────────────────────────────────────────
+# Prune activity.log entries older than LOG_RETAIN_DAYS, runs at most weekly.
+rotate_log() {
+    local now_epoch week_secs last_rotate
+    now_epoch=$(epoch)
+    week_secs=$(( 7 * 24 * 3600 ))
+
+    if [ -f "$ROTATE_MARKER" ]; then
+        last_rotate=$(cat "$ROTATE_MARKER")
+        [ $(( now_epoch - last_rotate )) -lt "$week_secs" ] && return 0
+    fi
+
+    local cutoff=$(( now_epoch - LOG_RETAIN_DAYS * 24 * 3600 ))
+    local tmp="${LOG}.rotate.$$"
+
+    python3 - "$LOG" "$cutoff" "$tmp" <<'PYEOF'
+import sys
+from datetime import datetime, timezone
+
+logfile, cutoff_str, outfile = sys.argv[1], sys.argv[2], sys.argv[3]
+cutoff_epoch = int(cutoff_str)
+kept, pruned = [], 0
+
+try:
+    with open(logfile) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                kept.append(line)
+                continue
+            try:
+                ts_str = stripped.split(' | ')[0].rstrip('Z')
+                ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+                if int(ts.timestamp()) >= cutoff_epoch:
+                    kept.append(line)
+                else:
+                    pruned += 1
+            except (ValueError, IndexError):
+                kept.append(line)
+except FileNotFoundError:
+    pass
+
+with open(outfile, 'w') as f:
+    f.writelines(kept)
+
+print(f"Log rotated: kept {len(kept)} lines, pruned {pruned} entries.", file=sys.stderr)
+PYEOF
+
+    mv "$tmp" "$LOG"
+    echo "$now_epoch" > "$ROTATE_MARKER"
+}
+
+# ── commands ──────────────────────────────────────────────────────────────────
+
+cmd_claim() {
+    local resource="${1:?resource required}" agent="${2:?agent-id required}"
+    local lock_dir="${LOCKS_DIR}/$(resource_to_dir "$resource")"
+
+    if mkdir "$lock_dir" 2>/dev/null; then
+        printf 'AGENT=%s\nRESOURCE=%s\nTIMESTAMP=%s\nEPOCH=%s\nPID=%s\n' \
+            "$agent" "$resource" "$(ts)" "$(epoch)" "$$" > "${lock_dir}/owner"
+        log_action CLAIM "$resource" "$agent"
+        write_status
+        rotate_log
+        echo "✓ Claimed: ${resource} → ${agent}"
+        return 0
+    fi
+
+    local owner_file="${lock_dir}/owner"
+    if [ ! -f "$owner_file" ]; then
+        echo "✗ ${resource} is locked (no owner file — partial write? retry shortly)" >&2
+        return 1
+    fi
+
+    local lock_epoch lock_agent
+    lock_epoch=$(grep '^EPOCH=' "$owner_file" | cut -d= -f2)
+    lock_agent=$(grep '^AGENT=' "$owner_file" | cut -d= -f2)
+    local age_secs=$(( $(epoch) - lock_epoch ))
+    local stale_secs=$(( STALE_MINUTES * 60 ))
+
+    if [ "$age_secs" -ge "$stale_secs" ]; then
+        printf 'AGENT=%s\nRESOURCE=%s\nTIMESTAMP=%s\nEPOCH=%s\nPID=%s\n' \
+            "$agent" "$resource" "$(ts)" "$(epoch)" "$$" > "${lock_dir}/owner"
+        log_action STALE-CLAIM "$resource" "${agent} (evicted ${lock_agent}, age ${age_secs}s)"
+        write_status
+        echo "⚠ Claimed (stale lock from ${lock_agent} evicted, age ${age_secs}s): ${resource}"
+        return 0
+    fi
+
+    echo "✗ ${resource} is held by ${lock_agent} (${age_secs}s ago). Choose a different task." >&2
+    return 1
+}
+
+cmd_release() {
+    local resource="${1:?resource required}" agent="${2:?agent-id required}"
+    local lock_dir="${LOCKS_DIR}/$(resource_to_dir "$resource")"
+
+    if [ ! -d "$lock_dir" ]; then
+        echo "✗ No lock found for: ${resource}" >&2
+        return 1
+    fi
+
+    if [ -f "${lock_dir}/owner" ]; then
+        local lock_agent
+        lock_agent=$(grep '^AGENT=' "${lock_dir}/owner" | cut -d= -f2)
+        if [ "$lock_agent" != "$agent" ]; then
+            echo "✗ Cannot release: ${resource} is held by ${lock_agent}, not ${agent}" >&2
+            return 1
+        fi
+    fi
+
+    rm -rf "$lock_dir"
+    log_action RELEASE "$resource" "$agent"
+    write_status
+    rotate_log
+    echo "✓ Released: ${resource}"
+}
+
+cmd_check() {
+    local resource="${1:?resource required}"
+    local lock_dir="${LOCKS_DIR}/$(resource_to_dir "$resource")"
+
+    if [ ! -d "$lock_dir" ]; then
+        echo "free"
+        return 0
+    fi
+
+    if [ -f "${lock_dir}/owner" ]; then
+        local age_secs lock_epoch
+        lock_epoch=$(grep '^EPOCH=' "${lock_dir}/owner" | cut -d= -f2)
+        age_secs=$(( $(epoch) - lock_epoch ))
+        cat "${lock_dir}/owner"
+        echo "AGE_SECONDS=${age_secs}"
+        [ "$age_secs" -ge $(( STALE_MINUTES * 60 )) ] && echo "STATUS=STALE"
+    else
+        echo "locked (no owner metadata)"
+    fi
+}
+
+cmd_status() {
+    write_status
+    cat "$STATUS_FILE"
+    echo ""
+    echo "=== Recent activity (last 10 lines) ==="
+    tail -10 "$LOG" 2>/dev/null | grep -v '^#' | grep -v '^$' || true
+}
+
+cmd_cleanup() {
+    local now_epoch stale_secs removed=0
+    now_epoch=$(epoch)
+    stale_secs=$(( STALE_MINUTES * 60 ))
+
+    for lock_dir in "${LOCKS_DIR}"/*/; do
+        [ -d "$lock_dir" ] || continue
+        [ -f "${lock_dir}/owner" ] || continue
+        local lock_epoch lock_agent resource age_secs
+        lock_epoch=$(grep '^EPOCH=' "${lock_dir}/owner" | cut -d= -f2)
+        lock_agent=$(grep '^AGENT=' "${lock_dir}/owner" | cut -d= -f2)
+        resource=$(grep  '^RESOURCE=' "${lock_dir}/owner" | cut -d= -f2)
+        age_secs=$(( now_epoch - lock_epoch ))
+        if [ "$age_secs" -ge "$stale_secs" ]; then
+            rm -rf "$lock_dir"
+            log_action CLEANUP "$resource" "cleanup (evicted ${lock_agent}, age ${age_secs}s)"
+            echo "Removed stale lock: ${resource} (${lock_agent}, ${age_secs}s old)"
+            removed=$(( removed + 1 ))
+        fi
+    done
+
+    write_status
+    rotate_log
+    echo "Done. Removed ${removed} stale lock(s)."
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+case "${1:-status}" in
+    claim)   cmd_claim   "${2:-}" "${3:-}" ;;
+    release) cmd_release "${2:-}" "${3:-}" ;;
+    check)   cmd_check   "${2:-}" ;;
+    status)  cmd_status ;;
+    cleanup) cmd_cleanup ;;
+    rotate)  rotate_log && echo "Log rotation check complete." ;;
+    *)
+        echo "Usage: $0 {claim|release|check|status|cleanup|rotate} [resource] [agent-id]" >&2
+        exit 1
+        ;;
+esac

--- a/.agent/current.md
+++ b/.agent/current.md
@@ -1,0 +1,4 @@
+# Agent Coordination — Current Status
+Last updated: 2026-04-08T03:03:50Z
+
+(no active locks)

--- a/.claude/hooks/require-worktree.sh
+++ b/.claude/hooks/require-worktree.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# PreToolUse hook — blocks file-editing tools when CWD is the main checkout.
+#
+# Enforces: agents must work in a git worktree (use the EnterWorktree tool),
+# never directly in the main checkout. Prevents concurrent agents from
+# stepping on each other's edits, branches, and staged changes.
+#
+# Detection: in a linked worktree, `git rev-parse --git-dir` resolves to
+# something like `<main>/.git/worktrees/<name>`, while `git-common-dir`
+# always points to the main `.git`. They differ ⇔ we are in a worktree.
+#
+# Exit codes:
+#   0 — allow the tool call
+#   2 — block (stderr is shown to Claude so it can self-correct)
+
+set -euo pipefail
+
+# Resolve git directories. Outside a git repo, allow the tool.
+git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+
+if [ -z "$git_dir" ] || [ -z "$git_common_dir" ]; then
+    exit 0
+fi
+
+# Normalize to absolute paths so the comparison is reliable.
+git_dir_abs="$(cd "$git_dir" 2>/dev/null && pwd || echo "$git_dir")"
+git_common_dir_abs="$(cd "$git_common_dir" 2>/dev/null && pwd || echo "$git_common_dir")"
+
+# In a linked worktree these differ; in the main checkout they're identical.
+if [ "$git_dir_abs" != "$git_common_dir_abs" ]; then
+    exit 0
+fi
+
+cat >&2 <<'MSG'
+✗ BLOCKED: file edits are not allowed in the main repository checkout.
+
+This project enforces git worktree isolation so concurrent agents cannot
+step on each other's branches, staged changes, or working-tree edits.
+
+To proceed:
+  1. Use the EnterWorktree tool to create an isolated worktree, OR
+  2. Run: git worktree add .claude/worktrees/<name> -b <new-branch>
+     and then `cd` into it.
+
+After moving into a worktree, retry the edit.
+
+When the PR is ready, land it via the GitHub merge queue:
+  gh pr merge <pr-number> --squash --auto
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/require-worktree.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Merge queue — re-runs CI on combined state of queued PRs before landing on main
+  merge_group:
+    branches: [ "main" ]
 
 jobs:
   test:

--- a/.github/workflows/frontend_preflight.yml
+++ b/.github/workflows/frontend_preflight.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+  # Merge queue — re-runs TS build check on combined state before landing on main
+  merge_group:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ pipeline/local_libs/
 
 # Logs
 *.log
+# Agent coordination audit log must be tracked (negation must come after *.log)
+!.agent/activity.log
 dbt/logs/
 airflow/logs/
 airflow/*.db*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,148 @@
+# NFL Dead Money / Pundit Prediction Ledger — Agent Instructions
+
+> ## ⚠️ STOP — READ THIS FIRST
+>
+> **All agent work on this repo MUST happen in a git worktree, and all PRs MUST land via the GitHub merge queue.**
+>
+> - **Never edit files in the main checkout.** A PreToolUse hook (`.claude/hooks/require-worktree.sh`) blocks Edit/Write/MultiEdit when CWD is the main repo. If you see that error, switch to a worktree.
+> - **Use `EnterWorktree` first**, or run `git worktree add .claude/worktrees/<name> -b <branch>` and `cd` into it before any edit.
+> - **Land PRs with `gh pr merge <n> --squash --auto`** (queue), never with direct merge.
+> - **Why:** concurrent agents in the same checkout cause branch switches, vanishing edits, and merge conflicts. Worktrees give physical isolation; the merge queue serializes landings and re-runs CI on the combined state.
+>
+> Established 2026-04-07 after multi-agent coordination failures.
+
+---
+
+## Project overview
+NFL contract analytics pipeline + **Pundit Prediction Ledger** (the product). Medallion architecture (bronze/silver/gold) on BigQuery. XGBoost risk model. FastAPI backend. Next.js dashboard.
+
+## Tech stack
+- **Python 3.14** (local), Docker for pipeline execution
+- **BigQuery** — sole data warehouse (no DuckDB/MotherDuck)
+- **Pipeline**: custom Python ETL in `pipeline/src/`
+- **ML**: XGBoost, scikit-learn, SHAP
+- **API**: FastAPI (`pipeline/api/`)
+- **Frontend**: Next.js (`web/`)
+- **CI**: GitHub Actions (`.github/workflows/`)
+- **Testing**: pytest (`pipeline/pytest.ini`, `pipeline/tests/`)
+
+## Execution environment
+
+**All pipeline code runs inside Docker, not on the local filesystem.**
+
+```bash
+make up
+docker compose --env-file docker_env.txt exec pipeline bash -c "<command>"
+```
+
+Local Python is fine for `black`, `isort`, `flake8`, `git`, file reads/edits/searches.
+
+## Agent coordination
+
+Multiple agents may run concurrently. The combination of **worktrees + merge queue + locks** prevents stepping on each other:
+
+| Layer | Tool | What it prevents |
+|---|---|---|
+| File isolation | Git worktrees (`EnterWorktree`) | Concurrent edits to the same checkout |
+| Task isolation | `.agent/claim.sh` issue/PR locks | Two agents picking the same issue |
+| Landing isolation | GitHub merge queue (`gh pr merge --auto`) | Semantic conflicts at merge time |
+| Enforcement | `.claude/hooks/require-worktree.sh` | Edit/Write tools refuse to run in main checkout |
+
+### Protocol
+
+```bash
+# 1. Create an isolated worktree (or use the EnterWorktree tool)
+git worktree add .claude/worktrees/issue-129 -b feat/129-pundit-roster
+cd .claude/worktrees/issue-129
+
+# 2. Check what's currently claimed (run from the worktree)
+cat .agent/current.md
+
+# 3. Claim the issue and any shared files you'll edit
+.agent/claim.sh claim issue:129 claude-sonnet-<session>
+.agent/claim.sh claim file:pipeline/src/assertion_extractor.py claude-sonnet-<session>
+
+# 4. Do your work, commit, push, open the PR
+
+# 5. Queue the PR for landing — never direct merge
+gh pr merge <pr-number> --squash --auto
+
+# 6. After the PR lands on main, release locks
+.agent/claim.sh release issue:129 claude-sonnet-<session>
+.agent/claim.sh release file:pipeline/src/assertion_extractor.py claude-sonnet-<session>
+```
+
+### Lock semantics
+- POSIX-atomic `mkdir` — exactly one concurrent caller wins, others get an immediate error and the holder's identity.
+- `current.md` regenerated atomically on every claim/release; `cat .agent/current.md` for an instant snapshot.
+- `activity.log` is append-only audit history; entries older than 7 days pruned weekly.
+- Stale locks auto-evict after 60 minutes (`STALE_MINUTES` env var to override).
+- `claim.sh` refuses to run from the main checkout unless `ALLOW_MAIN_CHECKOUT=1`.
+
+### Shared files (high conflict risk — always claim before editing)
+```
+pipeline/src/assertion_extractor.py
+pipeline/src/cryptographic_ledger.py
+pipeline/src/db_manager.py
+pipeline/config/media_sources.yaml
+web/app/layout.tsx
+```
+
+## Conventions
+- BigQuery only. No DuckDB/MotherDuck references.
+- Medallion layers: bronze (raw) → silver (cleaned) → gold (features/aggregates)
+- All BigQuery access goes through `pipeline/src/db_manager.py`
+- Config via `pipeline/src/config.py` and `pipeline/config/`
+- Environment variables for secrets (never hardcode)
+- Commit messages: `type(scope): description`
+- All SQL must compile natively for BigQuery (`STRING` not `VARCHAR`, `FLOAT64`/`INT64`, `SAFE_CAST` not `TRY_CAST`, `MOD()` not `%`).
+
+## Workflows
+
+### /preflight — Run before any PR
+```
+1. black --check pipeline/src/
+2. isort --check pipeline/src/
+3. flake8 pipeline/src/
+4. make up  # ensure Docker is running
+5. docker compose --env-file docker_env.txt exec pipeline bash -c "python -m pytest pipeline/tests/ -v --tb=short"
+```
+
+### /test — Run the test suite
+```
+make up
+docker compose --env-file docker_env.txt exec pipeline bash -c "python -m pytest pipeline/tests/ -v --tb=short"
+```
+
+### /lint — Format and lint
+```
+black pipeline/src/
+isort pipeline/src/
+flake8 pipeline/src/
+```
+
+## Working style
+
+### Autonomy defaults
+- If multiple paths forward exist and they're roughly equal, pick one. Don't ask.
+- Inform the user what you're doing, then do it. Don't wait for permission on routine work.
+- Prefer small, focused PRs. One concern per commit.
+
+### Decision authority — what to do without asking
+- **Code changes**: refactor, fix bugs, add features described in an issue — just do it.
+- **File creation/deletion**: create new modules, tests, migrations as needed.
+- **Dependency changes**: add packages to requirements.txt if the task clearly needs them.
+- **Git**: create branches, commit, push feature branches. Never force-push or push to main.
+- **CI fixes**: if a workflow is broken and the fix is obvious, fix it.
+
+### When to ask the user
+- **Product questions** — "should this work like X or Y?"
+- **Scope ambiguity** — 1-hour fix vs 1-week feature?
+- **External service changes** — new API keys, GCP resources, billing implications.
+- **Data model changes** — altering existing BigQuery schemas (adding columns is fine).
+
+## Token discipline — fix it, don't churn on it
+- **Fix proactively** — don't leave broken things for the user to discover.
+- **Recognize when you're spinning wheels.** 2-3 attempts at the same fix without convergence = stop. Summarize and hand back.
+- Diagnose before retrying. Try a *different* approach.
+- Stay on target. No speculative refactoring or gold-plating.


### PR DESCRIPTION
## Summary
- **PreToolUse hook** blocks file edits in the main checkout, forcing agents into worktrees
- **Atomic mkdir locks** in .agent/claim.sh prevent two agents from claiming the same issue/file
- **Merge queue triggers** added to tests.yml, ci.yml, frontend_preflight.yml
- **current.md** regenerated atomically on every claim/release for instant status
- **CLAUDE.md** rewritten with worktree/merge-queue rule at the top

## Why
After a session of agents stepping on each other (branch switches mid-operation, vanishing staged changes, reverted edits), the root cause is concurrent modification of the same working tree. Worktrees provide physical isolation; merge queue catches semantic conflicts at land time.

## Manual step required
Enable merge queue in repo settings: **Settings → Branches → Add ruleset → merge queue** (the API does not accept the merge_queue rule type for this account tier).

## Test plan
- [x] claim.sh refuses to run from main checkout (tested)
- [x] claim.sh works inside a worktree (tested)
- [x] current.md regenerates atomically on claim/release (tested)
- [x] Stale lock eviction after STALE_MINUTES (tested)
- [ ] Verify PreToolUse hook blocks Edit/Write in main checkout on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)