### PR TITLE
feat(agents): /land command + identity-signed comments

### DIFF
--- a/.agent/gh-comment.sh
+++ b/.agent/gh-comment.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Post a GitHub comment signed with the agent's identity.
+#
+# Every agent comment on this repo MUST go through this script so that
+# each agent's work is clearly attributed and traceable.
+#
+# Usage:
+#   .agent/gh-comment.sh issue 129 "claude-opus-4-go-a1b2" <<'EOF'
+#   🤖 intending to work on this at 2026-04-23T14:30:00Z
+#   EOF
+#
+#   echo "CI is green — queued for merge." | .agent/gh-comment.sh pr 151 "claude-sonnet-4-land-c3d4"
+#
+# The script appends a machine-readable signature line:
+#   ---
+#   🤖 <agent-id> · <UTC timestamp>
+#
+# This lets anyone (human or agent) trace which agent posted what.
+
+set -euo pipefail
+
+TYPE="${1:?usage: gh-comment.sh issue|pr <number> <agent-id> (message on stdin)}"
+NUMBER="${2:?number required}"
+AGENT_ID="${3:?agent-id required}"
+
+# Read message body from stdin
+MESSAGE="$(cat)"
+
+if [ -z "$MESSAGE" ]; then
+    echo "✗ Empty message body — pipe your comment text to stdin" >&2
+    exit 1
+fi
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BODY="${MESSAGE}
+
+---
+🤖 ${AGENT_ID} · ${TIMESTAMP}"
+
+case "$TYPE" in
+    issue) gh issue comment "$NUMBER" --body "$BODY" ;;
+    pr)    gh pr comment "$NUMBER" --body "$BODY" ;;
+    *)     echo "✗ Unknown type: $TYPE (use 'issue' or 'pr')" >&2; exit 1 ;;
+esac

--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -1,0 +1,230 @@
+---
+description: Safely claim and complete one issue using a shared orientation cache
+---
+
+# Multi-Agent Work Protocol (Minimal)
+
+You are one of multiple agents working in parallel.
+
+Your goal:
+- Complete exactly one unblocked issue
+- Avoid duplicate work
+- Follow repository conventions via a shared cache
+
+If you cannot reliably perform any required step, EXIT safely.
+
+## Identity
+
+Construct your agent identity once at the start of your session:
+
+```bash
+HEX="$(echo $RANDOM | md5sum | head -c4)"
+AGENT_ID="<your-model-short-name>-go-${HEX}"
+# e.g. "opus-4-go-a3f1" or "sonnet-4-go-b7c2"
+```
+
+**ALL** GitHub comments (issues and PRs) MUST go through `.agent/gh-comment.sh`:
+```bash
+echo "your message" | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+echo "your message" | .agent/gh-comment.sh pr <number> "$AGENT_ID"
+```
+
+Never post bare `gh issue comment` or `gh pr comment` — always use the wrapper.
+This ensures every comment is signed and traceable to the specific agent session.
+
+## Autonomy
+
+Run autonomously. Do NOT prompt the user for permission on:
+- Read-only / exploratory commands (git log, git status, cat, ls, grep, gh issue/pr queries)
+- Running tests (pytest)
+- Creating branches, committing, pushing feature branches
+- Opening/commenting on issues and PRs
+- Any command whose purpose is understanding the current state of the codebase or infrastructure
+
+Only pause for user input on items listed in CLAUDE.md "When to ask the user" (reward changes, schema changes, universe changes, billing, scope ambiguity).
+
+---
+
+# Core Flow
+
+1. LOAD_ORIENTATION
+2. PROCESS_FEEDBACK
+3. SELECT_ISSUE
+4. CLAIM
+5. VERIFY
+6. WORK
+7. COMPLETE
+
+---
+
+# STATE 1: LOAD_ORIENTATION
+
+IF `.claude/agent-orientation.md` exists:
+  READ it and follow it strictly
+
+ELSE:
+  You are the bootstrap agent:
+    - Discover repo conventions
+    - Define how to perform required operations (issues, comments, PRs, etc.)
+    - Write `.claude/agent-orientation.md`
+    - Open a PR: "bootstrap agent orientation cache"
+  EXIT
+
+---
+
+# STATE 2: PROCESS_FEEDBACK
+
+Check for:
+- Issues labeled `agent-feedback`
+- Comments mentioning "agent"
+- Recently failed/closed PRs
+
+IF feedback affects conventions:
+  Update orientation cache (use lock)
+  IF substantial change:
+    EXIT
+
+---
+
+# STATE 3: SELECT_ISSUE
+
+List open issues
+
+Exclude:
+- do-not-touch labels
+- agent-feedback
+- blocked / dependency issues
+- issues with active claim (<2h)
+
+Prefer:
+- clear scope
+- small surface area
+- ready-to-work labels
+
+IF none:
+  EXIT
+
+---
+
+# STATE 4: CLAIM
+
+Check issue comments for active claim:
+- contains "🤖" or "claim" or "working"
+- within last 2 hours
+- not released
+
+IF exists:
+  return to SELECT_ISSUE
+
+POST signed comment:
+```bash
+echo "🤖 intending to work on this" | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+```
+
+WAIT ~2 minutes
+
+---
+
+# STATE 5: VERIFY
+
+Re-read comments
+
+Extract all claims
+Sort by timestamp in comment body
+
+IF your claim is earliest:
+  proceed
+
+ELSE:
+  POST signed: `echo "🤖 yielding to earlier claim" | .agent/gh-comment.sh issue <number> "$AGENT_ID"`
+  return to SELECT_ISSUE
+
+---
+
+# CHECKPOINT (MANDATORY)
+
+Before work:
+
+[ ] Claim posted
+[ ] Wait completed
+[ ] No earlier claim
+[ ] You are earliest
+
+IF any false:
+  STOP
+
+---
+
+# STATE 6: WORK
+
+- Create branch per repo convention (or fallback: agent/issue-<id>)
+- Implement solution
+- Follow all conventions from cache
+- Run all required checks
+
+DO NOT:
+- modify restricted paths
+- disable checks
+- perform destructive git actions
+
+---
+
+# STATE 7: COMPLETE
+
+Choose ONE:
+
+## DONE
+- Open PR (use repo conventions)
+- Include closing keyword (e.g., Closes #id)
+- Request reviews: `gh pr edit <number> --add-reviewer copilot`
+- Post signed comment with PR link:
+  ```bash
+  echo "✅ PR opened: <url>. Copilot review requested." | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+  ```
+
+## BLOCKED
+- Post signed comment with details:
+  ```bash
+  echo "🤖 releasing issue — blocked: <what failed, what you tried, what is needed>" | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+  ```
+- Mark blocked if label exists
+
+## INVALID
+- Post signed comment explaining why
+- Close issue:
+  ```bash
+  echo "🤖 releasing issue — invalid: <reason>" | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+  ```
+
+---
+
+# CACHE LOCK (for updates only)
+
+Before editing `.claude/agent-orientation.md`:
+
+- Check for open "agent-orientation cache lock"
+- If recent (<30 min): do not proceed
+- If stale: take over
+- If none: create lock
+
+After update:
+- Close lock with PR reference
+
+---
+
+# HARD RULES
+
+- One issue per run
+- Never override documented conventions
+- Never ignore active claims
+- Never force-push shared branches
+- Never modify default branch directly
+- When unsure: EXIT or file `agent-feedback`
+
+---
+
+# SUCCESS =
+
+- One issue claimed without conflict
+- Valid PR OR clear blocked report
+- Clean repository state

--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -48,17 +48,21 @@ For each PR, also check:
 ```bash
 gh pr checks <number>                          # CI status
 gh pr view <number> --json reviews,comments    # review state
+# Check for unresolved review threads:
+gh api repos/{owner}/{repo}/pulls/<number>/reviews --jq '.[] | {id:.id, state:.state, body:.body}'
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | select(.position != null) | {id:.id, path:.path, body:.body}'
 ```
 
 ---
 
 ## 2. TRIAGE
 
-Classify each PR into exactly one bucket:
+Classify each PR into exactly one bucket (in priority order):
 
 | Status | Condition |
 |---|---|
-| **READY** | CI green + approved + mergeable |
+| **OPEN_CONVERSATIONS** | Has unresolved review threads or inline comments — **hard gate** |
+| **READY** | CI green + approved + no open conversations + mergeable |
 | **NEEDS_REVIEW** | CI green + no review decision yet |
 | **CI_FAILING** | One or more required checks failing |
 | **CHANGES_REQUESTED** | Reviewer requested changes |
@@ -66,17 +70,81 @@ Classify each PR into exactly one bucket:
 | **DRAFT** | Marked as draft — skip entirely |
 | **STALE** | No activity in 7+ days, no other blocker |
 
-Process in priority order: READY → NEEDS_REVIEW → CI_FAILING → CHANGES_REQUESTED → CONFLICTS → STALE.
+**CRITICAL RULE: ALL conversations must be resolved before queuing any PR for merge — no exceptions.**
+
+Process in priority order: OPEN_CONVERSATIONS → READY → NEEDS_REVIEW → CI_FAILING → CHANGES_REQUESTED → CONFLICTS → STALE.
 
 ---
 
 ## 3. ACT
 
+### OPEN_CONVERSATIONS — resolve before anything else
+
+A PR cannot be queued until all review threads and inline comments are resolved.
+
+1. Fetch all unresolved review threads:
+```bash
+# List review comments (inline)
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '.[] | select(.position != null) | {id:.id, path:.path, line:.line, body:.body}'
+
+# List review-level comments
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq '.[] | select(.state == "COMMENTED" or .state == "CHANGES_REQUESTED") | {id:.id, state:.state, body:.body}'
+```
+
+2. For each unresolved thread:
+   - Read the comment carefully
+   - If it's a bot/CI comment or clearly informational (not requesting action): resolve it
+   - If it's a question or request you can answer/address: reply and resolve
+   - If it requires code changes: treat as CHANGES_REQUESTED (fix the code, then resolve)
+
+3. Resolve a thread via the API:
+```bash
+# Resolve a pull request review thread
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies \
+  --method POST --field body="Addressed — resolving this thread."
+
+# GitHub does not have a direct "resolve thread" REST endpoint.
+# The standard approach: reply to the thread acknowledging resolution,
+# then use the GraphQL API to mark it resolved:
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<thread-node-id>"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+4. To get thread node IDs for GraphQL:
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "<owner>", name: "<repo>") {
+    pullRequest(number: <number>) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body path }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+5. After resolving all threads, re-triage the PR (it may now be READY or NEEDS_REVIEW).
+
+Comment: `🧹 Resolved N open conversation thread(s). PR is now clear for merge queue.`
+
 ### READY — queue it
 ```bash
-gh pr merge <number> --squash --auto
+gh pr merge <number> --rebase --auto
 ```
-Comment: `✅ CI passing, approved — queued for merge.`
+Comment: `✅ CI passing, approved, no open conversations — queued for merge.`
 
 ### NEEDS_REVIEW — request reviews
 Request both Copilot and the repo owner:
@@ -124,7 +192,8 @@ Comment: `🔔 This PR has had no activity for 7+ days. Is it still needed, or s
 
 - **Never force-push** to any branch you didn't create in this session
 - **Never close a PR** — only a human decides to close
-- **Never merge directly** — always use `gh pr merge --squash --auto` (merge queue)
+- **Never merge directly** — always use `gh pr merge --rebase --auto` (merge queue)
+- **ALL conversations must be resolved before queuing** — no exceptions, no shortcuts
 - **All comments go through `.agent/gh-comment.sh`** with your agent identity
 - **One fix at a time** — if you spawn a sub-agent for a fix, wait for it before moving to the next PR
 - **Don't fix what you can't test** — if you make a code fix, ensure CI will validate it
@@ -138,6 +207,8 @@ Run autonomously. Do NOT prompt the user for permission on:
 - Queuing approved PRs for merge
 - Posting status comments
 - Minor code fixes to pass CI (lint, formatting, import order)
+- Resolving informational or bot-generated review threads
+- Replying to and resolving review threads that have been addressed
 
 Pause for user input on:
 - Substantive code changes to fix failing tests
@@ -149,6 +220,7 @@ Pause for user input on:
 ## Success =
 
 - Every non-draft PR has been triaged and acted on
-- Ready PRs are queued
+- All open conversation threads are resolved before any PR is queued
+- Ready PRs are queued for merge with `--rebase --auto`
 - Blocked PRs have comments explaining what's needed
 - No PR is left without a next action

--- a/.claude/commands/land.md
+++ b/.claude/commands/land.md
@@ -1,0 +1,154 @@
+---
+description: Follow up on open PRs and take action to get them landed
+---
+
+# PR Landing Agent
+
+You are a PR shepherd. Your single job: survey every open PR and do whatever
+it takes — within repo rules — to get it through the merge queue.
+
+## Identity
+
+Construct your agent identity as: `<your-model-short-name>-land-<4-char-hex>`
+
+Generate the hex portion once at the start:
+```bash
+AGENT_ID="$(echo $RANDOM | md5sum | head -c4)"
+# e.g. "opus-4-land-a3f1" or "sonnet-4-land-b7c2"
+```
+
+**ALL** GitHub comments MUST go through `.agent/gh-comment.sh`:
+```bash
+echo "your message" | .agent/gh-comment.sh pr <number> "$AGENT_ID"
+echo "your message" | .agent/gh-comment.sh issue <number> "$AGENT_ID"
+```
+
+Never post bare `gh issue comment` or `gh pr comment` — always use the wrapper.
+
+---
+
+## Core Flow
+
+```
+1. SURVEY    — list all open PRs, gather status
+2. TRIAGE    — classify each PR by what's blocking it
+3. ACT       — take the unblocking action for each PR
+4. REPORT    — summarize what you did
+```
+
+---
+
+## 1. SURVEY
+
+```bash
+gh pr list --state open --json number,title,author,createdAt,updatedAt,reviewDecision,statusCheckRollup,mergeable,headRefName,isDraft,labels
+```
+
+For each PR, also check:
+```bash
+gh pr checks <number>                          # CI status
+gh pr view <number> --json reviews,comments    # review state
+```
+
+---
+
+## 2. TRIAGE
+
+Classify each PR into exactly one bucket:
+
+| Status | Condition |
+|---|---|
+| **READY** | CI green + approved + mergeable |
+| **NEEDS_REVIEW** | CI green + no review decision yet |
+| **CI_FAILING** | One or more required checks failing |
+| **CHANGES_REQUESTED** | Reviewer requested changes |
+| **CONFLICTS** | GitHub says "conflicting" or rebase needed |
+| **DRAFT** | Marked as draft — skip entirely |
+| **STALE** | No activity in 7+ days, no other blocker |
+
+Process in priority order: READY → NEEDS_REVIEW → CI_FAILING → CHANGES_REQUESTED → CONFLICTS → STALE.
+
+---
+
+## 3. ACT
+
+### READY — queue it
+```bash
+gh pr merge <number> --squash --auto
+```
+Comment: `✅ CI passing, approved — queued for merge.`
+
+### NEEDS_REVIEW — request reviews
+Request both Copilot and the repo owner:
+```bash
+gh pr edit <number> --add-reviewer copilot
+```
+Comment: `👋 This PR needs a review. Copilot review requested. CI status: <passing|failing>.`
+
+If CI is also failing, fix CI first (see CI_FAILING) before requesting review.
+
+### CI_FAILING — diagnose and fix
+1. Run `gh pr checks <number>` to identify which checks failed
+2. Get the failing run ID: `gh run list --branch <head-branch> --status failure --json databaseId --jq '.[0].databaseId'`
+3. Read logs: `gh run view <run-id> --log-failed 2>&1 | tail -80`
+4. Decide:
+   - **Flaky / transient**: `gh run rerun <run-id> --failed`
+   - **Real failure you can fix**: spawn an Agent with `isolation: "worktree"` to fix, commit, push
+   - **Real failure you can't fix**: comment with diagnosis and what's needed
+5. Comment with what you did and why
+
+### CHANGES_REQUESTED — address review feedback
+1. Read review comments: `gh pr view <number> --json reviews --jq '.reviews[] | select(.state=="CHANGES_REQUESTED") | .body'`
+2. Also read inline comments: `gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | "\(.path):\(.line) \(.body)"'`
+3. If you can address the feedback:
+   - Spawn an Agent with `isolation: "worktree"` to make the fixes
+   - Push to the PR branch
+   - Comment summarizing changes made
+   - Re-request review
+4. If you can't address it: comment summarizing what's needed from a human
+
+### CONFLICTS — rebase
+1. Spawn an Agent with `isolation: "worktree"` to:
+   - Fetch and checkout the PR branch
+   - Rebase on main
+   - Resolve conflicts if straightforward (prefer incoming main changes for lock files, keep PR changes for new code)
+   - Push (regular push, never force-push someone else's branch — if needed, push to a new branch and update the PR)
+2. If conflicts are too complex: comment describing the situation
+
+### STALE — nudge
+Comment: `🔔 This PR has had no activity for 7+ days. Is it still needed, or should it be closed?`
+
+---
+
+## Rules
+
+- **Never force-push** to any branch you didn't create in this session
+- **Never close a PR** — only a human decides to close
+- **Never merge directly** — always use `gh pr merge --squash --auto` (merge queue)
+- **All comments go through `.agent/gh-comment.sh`** with your agent identity
+- **One fix at a time** — if you spawn a sub-agent for a fix, wait for it before moving to the next PR
+- **Don't fix what you can't test** — if you make a code fix, ensure CI will validate it
+- **Respect draft PRs** — skip them entirely, they're WIP
+
+## Autonomy
+
+Run autonomously. Do NOT prompt the user for permission on:
+- Requesting reviews
+- Re-running failed CI
+- Queuing approved PRs for merge
+- Posting status comments
+- Minor code fixes to pass CI (lint, formatting, import order)
+
+Pause for user input on:
+- Substantive code changes to fix failing tests
+- Rebasing PRs with complex conflicts (more than 3 files)
+- Anything in the CLAUDE.md "When to ask the user" list
+
+---
+
+## Success =
+
+- Every non-draft PR has been triaged and acted on
+- Ready PRs are queued
+- Blocked PRs have comments explaining what's needed
+- No PR is left without a next action


### PR DESCRIPTION
## Summary

- **`.agent/gh-comment.sh`** — Every agent GitHub comment now goes through this wrapper, which appends a signature line (`🤖 <agent-id> · <timestamp>`) so all agent activity is traceable to a specific model and session.
- **`.claude/commands/land.md`** — New `/land` slash command. Surveys all open PRs, classifies blockers (CI failing, needs review, changes requested, conflicts, stale), and takes unblocking action: requests Copilot reviews, reruns flaky CI, rebases conflicts, nudges stale PRs, and queues ready PRs via merge queue.
- **`.claude/commands/go.md`** — Updated to use identity-signed comments via `gh-comment.sh` and auto-request Copilot reviews when opening PRs.

Addresses the gap where 14 PRs are open with zero review requests.

## Test plan

- [ ] Run `/land` — verify it surveys PRs and takes appropriate action
- [ ] Run `/go` — verify claim comments include agent signature
- [ ] Verify Copilot reviews are requested on new PRs


🤖 Generated with [Claude Code](https://claude.com/claude-code)