### PR TITLE
feat(pipeline): pipeline_runs observability table + row-delta checks (#188)

### DIFF
--- a/.agent/current.md
+++ b/.agent/current.md
@@ -1,4 +1,0 @@
-# Agent Coordination — Current Status
-Last updated: 2026-04-08T03:03:50Z
-
-(no active locks)

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ pipeline/local_libs/
 *.log
 # Agent coordination audit log must be tracked (negation must come after *.log)
 !.agent/activity.log
+
+# Agent coordination ephemeral state
+.agent/current.md
+.agent/.last_rotate
+.agent/locks/
+
+# Claude worktree-local files
+.claude/agent-orientation.md
 dbt/logs/
 airflow/logs/
 airflow/*.db*

--- a/pipeline/src/pipeline_telemetry.py
+++ b/pipeline/src/pipeline_telemetry.py
@@ -1,0 +1,170 @@
+"""
+Pipeline Telemetry — observability for daily pipeline runs.
+
+Tracks each stage's timing, row counts, and status, then writes
+results to gold_layer.pipeline_runs in BigQuery.
+"""
+
+import json
+import logging
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_RUNS_TABLE = "pipeline_runs"
+
+PIPELINE_RUNS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+  run_id STRING NOT NULL,
+  stage STRING NOT NULL,
+  started_at TIMESTAMP NOT NULL,
+  ended_at TIMESTAMP,
+  rows_in INT64,
+  rows_out INT64,
+  status STRING NOT NULL,
+  error STRING,
+  run_date DATE NOT NULL
+)
+PARTITION BY run_date
+"""
+
+
+@dataclass
+class StageResult:
+    """Result of a single pipeline stage execution."""
+
+    stage: str
+    started_at: datetime
+    ended_at: Optional[datetime] = None
+    rows_in: Optional[int] = None
+    rows_out: Optional[int] = None
+    status: str = "SUCCESS"
+    error: Optional[str] = None
+
+
+class PipelineRun:
+    """Tracks a full pipeline invocation across multiple stages."""
+
+    def __init__(self, run_id: Optional[str] = None):
+        self.run_id = run_id or uuid.uuid4().hex
+        self.run_date = datetime.now(timezone.utc).date()
+        self.stages: list[StageResult] = []
+        self._current_stage: Optional[StageResult] = None
+
+    def begin_stage(self, stage: str, rows_in: Optional[int] = None):
+        """Mark the start of a pipeline stage."""
+        self._current_stage = StageResult(
+            stage=stage,
+            started_at=datetime.now(timezone.utc),
+            rows_in=rows_in,
+        )
+
+    def end_stage(
+        self,
+        rows_out: Optional[int] = None,
+        status: str = "SUCCESS",
+        error: Optional[str] = None,
+    ):
+        """Mark the end of the current stage."""
+        if self._current_stage is None:
+            logger.warning("end_stage called without begin_stage")
+            return
+        self._current_stage.ended_at = datetime.now(timezone.utc)
+        self._current_stage.rows_out = rows_out
+        self._current_stage.status = status
+        self._current_stage.error = error
+        self.stages.append(self._current_stage)
+        self._current_stage = None
+
+    def check_row_delta(
+        self, rows_in: Optional[int], rows_out: Optional[int], strict: bool = True
+    ) -> bool:
+        """Check if a stage produced zero rows from non-empty input.
+
+        Returns True if the delta is acceptable, False if it looks like a failure.
+        """
+        if rows_in is None or rows_out is None:
+            return True
+        if rows_in > 0 and rows_out == 0 and strict:
+            return False
+        return True
+
+    @property
+    def has_failures(self) -> bool:
+        return any(s.status == "FAILURE" for s in self.stages)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert all stage results to a DataFrame for BigQuery insertion."""
+        rows = []
+        for s in self.stages:
+            rows.append(
+                {
+                    "run_id": self.run_id,
+                    "stage": s.stage,
+                    "started_at": s.started_at,
+                    "ended_at": s.ended_at,
+                    "rows_in": s.rows_in,
+                    "rows_out": s.rows_out,
+                    "status": s.status,
+                    "error": s.error,
+                    "run_date": self.run_date,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    def summary(self) -> str:
+        """Structured JSON summary for stdout logging."""
+        stages_summary = []
+        for s in self.stages:
+            entry = {
+                "stage": s.stage,
+                "status": s.status,
+                "rows_in": s.rows_in,
+                "rows_out": s.rows_out,
+            }
+            if s.error:
+                entry["error"] = s.error[:500]
+            if s.started_at and s.ended_at:
+                entry["duration_s"] = round(
+                    (s.ended_at - s.started_at).total_seconds(), 1
+                )
+            stages_summary.append(entry)
+
+        return json.dumps(
+            {
+                "run_id": self.run_id,
+                "run_date": str(self.run_date),
+                "has_failures": self.has_failures,
+                "stages": stages_summary,
+            },
+            indent=2,
+        )
+
+    def persist(self, db):
+        """Write stage results to BigQuery pipeline_runs table."""
+        if not self.stages:
+            logger.warning("No stages to persist")
+            return
+        df = self.to_dataframe()
+        try:
+            db.append_dataframe_to_table(df, PIPELINE_RUNS_TABLE)
+            logger.info(
+                f"Persisted {len(self.stages)} stage results to {PIPELINE_RUNS_TABLE}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to persist pipeline telemetry: {e}")
+
+
+def ensure_pipeline_runs_table(db):
+    """Create the pipeline_runs table if it doesn't exist."""
+    if not db.table_exists(PIPELINE_RUNS_TABLE):
+        logger.info(f"Creating {PIPELINE_RUNS_TABLE} table...")
+        db.execute(PIPELINE_RUNS_SCHEMA)
+        logger.info(f"{PIPELINE_RUNS_TABLE} table created.")
+    else:
+        logger.info(f"{PIPELINE_RUNS_TABLE} table already exists.")

--- a/pipeline/src/run_daily.py
+++ b/pipeline/src/run_daily.py
@@ -6,6 +6,9 @@ Runs all pipeline stages in order. Designed to run inside Docker via:
 
 Each stage is isolated — a failure in one stage logs the error and continues
 to the next. The exit code reflects whether any critical stage failed.
+
+Telemetry: each stage writes timing, row counts, and status to
+gold_layer.pipeline_runs via PipelineRun.
 """
 
 import logging
@@ -23,64 +26,194 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(PROJECT_ROOT)
 
 
+# Stages that treat zero-rows-on-nonempty-input as failure.
+STRICT_ZERO_ROW_STAGES = {
+    "media_ingestor",
+    "assertion_extractor",
+    "silver_transform",
+}
+
+
 def run_cmd(cmd: str, env: dict = None, ignore_failure=False):
     logger.info(f"Running: {cmd}")
     full_env = os.environ.copy()
     if env:
         full_env.update(env)
 
-    result = subprocess.run(cmd, shell=True, env=full_env)
+    result = subprocess.run(
+        cmd, shell=True, env=full_env, capture_output=True, text=True
+    )
+
+    if result.stdout:
+        logger.info(result.stdout[-2000:])
+    if result.stderr:
+        logger.warning(result.stderr[-2000:])
 
     if result.returncode != 0:
         if ignore_failure:
             logger.warning(f"Command failed (ignored): {cmd}")
         else:
             logger.error(f"Command failed with exit code {result.returncode}: {cmd}")
-            sys.exit(result.returncode)
     return result
 
 
+def _get_table_count(db, table_name: str):
+    """Get row count for a table, or None if it doesn't exist."""
+    try:
+        if not db.table_exists(table_name):
+            return None
+        result = db.execute(f"SELECT COUNT(*) FROM `{table_name}`")
+        row = result.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        logger.warning(f"Could not get row count for {table_name}: {e}")
+        return None
+
+
+def _run_stage(
+    pipeline_run,
+    stage_name,
+    cmd,
+    db=None,
+    input_table=None,
+    output_table=None,
+    env=None,
+):
+    """Run a single stage with telemetry tracking."""
+    rows_in = _get_table_count(db, input_table) if db and input_table else None
+    pipeline_run.begin_stage(stage_name, rows_in=rows_in)
+
+    result = run_cmd(cmd, env=env, ignore_failure=True)
+
+    rows_out = _get_table_count(db, output_table) if db and output_table else None
+
+    if result.returncode != 0:
+        error_text = (result.stderr or "")[-500:]
+        pipeline_run.end_stage(rows_out=rows_out, status="FAILURE", error=error_text)
+    else:
+        strict = stage_name in STRICT_ZERO_ROW_STAGES
+        if not pipeline_run.check_row_delta(rows_in, rows_out, strict=strict):
+            pipeline_run.end_stage(
+                rows_out=rows_out,
+                status="FAILURE",
+                error=f"Zero rows written from {rows_in} input rows",
+            )
+        else:
+            pipeline_run.end_stage(rows_out=rows_out, status="SUCCESS")
+
+
 def main():
+    from src.pipeline_telemetry import PipelineRun, ensure_pipeline_runs_table
+
     year = str(datetime.now().year)
     logger.info(f"Starting Daily Pipeline for year {year}")
 
+    # Initialize telemetry
+    pipeline_run = PipelineRun()
+    logger.info(f"Pipeline run_id: {pipeline_run.run_id}")
+
+    # Try to connect to BigQuery for telemetry (non-fatal if unavailable)
+    db = None
+    try:
+        from src.db_manager import DBManager
+
+        db = DBManager()
+        ensure_pipeline_runs_table(db)
+    except Exception as e:
+        logger.warning(f"BigQuery unavailable for telemetry: {e}")
+
     # ── Stage 1: Scrapers (contract/roster data) ────────────────────────
-    run_cmd(
+    _run_stage(
+        pipeline_run,
+        "scraper_team_cap",
         f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
         f"from src.spotrac_scraper_v2 import scrape_and_save_team_cap; "
         f'scrape_and_save_team_cap({year})"',
-        ignore_failure=True,
+        db=db,
+        output_table="team_cap_data",
     )
-    run_cmd(
+    _run_stage(
+        pipeline_run,
+        "scraper_player_rankings",
         f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
         f"from src.spotrac_scraper_v2 import scrape_and_save_player_rankings; "
         f'scrape_and_save_player_rankings({year})"',
-        ignore_failure=True,
+        db=db,
+        output_table="player_rankings",
     )
 
     # ── Stage 2: Media Ingestion (pundit predictions) ───────────────────
-    run_cmd("python -m src.media_ingestor", ignore_failure=True)
-
-    # ── Stage 3: NLP Assertion Extraction (Gemini) ────────────────────
-    run_cmd("python -m src.assertion_extractor --limit 50", ignore_failure=True)
-
-    # ── Stage 4: Silver transforms ──────────────────────────────────────
-    run_cmd("python -m src.silver_sportsdataio_transform", ignore_failure=True)
-
-    # ── Stage 4: Feature engineering & ML ───────────────────────────────
-    run_cmd("python src/feature_factory.py", ignore_failure=True)
-    run_cmd("python src/train_model.py", ignore_failure=True)
-
-    # ── Stage 5: Cryptographic Ledger hash ──────────────────────────────
-    run_cmd("python -m src.cryptographic_ledger", ignore_failure=True)
-
-    # ── Stage 6: Data quality checks ────────────────────────────────────
-    run_cmd(
-        "python -m pytest tests/ -m unit -v --tb=short",
-        ignore_failure=True,
+    _run_stage(
+        pipeline_run,
+        "media_ingestor",
+        "python -m src.media_ingestor",
+        db=db,
+        output_table="raw_pundit_media",
     )
 
-    logger.info("Daily Pipeline completed.")
+    # ── Stage 3: NLP Assertion Extraction ───────────────────────────────
+    _run_stage(
+        pipeline_run,
+        "assertion_extractor",
+        "python -m src.assertion_extractor --limit 50",
+        db=db,
+        input_table="raw_pundit_media",
+        output_table="pundit_assertions",
+    )
+
+    # ── Stage 4: Silver transforms ──────────────────────────────────────
+    _run_stage(
+        pipeline_run,
+        "silver_transform",
+        "python -m src.silver_sportsdataio_transform",
+        db=db,
+    )
+
+    # ── Stage 5: Feature engineering & ML ───────────────────────────────
+    _run_stage(
+        pipeline_run,
+        "feature_factory",
+        "python src/feature_factory.py",
+        db=db,
+    )
+    _run_stage(
+        pipeline_run,
+        "train_model",
+        "python src/train_model.py",
+        db=db,
+    )
+
+    # ── Stage 6: Cryptographic Ledger hash ──────────────────────────────
+    _run_stage(
+        pipeline_run,
+        "cryptographic_ledger",
+        "python -m src.cryptographic_ledger",
+        db=db,
+    )
+
+    # ── Stage 7: Data quality checks ────────────────────────────────────
+    _run_stage(
+        pipeline_run,
+        "data_quality_tests",
+        "python -m pytest tests/ -m unit -v --tb=short",
+    )
+
+    # ── Persist telemetry & summary ─────────────────────────────────────
+    logger.info(f"Pipeline summary:\n{pipeline_run.summary()}")
+
+    if db:
+        try:
+            pipeline_run.persist(db)
+        except Exception as e:
+            logger.error(f"Failed to persist telemetry: {e}")
+        finally:
+            db.close()
+
+    if pipeline_run.has_failures:
+        logger.error("Daily Pipeline completed with FAILURES.")
+        sys.exit(1)
+
+    logger.info("Daily Pipeline completed successfully.")
 
 
 if __name__ == "__main__":

--- a/pipeline/tests/test_pipeline_telemetry.py
+++ b/pipeline/tests/test_pipeline_telemetry.py
@@ -1,0 +1,255 @@
+"""
+Tests for pipeline telemetry (Issue #188).
+
+Unit tests — no BigQuery required.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+from src.pipeline_telemetry import (
+    PIPELINE_RUNS_TABLE,
+    PipelineRun,
+    StageResult,
+    ensure_pipeline_runs_table,
+)
+
+# ---------------------------------------------------------------------------
+# StageResult
+# ---------------------------------------------------------------------------
+
+
+class TestStageResult:
+    def test_defaults(self):
+        sr = StageResult(stage="test", started_at=datetime.now(timezone.utc))
+        assert sr.status == "SUCCESS"
+        assert sr.error is None
+        assert sr.rows_in is None
+        assert sr.rows_out is None
+
+
+# ---------------------------------------------------------------------------
+# PipelineRun — stage tracking
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineRun:
+    def test_run_id_auto_generated(self):
+        run = PipelineRun()
+        assert len(run.run_id) == 32  # hex UUID without dashes
+
+    def test_custom_run_id(self):
+        run = PipelineRun(run_id="custom-123")
+        assert run.run_id == "custom-123"
+
+    def test_begin_end_stage(self):
+        run = PipelineRun()
+        run.begin_stage("ingest", rows_in=100)
+        run.end_stage(rows_out=50)
+
+        assert len(run.stages) == 1
+        stage = run.stages[0]
+        assert stage.stage == "ingest"
+        assert stage.rows_in == 100
+        assert stage.rows_out == 50
+        assert stage.status == "SUCCESS"
+        assert stage.started_at is not None
+        assert stage.ended_at is not None
+        assert stage.ended_at >= stage.started_at
+
+    def test_end_stage_without_begin(self):
+        run = PipelineRun()
+        run.end_stage(rows_out=10)  # should not raise
+        assert len(run.stages) == 0
+
+    def test_failure_stage(self):
+        run = PipelineRun()
+        run.begin_stage("extract")
+        run.end_stage(status="FAILURE", error="Connection timeout")
+
+        assert run.stages[0].status == "FAILURE"
+        assert run.stages[0].error == "Connection timeout"
+
+    def test_multiple_stages(self):
+        run = PipelineRun()
+        for name in ["ingest", "extract", "transform"]:
+            run.begin_stage(name)
+            run.end_stage()
+        assert len(run.stages) == 3
+        assert [s.stage for s in run.stages] == ["ingest", "extract", "transform"]
+
+    def test_has_failures_false(self):
+        run = PipelineRun()
+        run.begin_stage("ok")
+        run.end_stage(status="SUCCESS")
+        assert run.has_failures is False
+
+    def test_has_failures_true(self):
+        run = PipelineRun()
+        run.begin_stage("ok")
+        run.end_stage(status="SUCCESS")
+        run.begin_stage("bad")
+        run.end_stage(status="FAILURE", error="boom")
+        assert run.has_failures is True
+
+
+# ---------------------------------------------------------------------------
+# Row-delta checks
+# ---------------------------------------------------------------------------
+
+
+class TestRowDeltaCheck:
+    def test_none_inputs_always_acceptable(self):
+        run = PipelineRun()
+        assert run.check_row_delta(None, 0) is True
+        assert run.check_row_delta(100, None) is True
+        assert run.check_row_delta(None, None) is True
+
+    def test_zero_in_zero_out_is_ok(self):
+        run = PipelineRun()
+        assert run.check_row_delta(0, 0) is True
+
+    def test_nonempty_in_zero_out_strict_fails(self):
+        run = PipelineRun()
+        assert run.check_row_delta(100, 0, strict=True) is False
+
+    def test_nonempty_in_zero_out_not_strict_ok(self):
+        run = PipelineRun()
+        assert run.check_row_delta(100, 0, strict=False) is True
+
+    def test_normal_delta_is_ok(self):
+        run = PipelineRun()
+        assert run.check_row_delta(100, 50) is True
+
+
+# ---------------------------------------------------------------------------
+# DataFrame conversion
+# ---------------------------------------------------------------------------
+
+
+class TestToDataFrame:
+    def test_columns(self):
+        run = PipelineRun(run_id="abc123")
+        run.begin_stage("test_stage", rows_in=10)
+        run.end_stage(rows_out=5)
+
+        df = run.to_dataframe()
+        expected_cols = {
+            "run_id",
+            "stage",
+            "started_at",
+            "ended_at",
+            "rows_in",
+            "rows_out",
+            "status",
+            "error",
+            "run_date",
+        }
+        assert set(df.columns) == expected_cols
+
+    def test_values(self):
+        run = PipelineRun(run_id="abc123")
+        run.begin_stage("test_stage", rows_in=10)
+        run.end_stage(rows_out=5, status="SUCCESS")
+
+        df = run.to_dataframe()
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["run_id"] == "abc123"
+        assert row["stage"] == "test_stage"
+        assert row["rows_in"] == 10
+        assert row["rows_out"] == 5
+        assert row["status"] == "SUCCESS"
+
+    def test_empty_run(self):
+        run = PipelineRun()
+        df = run.to_dataframe()
+        assert len(df) == 0
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+class TestSummary:
+    def test_summary_is_valid_json(self):
+        run = PipelineRun(run_id="test-run")
+        run.begin_stage("ingest", rows_in=100)
+        run.end_stage(rows_out=50)
+        run.begin_stage("extract")
+        run.end_stage(status="FAILURE", error="timeout")
+
+        summary = run.summary()
+        parsed = json.loads(summary)
+        assert parsed["run_id"] == "test-run"
+        assert parsed["has_failures"] is True
+        assert len(parsed["stages"]) == 2
+
+    def test_summary_truncates_errors(self):
+        run = PipelineRun()
+        run.begin_stage("bad")
+        run.end_stage(status="FAILURE", error="x" * 1000)
+
+        summary = json.loads(run.summary())
+        assert len(summary["stages"][0]["error"]) == 500
+
+
+# ---------------------------------------------------------------------------
+# Persist
+# ---------------------------------------------------------------------------
+
+
+class TestPersist:
+    def test_persist_calls_append(self):
+        db = MagicMock()
+        run = PipelineRun(run_id="persist-test")
+        run.begin_stage("ingest")
+        run.end_stage()
+
+        run.persist(db)
+
+        db.append_dataframe_to_table.assert_called_once()
+        args = db.append_dataframe_to_table.call_args
+        df = args[0][0]
+        table = args[0][1]
+        assert table == PIPELINE_RUNS_TABLE
+        assert len(df) == 1
+
+    def test_persist_empty_run_skips(self):
+        db = MagicMock()
+        run = PipelineRun()
+        run.persist(db)
+        db.append_dataframe_to_table.assert_not_called()
+
+    def test_persist_handles_db_error(self):
+        db = MagicMock()
+        db.append_dataframe_to_table.side_effect = Exception("BQ down")
+        run = PipelineRun()
+        run.begin_stage("x")
+        run.end_stage()
+        # Should not raise
+        run.persist(db)
+
+
+# ---------------------------------------------------------------------------
+# ensure_pipeline_runs_table
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTable:
+    def test_creates_if_not_exists(self):
+        db = MagicMock()
+        db.table_exists.return_value = False
+        ensure_pipeline_runs_table(db)
+        db.execute.assert_called_once()
+
+    def test_skips_if_exists(self):
+        db = MagicMock()
+        db.table_exists.return_value = True
+        ensure_pipeline_runs_table(db)
+        db.execute.assert_not_called()


### PR DESCRIPTION
## Summary

- New `pipeline/src/pipeline_telemetry.py` module:
  - `PipelineRun` class tracks each stage's timing, row counts, and status
  - `StageResult` dataclass for individual stage outcomes
  - Row-delta checks: zero rows from non-empty input treated as failure (configurable per stage)
  - Structured JSON summary to stdout for scheduler alerting
  - `ensure_pipeline_runs_table()` creates `pipeline_runs` table if missing
  - `persist()` writes results to BigQuery `pipeline_runs` table

- Rewired `pipeline/src/run_daily.py`:
  - Each stage wrapped with telemetry via `_run_stage()`
  - Captures stdout/stderr from subprocesses
  - Queries table row counts before/after stages for delta checks
  - Non-zero exit code on any stage failure
  - Graceful degradation if BigQuery is unavailable (telemetry is non-fatal)

- 24 unit tests in `pipeline/tests/test_pipeline_telemetry.py`

Closes #188

## Acceptance criteria
- [x] `pipeline_runs` table schema defined (CREATE TABLE IF NOT EXISTS)
- [x] Each stage in `run_daily.py` writes a row with counts and status
- [x] Zero-rows-on-nonempty-input treated as failure (configurable)
- [x] Non-zero exit code on any stage failure
- [x] Smoke query will return rows after first daily execution