### PR TITLE
fix(ingest): YouTube Tier 1 channels ingesting zero rows (#171)

### DIFF
--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -154,8 +154,10 @@ sources:
     name: "Undisputed"
     sport: "NFL"
     type: youtube_transcript
+    # Disabled: channel_id UCuF2PqOvMBKBVi9JvtC3GqA returns 404 — channel no longer
+    # exists. Skip Bayless left FS1/Undisputed in 2023. (#171)
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCuF2PqOvMBKBVi9JvtC3GqA"
-    enabled: true
+    enabled: false
     pundits:
       - id: skip_bayless
         name: "Skip Bayless"
@@ -179,8 +181,11 @@ sources:
     name: "The Herd with Colin Cowherd"
     sport: "NFL"
     type: youtube_transcript
+    # Disabled: UCFDidMd82mpDkKijLUqHp7A is the correct channel but only posts
+    # YouTube Shorts (clips <60s, no transcripts). Full episodes are on Fox Sports'
+    # channel. Re-enable with a full-episode channel ID once confirmed. (#171)
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCFDidMd82mpDkKijLUqHp7A"
-    enabled: true
+    enabled: false
     pundits:
       - id: colin_cowherd
         name: "Colin Cowherd"

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -355,9 +355,17 @@ def _chunk_transcript(text: str, max_chars: int = TRANSCRIPT_CHUNK_SIZE) -> list
 
 
 def _extract_video_id(url: str) -> str | None:
-    """Extract video ID from a YouTube URL."""
+    """Extract video ID from a YouTube URL (watch?v= or /shorts/)."""
     match = re.search(r"[?&]v=([a-zA-Z0-9_-]{11})", url)
+    if match:
+        return match.group(1)
+    match = re.search(r"/shorts/([a-zA-Z0-9_-]{11})", url)
     return match.group(1) if match else None
+
+
+def _is_youtube_short(url: str) -> bool:
+    """Return True if the URL points to a YouTube Short."""
+    return "/shorts/" in url
 
 
 def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
@@ -390,6 +398,12 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
         title = entry.get("title", "")
         link = entry.get("link", "")
         if not link:
+            continue
+
+        # Skip Shorts — they are clips (<60s), rarely have auto-captions,
+        # and don't contain full-length pundit commentary worth extracting.
+        if _is_youtube_short(link):
+            logger.debug(f"[{source_id}] Skipping Short: {title}")
             continue
 
         video_id = _extract_video_id(link)

--- a/pipeline/tests/test_media_ingestor.py
+++ b/pipeline/tests/test_media_ingestor.py
@@ -16,6 +16,8 @@ import pytest
 from src.media_ingestor import (
     MediaItem,
     SourceResult,
+    _extract_video_id,
+    _is_youtube_short,
     _passes_keyword_filter,
     compute_content_hash,
     fetch_rss,
@@ -597,3 +599,52 @@ class TestConfigLoading:
             assert "name" in source
             assert "type" in source
             assert "url" in source
+
+    def test_no_enabled_source_has_unknown_channel_id(self):
+        """Sanity check: no enabled YouTube source should have 'UNKNOWN' as channel_id."""
+        config = load_media_config()
+        for source in config["sources"]:
+            if source.get("enabled") and "youtube" in source.get("type", ""):
+                assert (
+                    "UNKNOWN" not in source["url"]
+                ), f"Source {source['id']} has UNKNOWN channel_id and is enabled"
+
+
+# ---------------------------------------------------------------------------
+# YouTube URL helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVideoId:
+    def test_standard_watch_url(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assert _extract_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_watch_url_with_extra_params(self):
+        url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&ab_channel=RickAstley"
+        assert _extract_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_shorts_url(self):
+        url = "https://www.youtube.com/shorts/zWHQIinOgZI"
+        assert _extract_video_id(url) == "zWHQIinOgZI"
+
+    def test_shorts_url_with_query(self):
+        url = "https://www.youtube.com/shorts/zWHQIinOgZI?feature=share"
+        assert _extract_video_id(url) == "zWHQIinOgZI"
+
+    def test_unrecognized_url_returns_none(self):
+        assert _extract_video_id("https://www.youtube.com/channel/UCxxx") is None
+
+    def test_empty_string_returns_none(self):
+        assert _extract_video_id("") is None
+
+
+class TestIsYoutubeShort:
+    def test_shorts_url_is_short(self):
+        assert _is_youtube_short("https://www.youtube.com/shorts/zWHQIinOgZI") is True
+
+    def test_watch_url_is_not_short(self):
+        assert _is_youtube_short("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is False
+
+    def test_empty_string_is_not_short(self):
+        assert _is_youtube_short("") is False


### PR DESCRIPTION
## Summary

Root causes identified per channel:
- **The Herd (Cowherd)**: `UCFDidMd82mpDkKijLUqHp7A` is correct but the channel only posts YouTube Shorts — `_extract_video_id` only matched `?v=` URLs so every entry was silently skipped. **Disabled** pending a full-episode channel ID.
- **Undisputed (Bayless)**: `UCuF2PqOvMBKBVi9JvtC3GqA` returns HTTP 404 — show ended when Bayless left FS1 in 2023. **Disabled** with explanatory comment.
- **Dan Patrick / Rich Eisen**: Channel IDs verified correct, feeds returning fresh `?v=` URLs. Zero rows most likely caused by pipeline not running (#167). Should self-resolve once pipeline is healthy.

Code fixes:
- `_extract_video_id`: now handles `/shorts/VIDEO_ID` URLs in addition to `?v=VIDEO_ID`
- `_is_youtube_short`: new helper; `fetch_youtube_transcripts` skips Shorts at the entry level (Shorts are <60s clips with no usable transcripts)
- `media_sources.yaml`: disabled `undisputed` (404 channel) and `the_herd` (Shorts-only) with comments explaining how to re-enable

Closes #171

## Test plan
- [x] Logic verified in Docker: all `_extract_video_id` and `_is_youtube_short` assertions pass
- [x] 10 new unit tests: `TestExtractVideoId` (6 cases), `TestIsYoutubeShort` (3 cases), config sanity check for UNKNOWN channel IDs
- [x] 33 existing tests unaffected
- [x] Lint clean (black + isort + flake8)
- [ ] Dan Patrick / Rich Eisen channels: verify ≥1 row after next pipeline run (blocked on #167 landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)