### PR TITLE
fix(ingest): source config cleanup and quality filters

### DIFF
--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -60,7 +60,22 @@ sources:
     # Disabled: ?sport=football returns all sports (soccer, NHL, NBA, tennis, cycling).
     # Re-enable once a working NFL-only feed URL is confirmed. (#128)
     url: "https://theathletic.com/feeds/rss/news/?sport=football"
-    enabled: false
+    enabled: true
+    # Feed may include non-NFL content; keyword_filter skips entries lacking these terms
+    keyword_filter:
+      - "NFL"
+      - "football"
+      - "quarterback"
+      - "touchdown"
+      - "draft"
+      - "free agent"
+      - "trade"
+      - "roster"
+      - "coach"
+      - "playoff"
+      - "Super Bowl"
+      - "AFC"
+      - "NFC"
     pundits:
       - id: dianna_russini
         name: "Dianna Russini"
@@ -126,7 +141,7 @@ sources:
     # Disabled: UCEjOSbbaOfgnfRODEEMYlCw is an NBA game highlights channel, not the
     # First Take debate/opinion show. Re-enable with correct channel ID. (#128)
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEjOSbbaOfgnfRODEEMYlCw"
-    enabled: false
+    enabled: false  # Disabled: channel is NBA game highlights, not NFL prediction content (#128)
     pundits:
       - id: stephen_a_smith
         name: "Stephen A. Smith"

--- a/pipeline/scripts/cleanup_failed_gemini_hashes.sql
+++ b/pipeline/scripts/cleanup_failed_gemini_hashes.sql
@@ -1,0 +1,26 @@
+-- One-time cleanup: remove processed_media_hashes entries from the failed
+-- Gemini 2.0 run that marked 130 rows as "processed" with 0 extractions.
+--
+-- These rows were marked done but produced no predictions, likely due to
+-- the Gemini 2.0 model issues. Clearing them allows re-processing after
+-- source fixes (The Athletic keyword filter, First Take disabled, pundit
+-- quality filter).
+--
+-- Run this AFTER deploying the source config + extractor fixes from #128.
+--
+-- Usage (inside Docker):
+--   bq query --use_legacy_sql=false < pipeline/scripts/cleanup_failed_gemini_hashes.sql
+--
+-- Safety: only deletes hashes that have zero corresponding predictions
+-- in the ledger, so successfully-extracted content is preserved.
+
+DELETE FROM `{project_id}.nfl_dead_money.processed_media_hashes` p
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM `{project_id}.nfl_dead_money.prediction_ledger` l
+    WHERE l.source_url IN (
+        SELECT r.source_url
+        FROM `{project_id}.nfl_dead_money.raw_pundit_media` r
+        WHERE r.content_hash = p.content_hash
+    )
+);

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -278,7 +278,6 @@ def run_extraction(
     include_unmatched: bool = False,
     db: Optional[DBManager] = None,
     gemini_client: Optional[genai.Client] = None,
-    include_unmatched: bool = False,
 ) -> dict:
     """
     Main extraction entry point.

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -177,9 +177,12 @@ def get_unprocessed_media(
     """
     Fetches raw_pundit_media rows that haven't been processed yet.
     Uses a processed_media_hashes tracking table to know what's been done.
+
+    By default, only returns rows with a matched pundit to avoid wasting
+    Gemini API calls on unattributed content. Pass include_unmatched=True
+    to override and process all content regardless of pundit match.
     """
     project_id = os.environ.get("GCP_PROJECT_ID")
-
     if include_unmatched:
         pundit_filter = ""
         fallback_pundit_filter = ""
@@ -275,6 +278,7 @@ def run_extraction(
     include_unmatched: bool = False,
     db: Optional[DBManager] = None,
     gemini_client: Optional[genai.Client] = None,
+    include_unmatched: bool = False,
 ) -> dict:
     """
     Main extraction entry point.

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -150,6 +150,12 @@ def match_pundit(
 # ---------------------------------------------------------------------------
 
 
+def _passes_keyword_filter(title: str, text: str, keywords: list[str]) -> bool:
+    """Check if title or text contains at least one keyword (case-insensitive)."""
+    combined = f"{title} {text}".lower()
+    return any(kw.lower() in combined for kw in keywords)
+
+
 def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
     """Fetches and parses an RSS feed, returning MediaItems."""
     url = source["url"]
@@ -158,6 +164,7 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
     sport = source.get("sport", "NFL")
     max_items = defaults.get("max_items_per_feed", 50)
     timeout = defaults.get("fetch_timeout_seconds", 30)
+    keyword_filter = source.get("keyword_filter", [])
 
     logger.info(f"Fetching RSS: {source['name']} ({url})")
     feed = feedparser.parse(url, request_headers={"User-Agent": "PunditLedger/1.0"})
@@ -167,6 +174,7 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
 
     items = []
     now = datetime.now(timezone.utc)
+    skipped_by_filter = 0
 
     for entry in feed.entries[:max_items]:
         title = entry.get("title", "")
@@ -199,6 +207,13 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
                 if len(text) > len(raw_text):
                     raw_text = text
 
+        # Apply keyword filter if configured (skip non-matching entries)
+        if keyword_filter and not _passes_keyword_filter(
+            title, raw_text, keyword_filter
+        ):
+            skipped_by_filter += 1
+            continue
+
         pundit_id, pundit_name = match_pundit(author, pundits)
         content_hash = compute_content_hash(link, title)
 
@@ -227,6 +242,11 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
                 sport=sport,
                 raw_metadata=json.dumps(metadata) if metadata else None,
             )
+        )
+
+    if skipped_by_filter:
+        logger.info(
+            f"[{source_id}] Keyword filter skipped {skipped_by_filter} non-matching entries"
         )
 
     return items

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -248,6 +248,20 @@ class TestGetUnprocessedMedia:
         assert "LEFT JOIN" in query
         assert "processed_media_hashes" in query
 
+    def test_filters_unmatched_pundits_by_default(self, mock_db):
+        """Default query should require matched_pundit_id IS NOT NULL."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" in query
+
+    def test_include_unmatched_skips_pundit_filter(self, mock_db):
+        """With include_unmatched=True, query should NOT filter on pundit."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        get_unprocessed_media(mock_db, include_unmatched=True)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "matched_pundit_id IS NOT NULL" not in query
+
     def test_falls_back_on_missing_tracking_table(self, mock_db):
         mock_db.fetch_df.side_effect = [
             NotFound("processed_media_hashes"),
@@ -422,6 +436,26 @@ class TestRunExtraction:
         summary = run_extraction(limit=10, db=mock_db, gemini_client=MagicMock())
 
         assert summary["total_processed"] == 0
+
+    @patch("src.assertion_extractor.get_unprocessed_media")
+    def test_passes_include_unmatched_flag(self, mock_get, mock_db):
+        """include_unmatched flag should be forwarded to get_unprocessed_media."""
+        mock_get.return_value = pd.DataFrame()
+
+        run_extraction(
+            limit=5, db=mock_db, gemini_client=MagicMock(), include_unmatched=True
+        )
+
+        mock_get.assert_called_once_with(mock_db, limit=5, include_unmatched=True)
+
+    @patch("src.assertion_extractor.get_unprocessed_media")
+    def test_default_excludes_unmatched(self, mock_get, mock_db):
+        """By default, include_unmatched should be False."""
+        mock_get.return_value = pd.DataFrame()
+
+        run_extraction(limit=5, db=mock_db, gemini_client=MagicMock())
+
+        mock_get.assert_called_once_with(mock_db, limit=5, include_unmatched=False)
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_media_ingestor.py
+++ b/pipeline/tests/test_media_ingestor.py
@@ -16,6 +16,7 @@ import pytest
 from src.media_ingestor import (
     MediaItem,
     SourceResult,
+    _passes_keyword_filter,
     compute_content_hash,
     fetch_rss,
     get_existing_hashes,
@@ -145,6 +146,85 @@ class TestPunditMatching:
         pid, pname = match_pundit(None, self.PUNDITS)
         assert pid is None
         assert pname is None
+
+
+# ---------------------------------------------------------------------------
+# Keyword filter
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordFilter:
+    def test_matches_title(self):
+        assert _passes_keyword_filter("NFL Draft Preview", "", ["NFL", "football"])
+
+    def test_matches_text(self):
+        assert _passes_keyword_filter(
+            "", "The quarterback threw a touchdown", ["touchdown"]
+        )
+
+    def test_case_insensitive(self):
+        assert _passes_keyword_filter("nfl news", "", ["NFL"])
+
+    def test_no_match(self):
+        assert not _passes_keyword_filter(
+            "Premier League Recap", "Soccer highlights", ["NFL", "football", "draft"]
+        )
+
+    def test_empty_keywords_returns_false(self):
+        # Empty keyword list means any() over empty iterable → False.
+        # Callers guard with `if keyword_filter and ...` so this is safe.
+        assert not _passes_keyword_filter("Anything", "at all", [])
+
+    def test_partial_word_match(self):
+        """'football' in keyword list matches 'football' in text."""
+        assert _passes_keyword_filter("", "Great football game today", ["football"])
+
+    @patch("src.media_ingestor.feedparser")
+    def test_fetch_rss_skips_filtered_entries(self, mock_fp):
+        """Entries not matching keyword_filter should be skipped."""
+        entry_nfl = MagicMock()
+        entry_nfl.get = lambda k, d=None: {
+            "title": "NFL Draft Big Board",
+            "link": "https://example.com/nfl",
+            "author": "Test Author",
+        }.get(k, d)
+        entry_nfl.published_parsed = (2025, 9, 1, 12, 0, 0, 0, 0, 0)
+        type(entry_nfl).summary = property(lambda self: "<p>NFL draft content</p>")
+        entry_nfl.content = []
+        entry_nfl.tags = []
+
+        entry_soccer = MagicMock()
+        entry_soccer.get = lambda k, d=None: {
+            "title": "Premier League Weekend Recap",
+            "link": "https://example.com/soccer",
+            "author": "Test Author",
+        }.get(k, d)
+        entry_soccer.published_parsed = (2025, 9, 1, 12, 0, 0, 0, 0, 0)
+        type(entry_soccer).summary = property(
+            lambda self: "<p>Soccer match highlights</p>"
+        )
+        entry_soccer.content = []
+        entry_soccer.tags = []
+
+        feed = MagicMock()
+        feed.bozo = False
+        feed.entries = [entry_nfl, entry_soccer]
+        mock_fp.parse.return_value = feed
+
+        source = {
+            "id": "theathletic_nfl",
+            "name": "The Athletic NFL",
+            "type": "rss",
+            "url": "https://example.com/feed",
+            "sport": "NFL",
+            "keyword_filter": ["NFL", "football", "draft"],
+            "pundits": [],
+        }
+        defaults = {"max_items_per_feed": 50, "fetch_timeout_seconds": 30}
+
+        items = fetch_rss(source, defaults)
+        assert len(items) == 1
+        assert items[0].title == "NFL Draft Big Board"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #128. Adds keyword filter for The Athletic RSS, disables First Take, adds pundit quality filter to assertion extractor with --include-unmatched override, and cleanup SQL script.