### PR TITLE
fix(extract): tighten prompt, add semantic dedup, void bad rows

### DIFF
--- a/pipeline/scripts/void_pre_prompt_fix_predictions.py
+++ b/pipeline/scripts/void_pre_prompt_fix_predictions.py
@@ -1,0 +1,86 @@
+"""
+Void Pre-Prompt-Fix Predictions (Issue #168)
+
+Marks all existing prediction_ledger rows as VOID in prediction_resolutions,
+since they were extracted with the original weak prompt that accepted vibes,
+stale news, and duplicates. Preserves the chain hash integrity (append-only).
+
+Idempotent — safe to re-run. Skips predictions that already have a resolution.
+
+Usage (inside Docker):
+    python pipeline/scripts/void_pre_prompt_fix_predictions.py
+    python pipeline/scripts/void_pre_prompt_fix_predictions.py --dry-run
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.db_manager import DBManager
+from src.resolution_engine import void_prediction
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+VOID_REASON = "low_quality_extraction_pre_prompt_fix_issue_168"
+
+
+def void_existing_predictions(dry_run: bool = False):
+    db = DBManager()
+    project_id = os.environ["GCP_PROJECT_ID"]
+
+    # Get all prediction hashes that don't already have a resolution
+    query = f"""
+        SELECT l.prediction_hash, l.pundit_name, l.extracted_claim
+        FROM `{project_id}.gold_layer.prediction_ledger` l
+        LEFT JOIN `{project_id}.gold_layer.prediction_resolutions` r
+            ON l.prediction_hash = r.prediction_hash
+        WHERE r.prediction_hash IS NULL
+        ORDER BY l.ingestion_timestamp ASC
+    """
+    df = db.fetch_df(query)
+    logger.info(f"Found {len(df)} unresolved predictions to void")
+
+    if df.empty:
+        logger.info("All predictions already have resolutions. Nothing to do.")
+        return
+
+    voided = 0
+    for _, row in df.iterrows():
+        phash = row["prediction_hash"]
+        claim = str(row.get("extracted_claim", ""))[:80]
+        pundit = row.get("pundit_name", "Unknown")
+
+        if dry_run:
+            logger.info(f"DRY RUN: would void {phash[:16]}… ({pundit}: {claim})")
+            voided += 1
+            continue
+
+        try:
+            void_prediction(
+                prediction_hash=phash,
+                reason=VOID_REASON,
+                db=db,
+            )
+            voided += 1
+            logger.info(f"VOIDED: {phash[:16]}… ({pundit}: {claim})")
+        except Exception as e:
+            logger.error(f"Failed to void {phash[:16]}…: {e}")
+
+    logger.info(f"Voided {voided}/{len(df)} predictions.")
+    db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Void pre-prompt-fix predictions"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    void_existing_predictions(dry_run=args.dry_run)

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -122,6 +122,39 @@ def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> lis
     return kept
 
 
+def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> list[dict]:
+    """
+    Remove near-duplicate claims from a single article's extraction.
+    Uses SequenceMatcher to detect semantic overlap. Keeps the longest
+    (most specific) claim from each cluster.
+    """
+    if len(predictions) <= 1:
+        return predictions
+
+    from difflib import SequenceMatcher
+
+    kept = []
+    for pred in predictions:
+        claim = pred.get("extracted_claim", "").lower()
+        is_dup = False
+        for i, existing in enumerate(kept):
+            existing_claim = existing.get("extracted_claim", "").lower()
+            ratio = SequenceMatcher(None, claim, existing_claim).ratio()
+            if ratio >= threshold:
+                # Keep the longer (more specific) one
+                if len(claim) > len(existing_claim):
+                    kept[i] = pred
+                is_dup = True
+                break
+        if not is_dup:
+            kept.append(pred)
+
+    removed = len(predictions) - len(kept)
+    if removed > 0:
+        logger.info(f"Dedup: removed {removed} near-duplicate claims")
+    return kept
+
+
 def extract_assertions(
     content_hash: str,
     text: str,


### PR DESCRIPTION
## Summary
Fixes #168

The assertion extractor had a ~70% garbage rate. Hand-audit of all 31 ledger rows found:
- ~40% vague vibes ("will make plays", "well worth it")
- ~15% near-duplicates from same article
- ~15% stale 2020 news extracted as predictions
- ~25-30% actually meaningful predictions

**Changes:**
- **Hardened prompt** with explicit negative examples: hedges, vague qualitative, tautologies, scheme descriptions, consensus, administrative details, past-season events
- **Positive examples** showing what good extractions look like
- **Publish date** passed to prompt so LLM can reject already-resolved events
- **Semantic dedup**: `SequenceMatcher(ratio >= 0.75)` clusters near-identical claims from same article, keeps most specific
- **Void script**: `pipeline/scripts/void_pre_prompt_fix_predictions.py` marks all 31 existing rows as VOID via `resolution_engine.void_prediction` (preserves chain hash integrity). Requires BQ billing for DML.

## Test plan
- [x] 30/30 existing assertion_extractor tests pass
- [x] Void script dry-run verified against production BQ (31 rows identified)
- [ ] Void script execution blocked by BQ billing (#167 root cause)
- [ ] Eval harness with 50 hand-labeled items (follow-up once re-extraction runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)