### PR TITLE
fix(e2e): make Clerk optional — graceful degradation without API keys

### DIFF
--- a/web/components/clerk-provider-wrapper.tsx
+++ b/web/components/clerk-provider-wrapper.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ClerkProvider } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
+import { ReactNode } from "react";
+
+export default function ClerkProviderWrapper({ children }: { children: ReactNode }) {
+    return (
+        <ClerkProvider
+            appearance={{
+                baseTheme: dark,
+                variables: { colorPrimary: '#10b981' },
+            }}
+        >
+            {children}
+        </ClerkProvider>
+    );
+}

--- a/web/components/navbar.tsx
+++ b/web/components/navbar.tsx
@@ -2,14 +2,21 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { UserButton, useUser, SignInButton } from "@clerk/nextjs";
 import { GlobalSearch } from "./global-search";
 import { useState, useEffect } from "react";
 import { useTeam } from "./team-context";
 
+const hasClerkKey = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+function useClerkAuth(): { isSignedIn: boolean; isLoaded: boolean } {
+    if (!hasClerkKey) return { isSignedIn: false, isLoaded: true };
+    const { useUser } = require("@clerk/nextjs");
+    return useUser();
+}
+
 export function Navbar() {
     const pathname = usePathname();
-    const { isSignedIn, isLoaded } = useUser();
+    const { isSignedIn, isLoaded } = useClerkAuth();
     const { activeTeam, setTeamSelectorOpen } = useTeam();
     const [isScrolled, setIsScrolled] = useState(false);
 
@@ -85,15 +92,23 @@ export function Navbar() {
                     <GlobalSearch />
                     
                     {/* Auth */}
-                    {isLoaded && (
+                    {isLoaded && hasClerkKey && (
                         isSignedIn ? (
-                            <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: "w-9 h-9 border border-emerald-500/50" } }} />
+                            (() => {
+                                const { UserButton } = require("@clerk/nextjs");
+                                return <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: "w-9 h-9 border border-emerald-500/50" } }} />;
+                            })()
                         ) : (
-                            <SignInButton mode="modal">
-                                <span className="cursor-pointer text-sm font-medium text-slate-300 hover:text-white transition-colors bg-white/5 px-4 py-2 rounded-md border border-white/10 hover:border-emerald-500/50 hover:bg-emerald-500/10">
-                                    Sign In
-                                </span>
-                            </SignInButton>
+                            (() => {
+                                const { SignInButton } = require("@clerk/nextjs");
+                                return (
+                                    <SignInButton mode="modal">
+                                        <span className="cursor-pointer text-sm font-medium text-slate-300 hover:text-white transition-colors bg-white/5 px-4 py-2 rounded-md border border-white/10 hover:border-emerald-500/50 hover:bg-emerald-500/10">
+                                            Sign In
+                                        </span>
+                                    </SignInButton>
+                                );
+                            })()
                         )
                     )}
                 </div>

--- a/web/components/providers.tsx
+++ b/web/components/providers.tsx
@@ -2,9 +2,14 @@
 
 import { PersonaProvider } from "@/components/persona-context";
 import { TeamProvider } from "@/components/team-context";
+import dynamic from "next/dynamic";
 import { ReactNode } from "react";
 
 const hasClerkKey = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+const ClerkProviderWrapper = hasClerkKey
+    ? dynamic(() => import("@/components/clerk-provider-wrapper"), { ssr: false })
+    : null;
 
 function InnerProviders({ children }: { children: ReactNode }) {
     return (
@@ -17,23 +22,13 @@ function InnerProviders({ children }: { children: ReactNode }) {
 }
 
 export function Providers({ children }: { children: ReactNode }) {
-    if (!hasClerkKey) {
+    if (!ClerkProviderWrapper) {
         return <InnerProviders>{children}</InnerProviders>;
     }
 
-    // Dynamic require avoids importing @clerk/nextjs when keys are absent.
-    // This is a top-level component, not a hook — safe to require conditionally.
-    const { ClerkProvider } = require("@clerk/nextjs");
-    const { dark } = require("@clerk/themes");
-
     return (
-        <ClerkProvider
-            appearance={{
-                baseTheme: dark,
-                variables: { colorPrimary: '#10b981' },
-            }}
-        >
+        <ClerkProviderWrapper>
             <InnerProviders>{children}</InnerProviders>
-        </ClerkProvider>
+        </ClerkProviderWrapper>
     );
 }

--- a/web/components/providers.tsx
+++ b/web/components/providers.tsx
@@ -1,12 +1,31 @@
 "use client";
 
-import { ClerkProvider } from "@clerk/nextjs";
-import { dark } from "@clerk/themes";
 import { PersonaProvider } from "@/components/persona-context";
 import { TeamProvider } from "@/components/team-context";
 import { ReactNode } from "react";
 
+const hasClerkKey = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+function InnerProviders({ children }: { children: ReactNode }) {
+    return (
+        <TeamProvider>
+            <PersonaProvider>
+                {children}
+            </PersonaProvider>
+        </TeamProvider>
+    );
+}
+
 export function Providers({ children }: { children: ReactNode }) {
+    if (!hasClerkKey) {
+        return <InnerProviders>{children}</InnerProviders>;
+    }
+
+    // Dynamic require avoids importing @clerk/nextjs when keys are absent.
+    // This is a top-level component, not a hook — safe to require conditionally.
+    const { ClerkProvider } = require("@clerk/nextjs");
+    const { dark } = require("@clerk/themes");
+
     return (
         <ClerkProvider
             appearance={{
@@ -14,11 +33,7 @@ export function Providers({ children }: { children: ReactNode }) {
                 variables: { colorPrimary: '#10b981' },
             }}
         >
-            <TeamProvider>
-                <PersonaProvider>
-                    {children}
-                </PersonaProvider>
-            </TeamProvider>
+            <InnerProviders>{children}</InnerProviders>
         </ClerkProvider>
     );
 }

--- a/web/components/team-context.tsx
+++ b/web/components/team-context.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from "react";
-import { useUser } from "@clerk/nextjs";
 import { updateUserTeam } from "@/app/actions/user";
+
+const hasClerkKey = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
 interface TeamContextType {
     activeTeam: string | null;
@@ -14,54 +15,76 @@ interface TeamContextType {
 
 const TeamContext = createContext<TeamContextType | undefined>(undefined);
 
+/**
+ * TeamProvider that uses Clerk for user metadata when available,
+ * falls back to localStorage-only when Clerk keys are absent (CI/Docker).
+ */
 export function TeamProvider({ children }: { children: ReactNode }) {
+    if (hasClerkKey) {
+        return <ClerkTeamProvider>{children}</ClerkTeamProvider>;
+    }
+    return <LocalTeamProvider>{children}</LocalTeamProvider>;
+}
+
+/** Full provider — uses Clerk useUser() for metadata sync. */
+function ClerkTeamProvider({ children }: { children: ReactNode }) {
+    // Safe to call useUser here — this component only renders when ClerkProvider exists
+    const { useUser } = require("@clerk/nextjs");
     const { user, isLoaded } = useUser();
     const [activeTeam, setActiveTeamState] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isTeamSelectorOpen, setTeamSelectorOpen] = useState(false);
 
-    // Sync with User Metadata or Local Storage
     useEffect(() => {
         if (!isLoaded) return;
-
         const syncTeam = async () => {
-            // 1. Check User Metadata (Server Truth)
             if (user?.publicMetadata?.favorite_team) {
-                console.log("TeamContext: Found team in metadata:", user.publicMetadata.favorite_team);
                 setActiveTeamState(user.publicMetadata.favorite_team as string);
-                localStorage.setItem("favorite_team", user.publicMetadata.favorite_team as string); // Sync local
-            }
-            // 2. Check Local Storage (Guest / Fallback)
-            else {
+                localStorage.setItem("favorite_team", user.publicMetadata.favorite_team as string);
+            } else {
                 const localTeam = localStorage.getItem("favorite_team");
-                if (localTeam) {
-                    console.log("TeamContext: Found team in localStorage:", localTeam);
-                    setActiveTeamState(localTeam);
-                }
+                if (localTeam) setActiveTeamState(localTeam);
             }
             setIsLoading(false);
         };
-
         syncTeam();
     }, [user, isLoaded]);
 
     const setActiveTeam = async (team: string) => {
-        // Optimistic Update
         setActiveTeamState(team);
         localStorage.setItem("favorite_team", team);
-
-        // Persist to Server if logged in
         if (user) {
             try {
                 await updateUserTeam(team);
-                // Also update client-side user object to reflect change immediately? 
-                // Clerk usually handles this via revalidation, but we might need user.reload() if strictly necessary.
                 await user.reload();
             } catch (error) {
                 console.error("TeamContext: Failed to persist team", error);
-                // Revert? For now, we keep optimistic update.
             }
         }
+    };
+
+    return (
+        <TeamContext.Provider value={{ activeTeam, setActiveTeam, isLoading, isTeamSelectorOpen, setTeamSelectorOpen }}>
+            {children}
+        </TeamContext.Provider>
+    );
+}
+
+/** Lightweight provider — localStorage only, no Clerk dependency. */
+function LocalTeamProvider({ children }: { children: ReactNode }) {
+    const [activeTeam, setActiveTeamState] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isTeamSelectorOpen, setTeamSelectorOpen] = useState(false);
+
+    useEffect(() => {
+        const localTeam = localStorage.getItem("favorite_team");
+        if (localTeam) setActiveTeamState(localTeam);
+        setIsLoading(false);
+    }, []);
+
+    const setActiveTeam = async (team: string) => {
+        setActiveTeamState(team);
+        localStorage.setItem("favorite_team", team);
     };
 
     return (

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,35 +1,61 @@
-import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import type { NextRequest, NextFetchEvent } from "next/server";
 
-const isProtectedRoute = createRouteMatcher([
-    "/scenarios(.*)",
-    "/fantasy(.*)",
-    "/dashboard/gm(.*)",
-    "/dashboard/agent(.*)",
-    "/dashboard/bettor(.*)",
-    "/dashboard/api-keys(.*)",
-    "/api/api-keys(.*)"
-]);
+const hasClerkKeys = !!(
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY &&
+    process.env.CLERK_SECRET_KEY
+);
 
-export default clerkMiddleware((auth, req) => {
-    if (isProtectedRoute(req)) {
-        auth().protect();
-    }
-    
+// Passthrough middleware when Clerk is not configured (CI/Docker)
+function passthroughMiddleware(req: NextRequest) {
     const requestHeaders = new Headers(req.headers);
-    requestHeaders.set('x-forwarded-proto', 'https'); // Often needed for local headless testing behind proxies
-    
-    const response = NextResponse.next({
-        request: {
-            headers: requestHeaders,
-        },
+    requestHeaders.set('x-forwarded-proto', 'https');
+    return NextResponse.next({
+        request: { headers: requestHeaders },
+    });
+}
+
+// Clerk middleware — only loaded when keys are present
+let clerkHandler: ((req: NextRequest, event: NextFetchEvent) => any) | null = null;
+
+async function getClerkHandler() {
+    if (clerkHandler) return clerkHandler;
+
+    const { clerkMiddleware, createRouteMatcher } = await import("@clerk/nextjs/server");
+
+    const isProtectedRoute = createRouteMatcher([
+        "/scenarios(.*)",
+        "/fantasy(.*)",
+        "/dashboard/gm(.*)",
+        "/dashboard/agent(.*)",
+        "/dashboard/bettor(.*)",
+        "/dashboard/api-keys(.*)",
+        "/api/api-keys(.*)"
+    ]);
+
+    clerkHandler = clerkMiddleware((auth, req) => {
+        if (isProtectedRoute(req)) {
+            auth().protect();
+        }
+
+        const requestHeaders = new Headers(req.headers);
+        requestHeaders.set('x-forwarded-proto', 'https');
+
+        return NextResponse.next({
+            request: { headers: requestHeaders },
+        });
     });
 
-    // We can also set CSP here if next.config.js headers are not enough:
-    // response.headers.set('Content-Security-Policy', "worker-src 'self' blob:;");
-    
-    return response;
-});
+    return clerkHandler;
+}
+
+export default async function middleware(req: NextRequest, event: NextFetchEvent) {
+    if (!hasClerkKeys) {
+        return passthroughMiddleware(req);
+    }
+    const handler = await getClerkHandler();
+    return handler(req, event);
+}
 
 export const config = {
     matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],


### PR DESCRIPTION
## Summary
Fixes #160 — **This PR unblocks ALL other PRs.** E2E integration tests are a required check and have been failing on every PR since the Clerk integration.

**Root cause:** `team-context.tsx` calls `useUser()` which requires `<ClerkProvider>`, but Docker CI has no Clerk env vars. Every page load crashes with `Error: useUser can only be used within the <ClerkProvider /> component`.

**Fix:** Split Clerk-dependent components into Clerk-aware and Clerk-free variants based on `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` presence. No conditional hooks — separate component trees avoid React rules-of-hooks violations entirely.

### Changes
| File | What |
|---|---|
| `providers.tsx` | Skip `<ClerkProvider>` wrapping when key is absent |
| `team-context.tsx` | `ClerkTeamProvider` (with `useUser`) vs `LocalTeamProvider` (localStorage only) |
| `navbar.tsx` | `useClerkAuth()` returns stub `{isSignedIn: false, isLoaded: true}` without key |
| `middleware.ts` | Passthrough middleware when Clerk keys absent, dynamic import otherwise |

### Impact
Once this merges, the following auto-merge-queued PRs should cascade:
- #172 (pundit matching), #173 (pipeline fail-loud), #174 (extractor quality), #176 (resolution engine), #183 (LLM provider abstraction)

## Test plan
- [ ] E2E tests pass in Docker CI (no Clerk keys) — pages return 200 instead of 500
- [ ] Production behavior unchanged when Clerk keys ARE present
- [ ] No React hooks violations (separate component trees, not conditional hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)