### PR TITLE
feat(feature-store): migrate FeatureStore from DuckDB to BigQuery

### DIFF
--- a/.github/workflows/sync_daily.yml
+++ b/.github/workflows/sync_daily.yml
@@ -50,4 +50,5 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           python pipeline/scripts/medallion_pipeline.py
+          python pipeline/scripts/materialize_features.py
           python pipeline/src/cryptographic_ledger.py

--- a/pipeline/scripts/materialize_features.py
+++ b/pipeline/scripts/materialize_features.py
@@ -3,15 +3,15 @@
 Materialize Features Pipeline
 
 This script is the dedicated pipeline step for materializing features into the
-Feature Store. It should be run after ingestion and before training.
+BigQuery-backed Feature Store. It should be run after ingestion and before training.
 
 Pipeline Order:
-1. ingest_to_duckdb.py (Bronze → Silver → Gold)
-2. materialize_features.py (Gold → Feature Store)  ← THIS SCRIPT
-3. train_model.py (Feature Store → Model)
+1. medallion_pipeline.py (Bronze -> Silver -> Gold)
+2. materialize_features.py (Gold -> Feature Store)  <- THIS SCRIPT
+3. train_model.py (Feature Store -> Model)
 
 Usage:
-    python scripts/materialize_features.py [--year YEAR] [--validate-only]
+    python scripts/materialize_features.py [--validate-only]
 """
 
 import argparse
@@ -22,28 +22,29 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from src.db_manager import DBManager
 from src.feature_store import FeatureStore
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 
 
-def materialize_all_features(validate_only: bool = False, read_only: bool = False):
+def materialize_all_features(validate_only: bool = False):
     """
     Materialize all features into the Feature Store.
-    
+
     Args:
         validate_only: If True, only validate existing features without re-materializing
-        read_only: If True, open the database in read-only mode
     """
-    store = FeatureStore(read_only=read_only)
-    
+    db = DBManager()
+    store = FeatureStore(db=db)
+
     # Initialize schema (idempotent)
     store.initialize_schema()
-    
+
     if validate_only:
         logger.info("=== Validation Only Mode ===")
         is_valid = store.validate_temporal_integrity()
@@ -51,53 +52,56 @@ def materialize_all_features(validate_only: bool = False, read_only: bool = Fals
         print("\n=== Feature Store Statistics ===")
         print(stats)
         return is_valid
-    
+
     # Step 1: Materialize Lag Features (critical for preventing leakage)
     logger.info("=== Step 1: Materializing Lag Features ===")
-    store.materialize_lag_features(source_table='fact_player_efficiency')
-    
+    store.materialize_lag_features(source_table="fact_player_efficiency")
+
     # Step 2: Materialize Interaction Features
     logger.info("=== Step 2: Materializing Interaction Features ===")
-    store.materialize_interaction_features(source_table='fact_player_efficiency')
-    
+    store.materialize_interaction_features(source_table="fact_player_efficiency")
+
     # Step 3: Validate Temporal Integrity
     logger.info("=== Step 3: Validating Temporal Integrity ===")
     is_valid = store.validate_temporal_integrity()
-    
+
     # Step 4: Report Statistics
     stats = store.get_feature_stats()
     print("\n=== Feature Store Statistics ===")
     print(stats)
-    
+
     # Step 5: Sample verification
     logger.info("=== Step 4: Sample Point-in-Time Check ===")
-    sample = store.con.execute("""
+    sample = db.fetch_df("""
         SELECT player_name, prediction_year, feature_name, feature_value, valid_from
         FROM feature_values
         WHERE feature_name = 'total_tds_lag_1'
-        ORDER BY RANDOM()
+        ORDER BY RAND()
         LIMIT 5
-    """).df()
+    """)
     print("\nSample lag_1 features (valid_from should be prediction_year - 1):")
     print(sample)
-    
+
     if is_valid:
-        logger.info("✅ Feature materialization complete. Zero temporal violations.")
+        logger.info("Feature materialization complete. Zero temporal violations.")
     else:
-        logger.error("❌ Feature materialization complete but violations detected!")
-        
+        logger.error("Feature materialization complete but violations detected!")
+
     return is_valid
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Materialize features into Feature Store')
-    parser.add_argument('--validate-only', action='store_true',
-                        help='Only validate existing features without re-materializing')
-    parser.add_argument('--read-only', action='store_true', default=True,
-                        help='Open the database in read-only mode (default: True)')
+    parser = argparse.ArgumentParser(
+        description="Materialize features into Feature Store"
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Only validate existing features without re-materializing",
+    )
     args = parser.parse_args()
-    
-    success = materialize_all_features(validate_only=args.validate_only, read_only=args.read_only)
+
+    success = materialize_all_features(validate_only=args.validate_only)
     sys.exit(0 if success else 1)
 
 

--- a/pipeline/src/feature_store.py
+++ b/pipeline/src/feature_store.py
@@ -1,7 +1,7 @@
 """
 Feature Store: Point-in-Time Feature Management
 
-This module provides a DuckDB-based feature store that prevents temporal data leakage
+This module provides a BigQuery-based feature store that prevents temporal data leakage
 by ensuring features are retrieved with strict point-in-time semantics.
 
 Key Concepts:
@@ -19,75 +19,63 @@ Usage:
     store.materialize_lag_features(source_table='fact_player_efficiency')
 
     # Retrieve for training (point-in-time)
-    features = store.get_training_matrix(as_of_year=2024)
+    features = store.get_training_matrix(as_of_date=date(2024, 9, 1))
 """
 
 import logging
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 import pandas as pd
 
-from src.config_loader import get_db_path
 from src.db_manager import DBManager
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-DB_PATH = get_db_path()
-
 
 class FeatureStore:
-    """DuckDB-based Feature Store with point-in-time semantics."""
+    """BigQuery-based Feature Store with point-in-time semantics."""
 
-    def __init__(self, db_path: str = DB_PATH, read_only: bool = False):
-        self.db = DBManager(db_path)
-        self.con = self.db.con
+    def __init__(self, db: Optional[DBManager] = None, read_only: bool = False):
+        self.db = db or DBManager()
         self.read_only = read_only
 
     def initialize_schema(self):
         """Create feature store tables if they don't exist."""
         if self.read_only:
-            logger.info("Database is read-only. Skipping schema initialization.")
+            logger.info("Read-only mode. Skipping schema initialization.")
             return
 
         logger.info("Initializing Feature Store schema...")
 
         # Feature Registry: Metadata about each feature
-        self.con.execute("""
+        self.db.execute("""
             CREATE TABLE IF NOT EXISTS feature_registry (
-                feature_name VARCHAR PRIMARY KEY,
-                feature_type VARCHAR,  -- 'lag', 'derived', 'raw', 'interaction'
-                source_column VARCHAR,
-                lag_periods INTEGER,
-                description VARCHAR,
+                feature_name STRING NOT NULL,
+                feature_type STRING,
+                source_column STRING,
+                lag_periods INT64,
+                description STRING,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
 
         # Feature Values: The actual feature data with temporal validity
-        # Changed: valid_from is DATE, added valid_until
-        self.con.execute("""
+        self.db.execute("""
             CREATE TABLE IF NOT EXISTS feature_values (
-                entity_key VARCHAR,           -- player_name||'_'||year
-                player_name VARCHAR,
-                prediction_year INTEGER,      -- Year we're making a prediction for
-                feature_name VARCHAR,
-                feature_value DOUBLE,
-                valid_from DATE,              -- Date feature became known
-                valid_until DATE,             -- Date feature became superseded (NULL if current)
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (entity_key, feature_name, valid_from)
+                entity_key STRING,
+                player_name STRING,
+                prediction_year INT64,
+                feature_name STRING,
+                feature_value FLOAT64,
+                valid_from DATE,
+                valid_until DATE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
 
-        # Create index for efficient point-in-time queries
-        self.con.execute("""
-            CREATE INDEX IF NOT EXISTS idx_feature_pit 
-            ON feature_values (player_name, valid_from, valid_until)
-        """)
-
-        logger.info("✓ Feature Store schema initialized.")
+        logger.info("Feature Store schema initialized.")
 
     def register_feature(
         self,
@@ -97,15 +85,28 @@ class FeatureStore:
         lag_periods: int = None,
         description: str = None,
     ):
-        """Register a feature in the registry."""
-        self.con.execute(
-            """
-            INSERT OR REPLACE INTO feature_registry 
-            (feature_name, feature_type, source_column, lag_periods, description)
-            VALUES (?, ?, ?, ?, ?)
-        """,
-            [feature_name, feature_type, source_column, lag_periods, description],
-        )
+        """Register a feature in the registry (upsert via MERGE)."""
+        self.db.execute(f"""
+            MERGE INTO feature_registry AS target
+            USING (
+                SELECT
+                    '{feature_name}' AS feature_name,
+                    '{feature_type}' AS feature_type,
+                    {_bq_str(source_column)} AS source_column,
+                    {_bq_int(lag_periods)} AS lag_periods,
+                    {_bq_str(description)} AS description
+            ) AS src
+            ON target.feature_name = src.feature_name
+            WHEN MATCHED THEN UPDATE SET
+                feature_type = src.feature_type,
+                source_column = src.source_column,
+                lag_periods = src.lag_periods,
+                description = src.description
+            WHEN NOT MATCHED THEN INSERT
+                (feature_name, feature_type, source_column, lag_periods, description)
+                VALUES (src.feature_name, src.feature_type, src.source_column,
+                        src.lag_periods, src.description)
+        """)
 
     def materialize_lag_features(self, source_table: str = "fact_player_efficiency"):
         """
@@ -128,17 +129,23 @@ class FeatureStore:
             "age",
         ]
 
+        # Get available columns from source table
+        cols_df = self.db.fetch_df(f"""
+            SELECT column_name
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE table_name = '{source_table}'
+        """)
+        available_cols = set(cols_df["column_name"].values)
+
         # Clear existing lag features
-        self.con.execute("""
-            DELETE FROM feature_values 
+        self.db.execute("""
+            DELETE FROM feature_values
             WHERE feature_name LIKE '%_lag_%'
         """)
 
         # Register and materialize each lag feature
         for col in lag_columns:
-            # Check if column exists in source
-            cols_df = self.con.execute(f"DESCRIBE {source_table}").df()
-            if col not in cols_df["column_name"].values:
+            if col not in available_cols:
                 logger.warning(f"Column {col} not in {source_table}, skipping.")
                 continue
 
@@ -158,35 +165,31 @@ class FeatureStore:
                 # Lag 1: Target Year 2024. Source Year 2023.
                 # Valid From: 2024-02-15 (After 2023 season ends)
                 # Valid Until: 2025-02-15 (When 2024 season data becomes available)
-
-                self.con.execute(f"""
-                    INSERT INTO feature_values (entity_key, player_name, prediction_year, 
-                                                feature_name, feature_value, valid_from, valid_until)
-                    SELECT 
-                        target.player_name || '_' || target.year as entity_key,
+                self.db.execute(f"""
+                    INSERT INTO feature_values
+                        (entity_key, player_name, prediction_year,
+                         feature_name, feature_value, valid_from, valid_until)
+                    SELECT
+                        CONCAT(target.player_name, '_', CAST(target.year AS STRING))
+                            AS entity_key,
                         target.player_name,
-                        target.year as prediction_year,
-                        '{feature_name}' as feature_name,
-                        source.{col} as feature_value,
-                        -- Validity Logic:
-                        -- If source year is Y, data is known in Feb of Y+1
-                        -- Example: 2022 stats known 2023-02-15.
-                        -- Valid for predicting 2023 season (which starts Sept 2023).
-                        make_date(source.year + 1, 2, 15) as valid_from,
-                        make_date(source.year + 2, 2, 15) as valid_until
+                        target.year AS prediction_year,
+                        '{feature_name}' AS feature_name,
+                        source.{col} AS feature_value,
+                        DATE(source.year + 1, 2, 15) AS valid_from,
+                        DATE(source.year + 2, 2, 15) AS valid_until
                     FROM {source_table} target
                     INNER JOIN {source_table} source
                         ON target.player_name = source.player_name
                         AND source.year = target.year - {lag}
                     WHERE source.{col} IS NOT NULL
-                    ON CONFLICT (entity_key, feature_name, valid_from) DO UPDATE 
-                        SET feature_value = EXCLUDED.feature_value,
-                            valid_until = EXCLUDED.valid_until
                 """)
 
         # Log summary
-        count = self.con.execute("SELECT COUNT(*) FROM feature_values").fetchone()[0]
-        logger.info(f"✓ Materialized {count:,} feature values in store.")
+        count = self.db.execute(
+            "SELECT COUNT(*) AS cnt FROM feature_values"
+        ).fetchone()[0]
+        logger.info(f"Materialized {count:,} feature values in store.")
 
     def materialize_interaction_features(
         self, source_table: str = "fact_player_efficiency"
@@ -198,9 +201,9 @@ class FeatureStore:
             (
                 "age_cap_interaction",
                 "age * cap_hit_millions",
-                "Age × Cap Hit interaction",
+                "Age x Cap Hit interaction",
             ),
-            ("experience_risk", "draft_round * age", "Draft round × Age risk"),
+            ("experience_risk", "draft_round * age", "Draft round x Age risk"),
         ]
 
         for feature_name, formula, description in interactions:
@@ -211,46 +214,40 @@ class FeatureStore:
             )
 
             try:
-                # Interactions are instantaneous for the target year (derived from other features normally)
-                # But here we are deriving from raw source table for simplicity.
-                # These are "known" when the component parts are known.
-                # Assuming these are static traits or current contract info known at start of league year.
-                # We'll set valid_from to March 1st of the year (start of league year approx).
-
-                self.con.execute(f"""
-                    INSERT INTO feature_values (entity_key, player_name, prediction_year, 
-                                                feature_name, feature_value, valid_from, valid_until)
-                    SELECT 
-                        player_name || '_' || year as entity_key,
+                first_operand = formula.split("*")[0].strip()
+                self.db.execute(f"""
+                    INSERT INTO feature_values
+                        (entity_key, player_name, prediction_year,
+                         feature_name, feature_value, valid_from, valid_until)
+                    SELECT
+                        CONCAT(player_name, '_', CAST(year AS STRING))
+                            AS entity_key,
                         player_name,
-                        year as prediction_year,
-                        '{feature_name}' as feature_name,
-                        {formula} as feature_value,
-                        make_date(year, 3, 15) as valid_from, -- known mid-March (League Year)
-                        make_date(year + 1, 3, 15) as valid_until
+                        year AS prediction_year,
+                        '{feature_name}' AS feature_name,
+                        {formula} AS feature_value,
+                        DATE(year, 3, 15) AS valid_from,
+                        DATE(year + 1, 3, 15) AS valid_until
                     FROM {source_table}
-                    WHERE {formula.split('*')[0].strip()} IS NOT NULL
-                    ON CONFLICT (entity_key, feature_name, valid_from) DO UPDATE 
-                        SET feature_value = EXCLUDED.feature_value
+                    WHERE {first_operand} IS NOT NULL
                 """)
             except Exception as e:
                 logger.warning(f"Could not compute {feature_name}: {e}")
 
-        count = self.con.execute("""
-            SELECT COUNT(*) FROM feature_values 
+        count = self.db.execute("""
+            SELECT COUNT(*) AS cnt FROM feature_values
             WHERE feature_name IN ('age_cap_interaction', 'experience_risk')
         """).fetchone()[0]
-        logger.info(f"✓ Materialized {count:,} interaction features.")
+        logger.info(f"Materialized {count:,} interaction features.")
 
     def get_training_matrix(
         self, as_of_date: date, min_year: int = 2015
     ) -> pd.DataFrame:
         """
         Get feature matrix for training with strict point-in-time semantics as of a SINGLE date.
-        Useful for Inference or specific backtest folds.
 
         Args:
-            as_of_date: The 'knowledge cutoff' date. We only use data valid on or before this date.
+            as_of_date: The 'knowledge cutoff' date. Only data valid on or before this date.
             min_year: Minimum prediction year to include
 
         Returns:
@@ -258,25 +255,24 @@ class FeatureStore:
         """
         logger.info(f"Retrieving training matrix (as of {as_of_date})...")
 
-        # Pivot features to wide format with point-in-time constraint
         query = f"""
             WITH base AS (
-                SELECT DISTINCT player_name, year 
-                FROM fact_player_efficiency 
+                SELECT DISTINCT player_name, year
+                FROM fact_player_efficiency
                 WHERE year >= {min_year}
             ),
             pit_features AS (
-                SELECT 
+                SELECT
                     fv.player_name,
                     fv.prediction_year,
                     fv.feature_name,
                     fv.feature_value
                 FROM feature_values fv
                 WHERE fv.prediction_year >= {min_year}
-                  AND fv.valid_from <= '{as_of_date}' -- Known by cutoff
-                  AND (fv.valid_until > '{as_of_date}' OR fv.valid_until IS NULL) -- Not yet superseded
+                  AND fv.valid_from <= '{as_of_date}'
+                  AND (fv.valid_until > '{as_of_date}' OR fv.valid_until IS NULL)
             )
-            SELECT 
+            SELECT
                 b.player_name,
                 b.year,
                 pf.feature_name,
@@ -287,7 +283,7 @@ class FeatureStore:
                 AND b.year = pf.prediction_year
         """
 
-        df = self.con.execute(query).df()
+        df = self.db.fetch_df(query)
 
         if df.empty:
             logger.warning("No features found. Run materialize_* methods first.")
@@ -307,7 +303,7 @@ class FeatureStore:
         ]
 
         logger.info(
-            f"✓ Retrieved {len(pivot_df):,} rows × {len(pivot_df.columns)} features"
+            f"Retrieved {len(pivot_df):,} rows x {len(pivot_df.columns)} features"
         )
         return pivot_df
 
@@ -319,7 +315,7 @@ class FeatureStore:
 
         Reconstructs what was known at the start of EACH season (Sept 1st) for that season.
         Unlike get_training_matrix (which uses one as_of_date), this uses a dynamic
-        as_of_date = make_date(prediction_year, 9, 1).
+        as_of_date = DATE(prediction_year, 9, 1).
 
         Args:
             min_year: Start year
@@ -331,24 +327,23 @@ class FeatureStore:
 
         query = f"""
             WITH base AS (
-                SELECT DISTINCT player_name, year 
-                FROM fact_player_efficiency 
+                SELECT DISTINCT player_name, year
+                FROM fact_player_efficiency
                 WHERE year BETWEEN {min_year} AND {max_year}
             ),
             pit_features AS (
-                SELECT 
+                SELECT
                     fv.player_name,
                     fv.prediction_year,
                     fv.feature_name,
                     fv.feature_value
                 FROM feature_values fv
                 WHERE fv.prediction_year BETWEEN {min_year} AND {max_year}
-                  -- DIAGONAL JOIN LOGIC:
-                  -- Valid at the start of the prediction season (Sept 1st)
-                  AND fv.valid_from <= make_date(fv.prediction_year, 9, 1)
-                  AND (fv.valid_until > make_date(fv.prediction_year, 9, 1) OR fv.valid_until IS NULL)
+                  AND fv.valid_from <= DATE(fv.prediction_year, 9, 1)
+                  AND (fv.valid_until > DATE(fv.prediction_year, 9, 1)
+                       OR fv.valid_until IS NULL)
             )
-            SELECT 
+            SELECT
                 b.player_name,
                 b.year,
                 pf.feature_name,
@@ -359,7 +354,7 @@ class FeatureStore:
                 AND b.year = pf.prediction_year
         """
 
-        df = self.con.execute(query).df()
+        df = self.db.fetch_df(query)
 
         if df.empty:
             logger.warning("No features found.")
@@ -376,7 +371,7 @@ class FeatureStore:
             col if isinstance(col, str) else col for col in pivot_df.columns
         ]
 
-        logger.info(f"✓ Retrieved {len(pivot_df):,} rows (Historical Batch)")
+        logger.info(f"Retrieved {len(pivot_df):,} rows (Historical Batch)")
         return pivot_df
 
     def validate_temporal_integrity(self) -> bool:
@@ -386,67 +381,61 @@ class FeatureStore:
         Rule: valid_from must be < season start date of prediction_year.
         Assuming season starts Sept 1st.
         """
-        logger.info("🔍 Validating temporal integrity...")
+        logger.info("Validating temporal integrity...")
 
-        violations = self.con.execute("""
-            SELECT COUNT(*) 
+        violations = self.db.execute("""
+            SELECT COUNT(*) AS cnt
             FROM feature_values fv
             JOIN feature_registry fr ON fv.feature_name = fr.feature_name
             WHERE fr.feature_type = 'lag'
-              -- Violation if 'known' date is AFTER the season starts
-              AND fv.valid_from >= make_date(fv.prediction_year, 9, 1)
+              AND fv.valid_from >= DATE(fv.prediction_year, 9, 1)
         """).fetchone()[0]
 
         if violations == 0:
-            logger.info("✅ Temporal integrity PASSED: Zero violations.")
+            logger.info("Temporal integrity PASSED: Zero violations.")
             return True
         else:
-            logger.error(
-                f"❌ Temporal integrity FAILED: {violations} violations found!"
-            )
+            logger.error(f"Temporal integrity FAILED: {violations} violations found!")
 
             # Show sample violations
-            samples = self.con.execute("""
-                SELECT fv.player_name, fv.prediction_year, fv.feature_name, fv.valid_from
+            samples = self.db.fetch_df("""
+                SELECT fv.player_name, fv.prediction_year,
+                       fv.feature_name, fv.valid_from
                 FROM feature_values fv
                 JOIN feature_registry fr ON fv.feature_name = fr.feature_name
                 WHERE fr.feature_type = 'lag'
-                  AND fv.valid_from >= make_date(fv.prediction_year, 9, 1)
+                  AND fv.valid_from >= DATE(fv.prediction_year, 9, 1)
                 LIMIT 5
-            """).df()
+            """)
             logger.error(f"Sample violations:\n{samples}")
             return False
 
     def get_feature_stats(self) -> pd.DataFrame:
         """Get summary statistics about the feature store."""
-        return self.con.execute("""
-            SELECT 
+        return self.db.fetch_df("""
+            SELECT
                 fr.feature_type,
-                COUNT(DISTINCT fv.feature_name) as num_features,
-                COUNT(*) as num_values,
-                MIN(fv.prediction_year) as min_year,
-                MAX(fv.prediction_year) as max_year
+                COUNT(DISTINCT fv.feature_name) AS num_features,
+                COUNT(*) AS num_values,
+                MIN(fv.prediction_year) AS min_year,
+                MAX(fv.prediction_year) AS max_year
             FROM feature_values fv
             JOIN feature_registry fr ON fv.feature_name = fr.feature_name
             GROUP BY fr.feature_type
             ORDER BY fr.feature_type
-        """).df()
+        """)
 
 
-if __name__ == "__main__":
-    # Demo usage
-    store = FeatureStore()
-    store.initialize_schema()
-    store.materialize_lag_features()
-    store.materialize_interaction_features()
+def _bq_str(val: Optional[str]) -> str:
+    """Format a Python string as a BigQuery string literal, or NULL."""
+    if val is None:
+        return "CAST(NULL AS STRING)"
+    escaped = val.replace("'", "\\'")
+    return f"'{escaped}'"
 
-    # Validate
-    store.validate_temporal_integrity()
 
-    # Show stats
-    print("\n=== Feature Store Statistics ===")
-    print(store.get_feature_stats())
-
-    # Get training matrix for 2024 season (as of start of season)
-    matrix = store.get_training_matrix(as_of_date=date(2024, 9, 1))
-    print(f"\nTraining matrix shape: {matrix.shape}")
+def _bq_int(val: Optional[int]) -> str:
+    """Format a Python int as a BigQuery INT64 literal, or NULL."""
+    if val is None:
+        return "CAST(NULL AS INT64)"
+    return str(int(val))

--- a/pipeline/tests/test_feature_store.py
+++ b/pipeline/tests/test_feature_store.py
@@ -1,307 +1,324 @@
+"""
+Tests for the BigQuery-backed FeatureStore (Issue #125).
+
+Unit tests mock DBManager to verify SQL generation and logic flow
+without requiring a live BigQuery connection.
+"""
+
 from datetime import date
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 
-from src.db_manager import DBManager
+from src.feature_store import FeatureStore, _bq_int, _bq_str
 
-# FeatureStore still uses DuckDB internals (self.db.con) — skip until ported to BigQuery
-pytestmark = pytest.mark.skip(
-    reason="FeatureStore not yet ported from DuckDB to BigQuery"
-)
-
-from src.feature_store import FeatureStore
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def store(tmp_path):
-    """Create a temporary FeatureStore for testing."""
-    db_path = str(tmp_path / "test_feature_store.duckdb")
-    store = FeatureStore(db_path=db_path)
-    store.initialize_schema()
-
-    # Mock the fact table which is required for get_training_matrix base spine
-    store.db.execute(
-        "CREATE TABLE IF NOT EXISTS fact_player_efficiency (player_name VARCHAR, year INTEGER, team VARCHAR)"
-    )
-
-    return store
-
-
-def test_schema_dates(store):
-    """Verify schema uses DATE types for validity."""
-    schema = store.db.fetch_df("DESCRIBE feature_values")
-
-    # Check valid_from is DATE
-    valid_from_type = schema.loc[
-        schema["column_name"] == "valid_from", "column_type"
-    ].iloc[0]
-    assert valid_from_type == "DATE"
-
-    # Check valid_until exists and is DATE
-    valid_until_type = schema.loc[
-        schema["column_name"] == "valid_until", "column_type"
-    ].iloc[0]
-    assert valid_until_type == "DATE"
+def mock_db():
+    """Create a mock DBManager for unit testing."""
+    db = MagicMock()
+    # Default: execute returns a result proxy with fetchone returning (0,)
+    result_proxy = MagicMock()
+    result_proxy.fetchone.return_value = (0,)
+    result_proxy.fetchall.return_value = []
+    result_proxy.df.return_value = pd.DataFrame()
+    db.execute.return_value = result_proxy
+    db.fetch_df.return_value = pd.DataFrame()
+    return db
 
 
-def test_temporal_leakage_protection(store):
-    """Ensure we cannot see features from the future."""
-    # Setup: Feature known from 2023-02-01 until 2024-02-01
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('P1_2023', 'PlayerOne', 2023, 'test_feat', 100.0, '2023-02-01', '2024-02-01')
-    """)
-
-    # Mock base row for join - ensure types match schema (VARCHAR, INTEGER)
-    store.db.execute(
-        "INSERT INTO fact_player_efficiency VALUES ('PlayerOne', CAST(2023 AS INTEGER), 'TeamA')"
-    )
-    store.db.execute(
-        "INSERT INTO fact_player_efficiency VALUES ('PlayerOne', CAST(2024 AS INTEGER), 'TeamA')"
-    )
-
-    # Query BEFORE valid_from (Should be empty)
-    df_early = store.get_training_matrix(as_of_date=date(2023, 1, 1), min_year=2023)
-    assert "test_feat" not in df_early.columns or df_early.empty
-
-    # Query DURING validity (Should find it)
-    df_valid = store.get_training_matrix(as_of_date=date(2023, 6, 1), min_year=2023)
-    assert not df_valid.empty
-    assert df_valid.iloc[0]["test_feat"] == 100.0
-
-    # Query AFTER valid_until (Should be empty or superseded -- here empty locally)
-    # Note: get_training_matrix normally filters by prediction year too, but focused on date joins
-    # We simulate a 2024 prediction year query
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('P1_2024', 'PlayerOne', 2024, 'test_feat', 200.0, '2024-02-01', NULL)
-    """)
-
-    # As of mid-2024, should see the NEW value (200.0), not old (100.0)
-    df_2024 = store.get_training_matrix(as_of_date=date(2024, 6, 1), min_year=2024)
-    assert df_2024.iloc[0]["test_feat"] == 200.0
+@pytest.fixture
+def store(mock_db):
+    """Create a FeatureStore backed by a mock DBManager."""
+    return FeatureStore(db=mock_db, read_only=False)
 
 
-def test_lag_materialization_dates(store):
-    """Test that lag materialization sets correct date boundaries."""
-    # Mock source data
-    store.db.execute("DROP TABLE IF EXISTS fact_player_efficiency")
-    store.db.execute(
-        "CREATE TABLE fact_player_efficiency (player_name VARCHAR, year INTEGER, total_pass_yds INTEGER)"
-    )
-    store.db.execute("INSERT INTO fact_player_efficiency VALUES ('QB1', 2022, 4000)")
-    store.db.execute("INSERT INTO fact_player_efficiency VALUES ('QB1', 2023, 4500)")
-
-    # Materialize
-    store.materialize_lag_features(source_table="fact_player_efficiency")
-
-    # Check valid_from dates
-    # 2022 season data -> Known early 2023 (e.g. 2023-02-13 roughly Super Bowl)
-    # The default impl should likely set it to YYYY+1-02-01 or similar constant
-
-    res = store.db.execute("""
-        SELECT feature_value, valid_from 
-        FROM feature_values 
-        WHERE feature_name = 'total_pass_yds_lag_1' AND prediction_year = 2023
-    """).fetchone()
-
-    # Target 2023:
-    # Lag 1 comes from 2022 data.
-    # 2022 data is known as of Fed 2023.
-    # So valid_from should be ~2023-02-XX.
-    # feature_value should be 4000.
-
-    assert res is not None
-    val, valid_from = res
-    assert val == 4000
-    assert valid_from.year == 2023  # Available IN 2023
+@pytest.fixture
+def ro_store(mock_db):
+    """Create a read-only FeatureStore."""
+    return FeatureStore(db=mock_db, read_only=True)
 
 
-def test_point_in_time_retrieval(store):
-    """Simulate a specific historical moment retrieval."""
-    # Data:
-    # V1: Known 2022-02-01 -> Value 10
-    # V2: Known 2022-06-01 -> Value 15 (Correction)
-    # V3: Known 2023-02-01 -> Value 20 (Next season)
-
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES 
-        ('k1', 'P1', 2022, 'f1', 10.0, '2022-02-01', '2022-06-01'),
-        ('k2', 'P1', 2022, 'f1', 15.0, '2022-06-01', '2023-02-01'),
-        ('k3', 'P1', 2023, 'f1', 20.0, '2023-02-01', NULL)
-    """)
-
-    # Mock base rows for retrieval
-    store.db.execute("INSERT INTO fact_player_efficiency VALUES ('P1', 2022, 'TeamA')")
-    store.db.execute("INSERT INTO fact_player_efficiency VALUES ('P1', 2023, 'TeamA')")
-
-    # 1. March 2022 -> Should see 10.0
-    df_mar = store.get_training_matrix(as_of_date=date(2022, 3, 1), min_year=2022)
-    assert df_mar.iloc[0]["f1"] == 10.0
-
-    # 2. July 2022 -> Should see 15.0 (Correction)
-    df_jul = store.get_training_matrix(as_of_date=date(2022, 7, 1), min_year=2022)
-    assert df_jul.iloc[0]["f1"] == 15.0
-
-    # 3. March 2023 -> Should see 20.0 (New Season)
-    # Note: query checks prediction_year too.
-    # For prediction_year 2022, valid_until was 2023-02-01.
-    # If we define "Training Matrix" as "What did we know for THIS target year at THAT time":
-
-    # If I am training for 2022 target, and I am currently at 2024:
-    # I should see the FINAL version of 2022 features (15.0).
-
-    # If I am training for 2023 target:
-    # I should see 20.0 (lag 1 from 2022 data)
-    pass
+# ---------------------------------------------------------------------------
+# Schema initialization
+# ---------------------------------------------------------------------------
 
 
-def test_feature_boundary_conditions(store):
-    """Test exact boundary conditions for feature validity."""
-    # Feature valid from 2023-02-15 to 2024-02-15
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('P1_2023', 'PlayerBound', 2023, 'bound_feat', 50.0, '2023-02-15', '2024-02-15')
-    """)
-    store.db.execute(
-        "INSERT INTO fact_player_efficiency VALUES ('PlayerBound', 2023, 'TeamB')"
-    )
+class TestInitializeSchema:
+    def test_creates_feature_registry_and_values(self, store, mock_db):
+        store.initialize_schema()
+        calls = [str(c) for c in mock_db.execute.call_args_list]
+        sql_concat = " ".join(calls)
+        assert "feature_registry" in sql_concat
+        assert "feature_values" in sql_concat
 
-    # 1. Day BEFORE valid_from (2023-02-14) -> Should NOT find feature
-    df_before = store.get_training_matrix(as_of_date=date(2023, 2, 14), min_year=2023)
-    assert "bound_feat" not in df_before.columns or pd.isna(
-        df_before.iloc[0].get("bound_feat")
-    )
+    def test_uses_bq_types(self, store, mock_db):
+        """Schema DDL should use BigQuery types (STRING, INT64, FLOAT64)."""
+        store.initialize_schema()
+        calls = [str(c) for c in mock_db.execute.call_args_list]
+        sql_concat = " ".join(calls)
+        assert "STRING" in sql_concat
+        assert "INT64" in sql_concat
+        assert "FLOAT64" in sql_concat
+        # Should NOT contain DuckDB types
+        assert "VARCHAR" not in sql_concat
+        assert "DOUBLE" not in sql_concat
 
-    # 2. ON valid_from date (2023-02-15) -> Should find feature
-    df_on_start = store.get_training_matrix(as_of_date=date(2023, 2, 15), min_year=2023)
-    assert df_on_start.iloc[0]["bound_feat"] == 50.0
-
-    # 3. ON valid_until date (2024-02-15) -> Should NOT find feature (strict < inequality usually, or <= depending on logic)
-    # Logic in query: valid_until > as_of_date.
-    # If valid_until is 2024-02-15 and as_of is 2024-02-15: 2024-02-15 > 2024-02-15 is FALSE.
-    # So on the expiry date, it is EXPIRED.
-    df_on_end = store.get_training_matrix(as_of_date=date(2024, 2, 15), min_year=2023)
-    assert "bound_feat" not in df_on_end.columns or pd.isna(
-        df_on_end.iloc[0].get("bound_feat")
-    )
-
-    # 4. Day BEFORE valid_until (2024-02-14) -> Should find feature
-    df_before_end = store.get_training_matrix(
-        as_of_date=date(2024, 2, 14), min_year=2023
-    )
-    assert df_before_end.iloc[0]["bound_feat"] == 50.0
+    def test_read_only_skips_schema(self, ro_store, mock_db):
+        ro_store.initialize_schema()
+        mock_db.execute.assert_not_called()
 
 
-def test_interaction_features(store):
-    """Test that materializing interaction features works and sets valid_from."""
-    # Setup data
-    store.db.execute("DROP TABLE IF EXISTS fact_player_efficiency")
-    store.db.execute("""
-        CREATE TABLE fact_player_efficiency (
-            player_name VARCHAR, 
-            year INTEGER, 
-            team VARCHAR,
-            age INTEGER,
-            cap_hit_millions DOUBLE,
-            draft_round INTEGER
+# ---------------------------------------------------------------------------
+# Feature registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterFeature:
+    def test_register_uses_merge(self, store, mock_db):
+        store.register_feature(
+            feature_name="test_feat",
+            feature_type="lag",
+            source_column="total_tds",
+            lag_periods=1,
+            description="test",
         )
-    """)
-    store.db.execute("""
-        INSERT INTO fact_player_efficiency VALUES 
-        ('P_Interact', 2023, 'TeamC', 25, 10.0, 1)
-    """)
+        sql = mock_db.execute.call_args[0][0]
+        assert "MERGE INTO feature_registry" in sql
+        assert "test_feat" in sql
 
-    store.materialize_interaction_features(source_table="fact_player_efficiency")
-
-    # Check 'age_cap_interaction': 25 * 10.0 = 250.0
-    # Valid from: March 15th of the year (2023-03-15)
-
-    res = store.db.execute("""
-        SELECT feature_value, valid_from 
-        FROM feature_values 
-        WHERE feature_name = 'age_cap_interaction' 
-          AND player_name = 'P_Interact'
-    """).fetchone()
-
-    assert res is not None
-    val, valid_from = res
-    assert val == 250.0
-    assert valid_from == date(2023, 3, 15)
+    def test_register_handles_none_values(self, store, mock_db):
+        store.register_feature(
+            feature_name="bare_feat",
+            feature_type="raw",
+        )
+        sql = mock_db.execute.call_args[0][0]
+        assert "CAST(NULL AS STRING)" in sql
+        assert "CAST(NULL AS INT64)" in sql
 
 
-def test_historical_features_diagonal_join(store):
-    """Test retrieval of features for multiple years using start-of-season logic."""
-    # Data Setup:
-    # Player 'Legacy':
-    # 2021 Season Stats -> Known Feb 2022. Lag 1 for 2022 season.
-    # 2022 Season Stats -> Known Feb 2023. Lag 1 for 2023 season.
-
-    # We insert into feature_values directly to control timestamps perfectly
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES 
-        ('k22', 'Legacy', 2022, 'yards_lag_1', 1000.0, '2022-02-15', '2023-02-15'),
-        ('k23', 'Legacy', 2023, 'yards_lag_1', 1100.0, '2023-02-15', '2024-02-15')
-    """)
-
-    # Base population
-    store.db.execute(
-        "INSERT INTO fact_player_efficiency (player_name, year) VALUES ('Legacy', 2022), ('Legacy', 2023)"
-    )
-
-    # Retrieve Batch (Diagonal Join)
-    # Logic: For 2022 prediction, uses data valid at 2022-09-01. (Should get 1000.0)
-    #        For 2023 prediction, uses data valid at 2023-09-01. (Should get 1100.0)
-
-    df = store.get_historical_features(min_year=2022, max_year=2023)
-
-    assert len(df) == 2
-    row_22 = df[df["year"] == 2022].iloc[0]
-    row_23 = df[df["year"] == 2023].iloc[0]
-
-    assert row_22["yards_lag_1"] == 1000.0
-    assert row_23["yards_lag_1"] == 1100.0
+# ---------------------------------------------------------------------------
+# Lag feature materialization
+# ---------------------------------------------------------------------------
 
 
-def test_temporal_integrity_validation(store):
-    """Test that we detect forward-looking info (leakage)."""
-    # Create a legitimate feature
-    store.db.execute("""
-        INSERT INTO feature_registry (feature_name, feature_type) VALUES ('clean_feat', 'lag')
-    """)
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('p1', 'Clean', 2023, 'clean_feat', 1.0, '2023-02-01', NULL)
-    """)
+class TestMaterializeLagFeatures:
+    def test_queries_information_schema(self, store, mock_db):
+        """Should check available columns via INFORMATION_SCHEMA."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {"column_name": ["total_pass_yds", "total_tds", "age"]}
+        )
+        store.materialize_lag_features()
+        info_call = mock_db.fetch_df.call_args_list[0]
+        assert "INFORMATION_SCHEMA.COLUMNS" in info_call[0][0]
 
-    # Create a LEAKY feature
-    # Prediction Year 2023 (Season starts Sept 2023)
-    # But valid_from is Dec 2023 (Future!)
-    store.db.execute("""
-        INSERT INTO feature_registry (feature_name, feature_type) VALUES ('leaky_feat', 'lag')
-    """)
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('p2', 'Leaky', 2023, 'leaky_feat', 1.0, '2023-12-01', NULL)
-    """)
+    def test_deletes_existing_lag_features(self, store, mock_db):
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {"column_name": ["total_pass_yds"]}
+        )
+        store.materialize_lag_features()
+        # One of the execute calls should be the DELETE
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        delete_sqls = [s for s in sqls if "DELETE FROM feature_values" in s]
+        assert len(delete_sqls) == 1
+        assert "LIKE '%_lag_%'" in delete_sqls[0]
 
-    # Should return False (integrity check failed)
-    assert store.validate_temporal_integrity() is False
+    def test_materializes_three_lags_per_column(self, store, mock_db):
+        """Each available column should produce lag_1, lag_2, lag_3."""
+        mock_db.fetch_df.return_value = pd.DataFrame({"column_name": ["total_tds"]})
+        store.materialize_lag_features()
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        insert_sqls = [s for s in sqls if "INSERT INTO feature_values" in s]
+        # 3 lags for 1 column
+        assert len(insert_sqls) == 3
+
+    def test_uses_date_function_not_make_date(self, store, mock_db):
+        """BigQuery uses DATE() not make_date()."""
+        mock_db.fetch_df.return_value = pd.DataFrame({"column_name": ["age"]})
+        store.materialize_lag_features()
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        insert_sqls = [s for s in sqls if "INSERT INTO feature_values" in s]
+        for sql in insert_sqls:
+            assert "DATE(source.year" in sql
+            assert "make_date" not in sql
+
+    def test_skips_missing_columns(self, store, mock_db):
+        """Columns not in source table should be skipped."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {"column_name": ["some_other_col"]}
+        )
+        store.materialize_lag_features()
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        insert_sqls = [s for s in sqls if "INSERT INTO feature_values" in s]
+        assert len(insert_sqls) == 0
 
 
-def test_feature_stats(store):
-    """Smoke test for stats generation."""
-    store.db.execute("""
-        INSERT INTO feature_registry (feature_name, feature_type) VALUES ('f1', 'lag')
-    """)
-    store.db.execute("""
-        INSERT INTO feature_values (entity_key, player_name, prediction_year, feature_name, feature_value, valid_from, valid_until)
-        VALUES ('k1', 'P1', 2023, 'f1', 10.0, '2023-02-01', NULL)
-    """)
+# ---------------------------------------------------------------------------
+# Interaction feature materialization
+# ---------------------------------------------------------------------------
 
-    stats = store.get_feature_stats()
-    assert not stats.empty
-    assert "lag" in stats["feature_type"].values
+
+class TestMaterializeInteractionFeatures:
+    def test_inserts_interaction_features(self, store, mock_db):
+        store.materialize_interaction_features()
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        insert_sqls = [s for s in sqls if "INSERT INTO feature_values" in s]
+        # 2 interaction features (age_cap_interaction, experience_risk)
+        assert len(insert_sqls) == 2
+
+    def test_uses_bq_date_function(self, store, mock_db):
+        store.materialize_interaction_features()
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        insert_sqls = [s for s in sqls if "INSERT INTO feature_values" in s]
+        for sql in insert_sqls:
+            assert "DATE(year, 3, 15)" in sql
+            assert "make_date" not in sql
+
+
+# ---------------------------------------------------------------------------
+# Training matrix retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestGetTrainingMatrix:
+    def test_point_in_time_filter(self, store, mock_db):
+        """Query should enforce valid_from <= as_of AND valid_until > as_of."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        store.get_training_matrix(as_of_date=date(2024, 9, 1))
+        sql = mock_db.fetch_df.call_args[0][0]
+        assert "valid_from <= '2024-09-01'" in sql
+        assert "valid_until > '2024-09-01'" in sql
+        assert "valid_until IS NULL" in sql
+
+    def test_empty_result_returns_empty_df(self, store, mock_db):
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        result = store.get_training_matrix(as_of_date=date(2024, 9, 1))
+        assert result.empty
+
+    def test_pivots_to_wide_format(self, store, mock_db):
+        """Non-empty results should be pivoted to wide format."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {
+                "player_name": ["QB1", "QB1"],
+                "year": [2023, 2023],
+                "feature_name": ["feat_a", "feat_b"],
+                "feature_value": [1.0, 2.0],
+            }
+        )
+        result = store.get_training_matrix(as_of_date=date(2024, 9, 1))
+        assert "feat_a" in result.columns
+        assert "feat_b" in result.columns
+        assert len(result) == 1  # One player-year after pivot
+
+
+# ---------------------------------------------------------------------------
+# Historical features (diagonal join)
+# ---------------------------------------------------------------------------
+
+
+class TestGetHistoricalFeatures:
+    def test_diagonal_join_uses_dynamic_date(self, store, mock_db):
+        """Diagonal join should use DATE(prediction_year, 9, 1)."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        store.get_historical_features(min_year=2020, max_year=2024)
+        sql = mock_db.fetch_df.call_args[0][0]
+        assert "DATE(fv.prediction_year, 9, 1)" in sql
+
+    def test_empty_result(self, store, mock_db):
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        result = store.get_historical_features()
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# Temporal integrity validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTemporalIntegrity:
+    def test_passes_when_zero_violations(self, store, mock_db):
+        result_proxy = MagicMock()
+        result_proxy.fetchone.return_value = (0,)
+        mock_db.execute.return_value = result_proxy
+
+        assert store.validate_temporal_integrity() is True
+
+    def test_fails_when_violations_exist(self, store, mock_db):
+        result_proxy = MagicMock()
+        result_proxy.fetchone.return_value = (5,)
+        mock_db.execute.return_value = result_proxy
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {
+                "player_name": ["Leaky"],
+                "prediction_year": [2023],
+                "feature_name": ["bad_feat"],
+                "valid_from": [date(2023, 12, 1)],
+            }
+        )
+
+        assert store.validate_temporal_integrity() is False
+
+
+# ---------------------------------------------------------------------------
+# Feature stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetFeatureStats:
+    def test_returns_dataframe(self, store, mock_db):
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            {
+                "feature_type": ["lag"],
+                "num_features": [24],
+                "num_values": [5000],
+                "min_year": [2015],
+                "max_year": [2024],
+            }
+        )
+        stats = store.get_feature_stats()
+        assert not stats.empty
+        assert "feature_type" in stats.columns
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_bq_str_none(self):
+        assert _bq_str(None) == "CAST(NULL AS STRING)"
+
+    def test_bq_str_value(self):
+        assert _bq_str("hello") == "'hello'"
+
+    def test_bq_str_escapes_quotes(self):
+        assert _bq_str("it's") == "'it\\'s'"
+
+    def test_bq_int_none(self):
+        assert _bq_int(None) == "CAST(NULL AS INT64)"
+
+    def test_bq_int_value(self):
+        assert _bq_int(3) == "3"
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    @patch("src.feature_store.DBManager")
+    def test_creates_default_db_when_none_provided(self, mock_dbm_cls):
+        """When no db is passed, FeatureStore should create its own DBManager."""
+        store = FeatureStore()
+        mock_dbm_cls.assert_called_once()
+
+    def test_uses_provided_db(self, mock_db):
+        store = FeatureStore(db=mock_db)
+        assert store.db is mock_db


### PR DESCRIPTION
Rewrite FeatureStore to use DBManager BigQuery instead of DuckDB. All SQL converted to BQ dialect. Update materialize_features.py. Re-add materialize step to sync_daily. Rewrite tests with mocked DBManager. Closes #125