### PR TITLE
fix(pipeline): fail-loud mode + --best-effort flag (#167)

### DIFF
--- a/pipeline/src/run_daily.py
+++ b/pipeline/src/run_daily.py
@@ -3,14 +3,20 @@ Daily Pipeline Orchestrator
 
 Runs all pipeline stages in order. Designed to run inside Docker via:
     python -m src.run_daily
+    python -m src.run_daily --best-effort   # old behavior: ignore failures
 
 Each stage is isolated — a failure in one stage logs the error and continues
-to the next. The exit code reflects whether any critical stage failed.
+to the next (in best-effort mode) or halts the pipeline (default fail-loud).
 
 Telemetry: each stage writes timing, row counts, and status to
 gold_layer.pipeline_runs via PipelineRun.
+
+Exit codes:
+  0 = all stages succeeded
+  1 = one or more stages failed
 """
 
+import argparse
 import logging
 import os
 import subprocess
@@ -79,7 +85,7 @@ def _run_stage(
     output_table=None,
     env=None,
 ):
-    """Run a single stage with telemetry tracking."""
+    """Run a single stage with telemetry tracking. Returns True if successful."""
     rows_in = _get_table_count(db, input_table) if db and input_table else None
     pipeline_run.begin_stage(stage_name, rows_in=rows_in)
 
@@ -90,6 +96,7 @@ def _run_stage(
     if result.returncode != 0:
         error_text = (result.stderr or "")[-500:]
         pipeline_run.end_stage(rows_out=rows_out, status="FAILURE", error=error_text)
+        return False
     else:
         strict = stage_name in STRICT_ZERO_ROW_STAGES
         if not pipeline_run.check_row_delta(rows_in, rows_out, strict=strict):
@@ -98,19 +105,32 @@ def _run_stage(
                 status="FAILURE",
                 error=f"Zero rows written from {rows_in} input rows",
             )
+            return False
         else:
             pipeline_run.end_stage(rows_out=rows_out, status="SUCCESS")
+            return True
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Daily Pipeline Orchestrator")
+    parser.add_argument(
+        "--best-effort",
+        action="store_true",
+        help="Continue on stage failure (old behavior). Default is fail-loud.",
+    )
+    args = parser.parse_args()
+    best_effort = args.best_effort
+
     from src.pipeline_telemetry import PipelineRun, ensure_pipeline_runs_table
 
     year = str(datetime.now().year)
-    logger.info(f"Starting Daily Pipeline for year {year}")
+    mode = "best-effort" if best_effort else "fail-loud"
 
     # Initialize telemetry
     pipeline_run = PipelineRun()
-    logger.info(f"Pipeline run_id: {pipeline_run.run_id}")
+    logger.info(
+        f"Starting Daily Pipeline (run={pipeline_run.run_id}, year={year}, mode={mode})"
+    )
 
     # Try to connect to BigQuery for telemetry (non-fatal if unavailable)
     db = None
@@ -122,81 +142,94 @@ def main():
     except Exception as e:
         logger.warning(f"BigQuery unavailable for telemetry: {e}")
 
+    def ok():
+        """In fail-loud mode, skip remaining stages after first failure."""
+        return best_effort or not pipeline_run.has_failures
+
     # ── Stage 1: Scrapers (contract/roster data) ────────────────────────
-    _run_stage(
-        pipeline_run,
-        "scraper_team_cap",
-        f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
-        f"from src.spotrac_scraper_v2 import scrape_and_save_team_cap; "
-        f'scrape_and_save_team_cap({year})"',
-        db=db,
-        output_table="team_cap_data",
-    )
-    _run_stage(
-        pipeline_run,
-        "scraper_player_rankings",
-        f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
-        f"from src.spotrac_scraper_v2 import scrape_and_save_player_rankings; "
-        f'scrape_and_save_player_rankings({year})"',
-        db=db,
-        output_table="player_rankings",
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "scraper_team_cap",
+            f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
+            f"from src.spotrac_scraper_v2 import scrape_and_save_team_cap; "
+            f'scrape_and_save_team_cap({year})"',
+            db=db,
+            output_table="team_cap_data",
+        )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "scraper_player_rankings",
+            f"python -c \"import sys; sys.path.insert(0, '{PROJECT_ROOT}'); "
+            f"from src.spotrac_scraper_v2 import scrape_and_save_player_rankings; "
+            f'scrape_and_save_player_rankings({year})"',
+            db=db,
+            output_table="player_rankings",
+        )
 
     # ── Stage 2: Media Ingestion (pundit predictions) ───────────────────
-    _run_stage(
-        pipeline_run,
-        "media_ingestor",
-        "python -m src.media_ingestor",
-        db=db,
-        output_table="raw_pundit_media",
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "media_ingestor",
+            "python -m src.media_ingestor",
+            db=db,
+            output_table="raw_pundit_media",
+        )
 
     # ── Stage 3: NLP Assertion Extraction ───────────────────────────────
-    _run_stage(
-        pipeline_run,
-        "assertion_extractor",
-        "python -m src.assertion_extractor --limit 50",
-        db=db,
-        input_table="raw_pundit_media",
-        output_table="pundit_assertions",
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "assertion_extractor",
+            "python -m src.assertion_extractor --limit 50",
+            db=db,
+            input_table="raw_pundit_media",
+            output_table="pundit_assertions",
+        )
 
     # ── Stage 4: Silver transforms ──────────────────────────────────────
-    _run_stage(
-        pipeline_run,
-        "silver_transform",
-        "python -m src.silver_sportsdataio_transform",
-        db=db,
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "silver_transform",
+            "python -m src.silver_sportsdataio_transform",
+            db=db,
+        )
 
     # ── Stage 5: Feature engineering & ML ───────────────────────────────
-    _run_stage(
-        pipeline_run,
-        "feature_factory",
-        "python src/feature_factory.py",
-        db=db,
-    )
-    _run_stage(
-        pipeline_run,
-        "train_model",
-        "python src/train_model.py",
-        db=db,
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "feature_factory",
+            "python src/feature_factory.py",
+            db=db,
+        )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "train_model",
+            "python src/train_model.py",
+            db=db,
+        )
 
     # ── Stage 6: Cryptographic Ledger hash ──────────────────────────────
-    _run_stage(
-        pipeline_run,
-        "cryptographic_ledger",
-        "python -m src.cryptographic_ledger",
-        db=db,
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "cryptographic_ledger",
+            "python -m src.cryptographic_ledger",
+            db=db,
+        )
 
     # ── Stage 7: Data quality checks ────────────────────────────────────
-    _run_stage(
-        pipeline_run,
-        "data_quality_tests",
-        "python -m pytest tests/ -m unit -v --tb=short",
-    )
+    if ok():
+        _run_stage(
+            pipeline_run,
+            "data_quality_tests",
+            "python -m pytest tests/ -m unit -v --tb=short",
+        )
 
     # ── Persist telemetry & summary ─────────────────────────────────────
     logger.info(f"Pipeline summary:\n{pipeline_run.summary()}")


### PR DESCRIPTION
## Summary

- Default behavior now halts the pipeline at the first stage failure (fail-loud)
- Pass `--best-effort` to restore the old continue-past-failures behavior
- `_run_stage()` returns `bool` so `ok()` can gate each subsequent stage
- All telemetry (`PipelineRun`, BigQuery persist, row-delta checks) preserved unchanged

Closes #167

## What changed

Single file: `pipeline/src/run_daily.py`
- Added `import argparse`
- Added `--best-effort` flag to `main()`
- `_run_stage()` now returns `True`/`False`
- Added `ok()` closure that checks `pipeline_run.has_failures` before each stage

## Test plan
- [ ] `make lint` passes (black/isort/flake8)
- [ ] `make test` passes (unit tests, no Docker needed)
- [ ] Run with no args → pipeline halts on first failing stage
- [ ] Run with `--best-effort` → pipeline continues past failures (old behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)