### PR TITLE
feat(resolve): daily prediction resolution engine with draft_pick resolver

### DIFF
--- a/pipeline/scripts/backfill_pundit_matching.py
+++ b/pipeline/scripts/backfill_pundit_matching.py
@@ -1,0 +1,125 @@
+"""
+Backfill Pundit Matching for Existing raw_pundit_media Rows (Issue #166)
+
+Re-runs the enhanced pundit matcher (author field → byline scan → source default)
+against all rows in raw_pundit_media that currently have no matched_pundit_id.
+Updates them in place.
+
+Usage (inside Docker):
+    python pipeline/scripts/backfill_pundit_matching.py             # live update
+    python pipeline/scripts/backfill_pundit_matching.py --dry-run   # preview
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.db_manager import DBManager
+from src.media_ingestor import load_media_config, match_pundit
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def backfill(dry_run: bool = False):
+    db = DBManager()
+    project_id = os.environ["GCP_PROJECT_ID"]
+
+    # Load current source config to get pundit rosters + defaults
+    config = load_media_config()
+    sources_by_id = {s["id"]: s for s in config.get("sources", [])}
+
+    # Fetch all unmatched rows (string "None" was written instead of actual NULL)
+    query = f"""
+        SELECT content_hash, source_id, author, raw_text
+        FROM `{project_id}.nfl_dead_money.raw_pundit_media`
+        WHERE matched_pundit_id IS NULL
+           OR matched_pundit_id = 'None'
+           OR matched_pundit_name IS NULL
+           OR matched_pundit_name = 'None'
+    """
+    df = db.fetch_df(query)
+    logger.info(f"Found {len(df)} unmatched rows to re-process")
+
+    if df.empty:
+        logger.info("Nothing to backfill.")
+        return
+
+    matched_count = 0
+    updates = []
+
+    for _, row in df.iterrows():
+        source_id = row["source_id"]
+        source = sources_by_id.get(source_id, {})
+        pundits = source.get("pundits", [])
+
+        pid, pname, method = match_pundit(
+            author=row.get("author"),
+            pundits=pundits,
+            raw_text=row.get("raw_text"),
+            source=source,
+        )
+
+        if pid:
+            matched_count += 1
+            updates.append(
+                {
+                    "content_hash": row["content_hash"],
+                    "pundit_id": pid,
+                    "pundit_name": pname,
+                    "method": method,
+                }
+            )
+            if matched_count <= 10:
+                logger.info(
+                    f"  MATCH [{method}]: {row['content_hash'][:16]}… "
+                    f"→ {pname} (source={source_id})"
+                )
+
+    logger.info(
+        f"Backfill results: {matched_count}/{len(df)} rows now matched "
+        f"({len(df) - matched_count} still unmatched)"
+    )
+
+    # Show method breakdown
+    methods = {}
+    for u in updates:
+        methods[u["method"]] = methods.get(u["method"], 0) + 1
+    for method, count in sorted(methods.items()):
+        logger.info(f"  {method}: {count}")
+
+    if dry_run:
+        logger.info("DRY RUN — no updates written.")
+        return
+
+    # Batch update via individual UPDATE statements
+    # (BigQuery doesn't support parameterized batch updates easily)
+    for u in updates:
+        escaped_name = u["pundit_name"].replace("'", "\\'")
+        update_sql = f"""
+            UPDATE `{project_id}.nfl_dead_money.raw_pundit_media`
+            SET matched_pundit_id = '{u["pundit_id"]}',
+                matched_pundit_name = '{escaped_name}'
+            WHERE content_hash = '{u["content_hash"]}'
+        """
+        try:
+            db.execute(update_sql)
+        except Exception as e:
+            logger.error(f"Failed to update {u['content_hash'][:16]}…: {e}")
+
+    logger.info(f"Wrote {len(updates)} updates to raw_pundit_media.")
+    db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill pundit matching")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    backfill(dry_run=args.dry_run)

--- a/pipeline/scripts/void_pre_prompt_fix_predictions.py
+++ b/pipeline/scripts/void_pre_prompt_fix_predictions.py
@@ -1,0 +1,86 @@
+"""
+Void Pre-Prompt-Fix Predictions (Issue #168)
+
+Marks all existing prediction_ledger rows as VOID in prediction_resolutions,
+since they were extracted with the original weak prompt that accepted vibes,
+stale news, and duplicates. Preserves the chain hash integrity (append-only).
+
+Idempotent — safe to re-run. Skips predictions that already have a resolution.
+
+Usage (inside Docker):
+    python pipeline/scripts/void_pre_prompt_fix_predictions.py
+    python pipeline/scripts/void_pre_prompt_fix_predictions.py --dry-run
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.db_manager import DBManager
+from src.resolution_engine import void_prediction
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+VOID_REASON = "low_quality_extraction_pre_prompt_fix_issue_168"
+
+
+def void_existing_predictions(dry_run: bool = False):
+    db = DBManager()
+    project_id = os.environ["GCP_PROJECT_ID"]
+
+    # Get all prediction hashes that don't already have a resolution
+    query = f"""
+        SELECT l.prediction_hash, l.pundit_name, l.extracted_claim
+        FROM `{project_id}.gold_layer.prediction_ledger` l
+        LEFT JOIN `{project_id}.gold_layer.prediction_resolutions` r
+            ON l.prediction_hash = r.prediction_hash
+        WHERE r.prediction_hash IS NULL
+        ORDER BY l.ingestion_timestamp ASC
+    """
+    df = db.fetch_df(query)
+    logger.info(f"Found {len(df)} unresolved predictions to void")
+
+    if df.empty:
+        logger.info("All predictions already have resolutions. Nothing to do.")
+        return
+
+    voided = 0
+    for _, row in df.iterrows():
+        phash = row["prediction_hash"]
+        claim = str(row.get("extracted_claim", ""))[:80]
+        pundit = row.get("pundit_name", "Unknown")
+
+        if dry_run:
+            logger.info(f"DRY RUN: would void {phash[:16]}… ({pundit}: {claim})")
+            voided += 1
+            continue
+
+        try:
+            void_prediction(
+                prediction_hash=phash,
+                reason=VOID_REASON,
+                db=db,
+            )
+            voided += 1
+            logger.info(f"VOIDED: {phash[:16]}… ({pundit}: {claim})")
+        except Exception as e:
+            logger.error(f"Failed to void {phash[:16]}…: {e}")
+
+    logger.info(f"Voided {voided}/{len(df)} predictions.")
+    db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Void pre-prompt-fix predictions"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    void_existing_predictions(dry_run=args.dry_run)

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -411,7 +411,6 @@ def run_extraction(
                     else:
                         player_name = raw_player
 
-
                 all_predictions.append(
                     PunditPrediction(
                         pundit_id=str(pundit_id),

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -122,6 +122,39 @@ def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> lis
     return kept
 
 
+def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> list[dict]:
+    """
+    Remove near-duplicate claims from a single article's extraction.
+    Uses SequenceMatcher to detect semantic overlap. Keeps the longest
+    (most specific) claim from each cluster.
+    """
+    if len(predictions) <= 1:
+        return predictions
+
+    from difflib import SequenceMatcher
+
+    kept = []
+    for pred in predictions:
+        claim = pred.get("extracted_claim", "").lower()
+        is_dup = False
+        for i, existing in enumerate(kept):
+            existing_claim = existing.get("extracted_claim", "").lower()
+            ratio = SequenceMatcher(None, claim, existing_claim).ratio()
+            if ratio >= threshold:
+                # Keep the longer (more specific) one
+                if len(claim) > len(existing_claim):
+                    kept[i] = pred
+                is_dup = True
+                break
+        if not is_dup:
+            kept.append(pred)
+
+    removed = len(predictions) - len(kept)
+    if removed > 0:
+        logger.info(f"Dedup: removed {removed} near-duplicate claims")
+    return kept
+
+
 def extract_assertions(
     content_hash: str,
     text: str,
@@ -377,6 +410,7 @@ def run_extraction(
                         player_name = "MULTI"
                     else:
                         player_name = raw_player
+
 
                 all_predictions.append(
                     PunditPrediction(

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -64,9 +64,9 @@ def _normalize_name(name: str) -> str:
     """Normalize player name for fuzzy matching."""
     name = name.lower().strip()
     # Remove common suffixes
-    name = re.sub(r'\s+(jr\.?|sr\.?|ii|iii|iv)$', '', name)
+    name = re.sub(r"\s+(jr\.?|sr\.?|ii|iii|iv)$", "", name)
     # Remove periods from initials
-    name = name.replace('.', '')
+    name = name.replace(".", "")
     return name
 
 
@@ -80,41 +80,47 @@ def _extract_draft_claim(claim: str) -> dict:
 
     # Extract "No. 1 overall pick" or "#1 pick" or "first overall pick"
     ordinals = {
-        'first': 1, 'second': 2, 'third': 3, 'fourth': 4, 'fifth': 5,
-        'sixth': 6, 'seventh': 7, 'eighth': 8, 'ninth': 9, 'tenth': 10,
+        "first": 1,
+        "second": 2,
+        "third": 3,
+        "fourth": 4,
+        "fifth": 5,
+        "sixth": 6,
+        "seventh": 7,
+        "eighth": 8,
+        "ninth": 9,
+        "tenth": 10,
     }
-    pick_match = re.search(r'(?:no\.?\s*|#)(\d+)\s*(?:overall\s*)?pick', claim_lower)
+    pick_match = re.search(r"(?:no\.?\s*|#)(\d+)\s*(?:overall\s*)?pick", claim_lower)
     if pick_match:
-        result['pick_number'] = int(pick_match.group(1))
+        result["pick_number"] = int(pick_match.group(1))
     else:
         for word, num in ordinals.items():
-            if f'{word} overall' in claim_lower or f'{word} pick' in claim_lower:
-                result['pick_number'] = num
+            if f"{word} overall" in claim_lower or f"{word} pick" in claim_lower:
+                result["pick_number"] = num
                 break
 
     # Extract "top-N pick"
-    top_match = re.search(r'top[- ](\d+)\s*pick', claim_lower)
+    top_match = re.search(r"top[- ](\d+)\s*pick", claim_lower)
     if top_match:
-        result['top_n'] = int(top_match.group(1))
+        result["top_n"] = int(top_match.group(1))
 
     # Extract "Round 1" or "first round"
-    round_match = re.search(r'round\s*(\d+)', claim_lower)
+    round_match = re.search(r"round\s*(\d+)", claim_lower)
     if round_match:
-        result['round_number'] = int(round_match.group(1))
-    elif 'first round' in claim_lower:
-        result['round_number'] = 1
+        result["round_number"] = int(round_match.group(1))
+    elif "first round" in claim_lower:
+        result["round_number"] = 1
 
     # Extract draft year
-    year_match = re.search(r'20\d{2}', claim)
+    year_match = re.search(r"20\d{2}", claim)
     if year_match:
-        result['draft_year'] = int(year_match.group())
+        result["draft_year"] = int(year_match.group())
 
     return result
 
 
-def resolve_draft_picks(
-    db: DBManager, dry_run: bool = False
-) -> dict:
+def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
     """
     Resolve draft_pick predictions against actual draft results.
     """
@@ -157,23 +163,22 @@ def resolve_draft_picks(
         # Check if this draft has actually happened
         current_year = pd.Timestamp.now().year
         # NFL draft is in late April; if we're past May of draft_year, it's happened
-        draft_completed = (
-            draft_year < current_year
-            or (draft_year == current_year and pd.Timestamp.now().month > 5)
+        draft_completed = draft_year < current_year or (
+            draft_year == current_year and pd.Timestamp.now().month > 5
         )
 
         if not draft_completed:
-            logger.info(
-                f"  SKIP {phash[:12]}… — {draft_year} draft not yet completed"
-            )
+            logger.info(f"  SKIP {phash[:12]}… — {draft_year} draft not yet completed")
             summary["skipped"] += 1
             continue
 
         # Find the player in draft data
         norm_name = _normalize_name(player_name) if player_name else ""
-        player_matches = draft_data[
-            draft_data["name_lower"].str.contains(norm_name, na=False)
-        ] if norm_name and norm_name != "none" else pd.DataFrame()
+        player_matches = (
+            draft_data[draft_data["name_lower"].str.contains(norm_name, na=False)]
+            if norm_name and norm_name != "none"
+            else pd.DataFrame()
+        )
 
         # Also try extracting player name from the claim itself
         if player_matches.empty:
@@ -200,17 +205,23 @@ def resolve_draft_picks(
 
         # Now evaluate the claim
         correct = None
-        notes_parts = [f"Actual: {actual_name} was pick #{actual_pick} (Round {actual_round}) by {actual_team}"]
+        notes_parts = [
+            f"Actual: {actual_name} was pick #{actual_pick} (Round {actual_round}) by {actual_team}"
+        ]
 
         if "pick_number" in parsed:
             correct = int(actual_pick) == parsed["pick_number"]
-            notes_parts.append(f"Claimed pick #{parsed['pick_number']}, actual #{actual_pick}")
+            notes_parts.append(
+                f"Claimed pick #{parsed['pick_number']}, actual #{actual_pick}"
+            )
         elif "top_n" in parsed:
             correct = int(actual_pick) <= parsed["top_n"]
             notes_parts.append(f"Claimed top-{parsed['top_n']}, actual #{actual_pick}")
         elif "round_number" in parsed:
             correct = int(actual_round) == parsed["round_number"]
-            notes_parts.append(f"Claimed Round {parsed['round_number']}, actual Round {actual_round}")
+            notes_parts.append(
+                f"Claimed Round {parsed['round_number']}, actual Round {actual_round}"
+            )
         else:
             # Can't determine specific claim — void
             logger.info(
@@ -296,4 +307,5 @@ if __name__ == "__main__":
 
     result = resolve_all(category=args.category, dry_run=args.dry_run)
     import json
+
     print(json.dumps(result, indent=2))

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -1,0 +1,299 @@
+"""
+Daily Prediction Resolution Engine (Issue #169)
+
+Matches PENDING predictions from gold_layer.prediction_ledger against actual
+NFL outcomes to automatically score pundit accuracy.
+
+Handles three easy-win categories:
+  1. draft_pick — resolved against bronze_sportsdataio_players draft data
+  2. game_outcome — resolved against silver_pfr_game_logs (future)
+  3. player_performance for completed seasons — resolved against season stats (future)
+
+Usage (inside Docker):
+    python -m src.resolve_daily                     # resolve all pending
+    python -m src.resolve_daily --category draft_pick  # single category
+    python -m src.resolve_daily --dry-run           # preview without writing
+"""
+
+import argparse
+import logging
+import os
+import re
+from typing import Optional
+
+import pandas as pd
+
+from src.db_manager import DBManager
+from src.resolution_engine import (
+    get_pending_predictions,
+    resolve_binary,
+    void_prediction,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Draft pick resolver
+# ---------------------------------------------------------------------------
+
+
+def _load_draft_data(db: DBManager) -> pd.DataFrame:
+    """Load draft pick data from bronze_sportsdataio_players."""
+    project_id = os.environ["GCP_PROJECT_ID"]
+    query = f"""
+        SELECT
+            Name,
+            LOWER(Name) AS name_lower,
+            CollegeDraftYear AS draft_year,
+            CollegeDraftRound AS draft_round,
+            CollegeDraftPick AS draft_pick,
+            CollegeDraftTeam AS draft_team,
+            Team AS current_team,
+            IsUndraftedFreeAgent AS undrafted
+        FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_players`
+        WHERE CollegeDraftYear IS NOT NULL
+    """
+    return db.fetch_df(query)
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize player name for fuzzy matching."""
+    name = name.lower().strip()
+    # Remove common suffixes
+    name = re.sub(r'\s+(jr\.?|sr\.?|ii|iii|iv)$', '', name)
+    # Remove periods from initials
+    name = name.replace('.', '')
+    return name
+
+
+def _extract_draft_claim(claim: str) -> dict:
+    """
+    Parse a draft_pick claim to extract structured components.
+    Returns dict with keys: player_name, pick_number, round_number, team, draft_year
+    """
+    claim_lower = claim.lower()
+    result = {}
+
+    # Extract "No. 1 overall pick" or "#1 pick" or "first overall pick"
+    ordinals = {
+        'first': 1, 'second': 2, 'third': 3, 'fourth': 4, 'fifth': 5,
+        'sixth': 6, 'seventh': 7, 'eighth': 8, 'ninth': 9, 'tenth': 10,
+    }
+    pick_match = re.search(r'(?:no\.?\s*|#)(\d+)\s*(?:overall\s*)?pick', claim_lower)
+    if pick_match:
+        result['pick_number'] = int(pick_match.group(1))
+    else:
+        for word, num in ordinals.items():
+            if f'{word} overall' in claim_lower or f'{word} pick' in claim_lower:
+                result['pick_number'] = num
+                break
+
+    # Extract "top-N pick"
+    top_match = re.search(r'top[- ](\d+)\s*pick', claim_lower)
+    if top_match:
+        result['top_n'] = int(top_match.group(1))
+
+    # Extract "Round 1" or "first round"
+    round_match = re.search(r'round\s*(\d+)', claim_lower)
+    if round_match:
+        result['round_number'] = int(round_match.group(1))
+    elif 'first round' in claim_lower:
+        result['round_number'] = 1
+
+    # Extract draft year
+    year_match = re.search(r'20\d{2}', claim)
+    if year_match:
+        result['draft_year'] = int(year_match.group())
+
+    return result
+
+
+def resolve_draft_picks(
+    db: DBManager, dry_run: bool = False
+) -> dict:
+    """
+    Resolve draft_pick predictions against actual draft results.
+    """
+    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
+
+    pending = get_pending_predictions(sport="NFL", db=db)
+    draft_preds = pending[pending["claim_category"] == "draft_pick"]
+
+    if draft_preds.empty:
+        logger.info("No pending draft_pick predictions to resolve.")
+        return summary
+
+    draft_data = _load_draft_data(db)
+    if draft_data.empty:
+        logger.warning("No draft data available for resolution.")
+        return summary
+
+    logger.info(
+        f"Resolving {len(draft_preds)} draft_pick predictions "
+        f"against {len(draft_data)} player draft records"
+    )
+
+    for _, pred in draft_preds.iterrows():
+        summary["checked"] += 1
+        claim = pred["extracted_claim"]
+        phash = pred["prediction_hash"]
+        player_name = pred.get("target_player_id") or ""  # Legacy field (has names)
+        season_year = pred.get("season_year")
+
+        parsed = _extract_draft_claim(claim)
+        draft_year = parsed.get("draft_year")
+        if not draft_year and pd.notna(season_year):
+            draft_year = int(season_year)
+
+        if not draft_year:
+            logger.info(f"  SKIP {phash[:12]}… — no draft year in claim or metadata")
+            summary["skipped"] += 1
+            continue
+
+        # Check if this draft has actually happened
+        current_year = pd.Timestamp.now().year
+        # NFL draft is in late April; if we're past May of draft_year, it's happened
+        draft_completed = (
+            draft_year < current_year
+            or (draft_year == current_year and pd.Timestamp.now().month > 5)
+        )
+
+        if not draft_completed:
+            logger.info(
+                f"  SKIP {phash[:12]}… — {draft_year} draft not yet completed"
+            )
+            summary["skipped"] += 1
+            continue
+
+        # Find the player in draft data
+        norm_name = _normalize_name(player_name) if player_name else ""
+        player_matches = draft_data[
+            draft_data["name_lower"].str.contains(norm_name, na=False)
+        ] if norm_name and norm_name != "none" else pd.DataFrame()
+
+        # Also try extracting player name from the claim itself
+        if player_matches.empty:
+            # Try each name in draft_data against the claim
+            claim_lower = claim.lower()
+            for _, draft_row in draft_data.iterrows():
+                if draft_row["name_lower"] in claim_lower:
+                    player_matches = pd.DataFrame([draft_row])
+                    break
+
+        if player_matches.empty:
+            logger.info(
+                f"  SKIP {phash[:12]}… — can't find player in draft data: {claim[:60]}"
+            )
+            summary["skipped"] += 1
+            continue
+
+        # Use the first match (best match)
+        actual = player_matches.iloc[0]
+        actual_pick = actual.get("draft_pick")
+        actual_round = actual.get("draft_round")
+        actual_team = actual.get("draft_team")
+        actual_name = actual.get("Name")
+
+        # Now evaluate the claim
+        correct = None
+        notes_parts = [f"Actual: {actual_name} was pick #{actual_pick} (Round {actual_round}) by {actual_team}"]
+
+        if "pick_number" in parsed:
+            correct = int(actual_pick) == parsed["pick_number"]
+            notes_parts.append(f"Claimed pick #{parsed['pick_number']}, actual #{actual_pick}")
+        elif "top_n" in parsed:
+            correct = int(actual_pick) <= parsed["top_n"]
+            notes_parts.append(f"Claimed top-{parsed['top_n']}, actual #{actual_pick}")
+        elif "round_number" in parsed:
+            correct = int(actual_round) == parsed["round_number"]
+            notes_parts.append(f"Claimed Round {parsed['round_number']}, actual Round {actual_round}")
+        else:
+            # Can't determine specific claim — void
+            logger.info(
+                f"  VOID {phash[:12]}… — can't parse specific claim: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "unparseable_draft_claim", db=db)
+            summary["voided"] += 1
+            continue
+
+        outcome_notes = "; ".join(notes_parts)
+        status = "CORRECT" if correct else "INCORRECT"
+        logger.info(f"  {status} {phash[:12]}… — {outcome_notes}")
+
+        if not dry_run:
+            resolve_binary(
+                prediction_hash=phash,
+                correct=correct,
+                outcome_source="sportsdataio",
+                outcome_notes=outcome_notes,
+                db=db,
+            )
+        summary["resolved"] += 1
+
+    logger.info(
+        f"Draft resolution: {summary['resolved']} resolved, "
+        f"{summary['voided']} voided, {summary['skipped']} skipped"
+    )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_all(
+    category: Optional[str] = None,
+    dry_run: bool = False,
+    db: Optional[DBManager] = None,
+) -> dict:
+    """Run all resolution passes. Returns combined summary."""
+    close_db = db is None
+    if db is None:
+        db = DBManager()
+
+    try:
+        summaries = {}
+
+        if not category or category == "draft_pick":
+            summaries["draft_pick"] = resolve_draft_picks(db, dry_run=dry_run)
+
+        # Future: game_outcome, player_performance resolvers
+
+        # Combined summary
+        total = {
+            "checked": sum(s["checked"] for s in summaries.values()),
+            "resolved": sum(s["resolved"] for s in summaries.values()),
+            "voided": sum(s["voided"] for s in summaries.values()),
+            "skipped": sum(s["skipped"] for s in summaries.values()),
+        }
+
+        logger.info(
+            f"Resolution complete: {total['resolved']} resolved, "
+            f"{total['voided']} voided, {total['skipped']} skipped "
+            f"out of {total['checked']} checked"
+        )
+        return total
+    finally:
+        if close_db:
+            db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Daily Prediction Resolver")
+    parser.add_argument(
+        "--category",
+        choices=["draft_pick", "game_outcome", "player_performance"],
+        help="Resolve only a specific category",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    result = resolve_all(category=args.category, dry_run=args.dry_run)
+    import json
+    print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary
Fixes #169

Builds the first automated resolution pass. Starts with `draft_pick` since we have complete draft data in `bronze_sportsdataio_players` and it's the most straightforward category to resolve.

**Draft pick resolver:**
- Parses claims for pick number, round, top-N, and draft year using regex
- Matches player names against `bronze_sportsdataio_players`
- Resolves as CORRECT/INCORRECT/VOID with detailed outcome notes
- Handles various claim formats: "No. 1 overall pick", "top-20 pick", "first round", etc.
- Skips predictions for drafts that haven't yet completed

**Architecture:**
- Standalone CLI: `python -m src.resolve_daily [--category draft_pick] [--dry-run]`
- Designed for additional resolvers (game_outcome, player_performance) as plug-in functions
- Uses existing `resolution_engine.resolve_binary` / `void_prediction`

Currently 0 pending predictions (all 31 pre-prompt-fix rows were VOID'd by #168). Engine is ready for new extractions once Gemini credits are refilled.

## Test plan
- [x] Claim parser smoke tests pass (3 claim formats)
- [x] Dry-run against production BQ: 0 pending, 0 errors
- [x] Module imports cleanly in Docker
- [ ] End-to-end resolution once new predictions are extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)