### PR TITLE
feat(api): draft night API — predictions, draft scoreboard, fix startup (#198, #201)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,23 @@ services:
     command: >
       bash -c "pip install --no-cache-dir -r pipeline/requirements.txt && tail -f /dev/null"
 
+  api:
+    image: python:3.11-slim
+    container_name: nfl_api
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./pipeline:/app/pipeline
+      - ~/.config/gcloud:/app/.config/gcloud:ro
+    environment:
+      - PYTHONPATH=/app/pipeline
+      - GCP_PROJECT_ID=cap-alpha-protocol
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/.config/gcloud/application_default_credentials.json
+    working_dir: /app
+    command: >
+      bash -c "pip install --no-cache-dir -r pipeline/requirements.txt &&
+      uvicorn pipeline.api.main:app --host 0.0.0.0 --port 8000"
+
   web:
     image: node:20
     container_name: nfl_web

--- a/pipeline/api/main.py
+++ b/pipeline/api/main.py
@@ -8,16 +8,19 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 try:
-    from src.adversarial_engine import AdversarialEngine
-    from src.win_probability import WinProbabilityModel
-    from src.trade_partner_finder import TradePartnerFinder
     from api.pundit_router import router as pundit_router
 except ImportError:
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-    from src.adversarial_engine import AdversarialEngine
-    from src.win_probability import WinProbabilityModel
-    from src.trade_partner_finder import TradePartnerFinder
     from api.pundit_router import router as pundit_router
+
+try:
+    from src.adversarial_engine import AdversarialEngine
+    from src.trade_partner_finder import TradePartnerFinder
+    from src.win_probability import WinProbabilityModel
+
+    _TRADE_AVAILABLE = True
+except Exception:
+    _TRADE_AVAILABLE = False
 
 # Setup Logger
 logging.basicConfig(level=logging.INFO)
@@ -31,10 +34,12 @@ app = FastAPI(
 
 app.include_router(pundit_router)
 
-# Initialize Engine
-engine = AdversarialEngine()
-win_model = WinProbabilityModel()
-partner_finder = TradePartnerFinder()
+# Initialize Engine (only if trade modules loaded successfully)
+if _TRADE_AVAILABLE:
+    engine = AdversarialEngine()
+    win_model = WinProbabilityModel()
+    partner_finder = TradePartnerFinder()
+
 
 class TradeProposal(BaseModel):
     team_a: str
@@ -43,49 +48,71 @@ class TradeProposal(BaseModel):
     team_b_assets: List[Dict[str, Any]]
     config: Optional[Dict[str, Any]] = None
 
+
 @app.get("/")
 def health_check():
-    return {"status": "ok", "service": "adversarial-engine", "version": "0.1.0"}
+    return {"status": "ok", "service": "pundit-prediction-ledger", "version": "1.0.0"}
+
 
 @app.post("/api/trade/evaluate")
 def evaluate_trade(proposal: TradeProposal):
+    if not _TRADE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Trade engine not available")
     try:
-        logger.info(f"Received trade evaluation request: {proposal.team_a} <-> {proposal.team_b}")
+        logger.info(
+            f"Received trade evaluation request: {proposal.team_a} <-> {proposal.team_b}"
+        )
         result = engine.evaluate_trade(proposal.dict())
         return result
     except Exception as e:
         logger.error(f"Error evaluating trade: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @app.post("/api/trade/counter")
 def generate_counter(proposal: TradeProposal):
+    if not _TRADE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Trade engine not available")
     try:
-        logger.info(f"Generating counter-offer for: {proposal.team_a} <-> {proposal.team_b}")
+        logger.info(
+            f"Generating counter-offer for: {proposal.team_a} <-> {proposal.team_b}"
+        )
         counter = engine.generate_counter_offer(proposal.dict())
         return counter
     except Exception as e:
         logger.error(f"Error generating counter: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @app.post("/api/analyze/vegas")
 def analyze_vegas(proposal: TradeProposal):
+    if not _TRADE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Trade engine not available")
     try:
-        logger.info(f"Analyzing Vegas impact for: {proposal.team_a} <-> {proposal.team_b}")
+        logger.info(
+            f"Analyzing Vegas impact for: {proposal.team_a} <-> {proposal.team_b}"
+        )
         impact = win_model.calculate_win_impact(proposal.dict())
         return impact
     except Exception as e:
         logger.error(f"Error analyzing Vegas impact: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @app.get("/api/trade/find_partner/{player_id}")
 def find_partner(player_id: str, cap_hit: float, position: str = "QB"):
+    if not _TRADE_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Trade engine not available")
     try:
         logger.info(f"Finding partners for {player_id} ({position}, ${cap_hit}M)")
-        partners = partner_finder.find_buyers(player_id, position=position, cap_hit=cap_hit)
+        partners = partner_finder.find_buyers(
+            player_id, position=position, cap_hit=cap_hit
+        )
         return {"player": player_id, "top_partners": partners}
     except Exception as e:
         logger.error(f"Error finding partners: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
+
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/pipeline/api/pundit_router.py
+++ b/pipeline/api/pundit_router.py
@@ -1,20 +1,25 @@
 """
-Pundit Scorecard API — Public REST Endpoints (Issue #113)
+Pundit Scorecard API — Public REST Endpoints (Issue #113, #198, #201)
 
 Endpoints:
   GET /v1/pundits/                          — List all tracked pundits with summary scores
   GET /v1/pundits/{pundit_id}               — Pundit detail with accuracy breakdown by category
   GET /v1/pundits/{pundit_id}/predictions   — Paginated prediction history with resolution status
+  GET /v1/predictions/                      — Filterable prediction search with parameterized queries
   GET /v1/predictions/recent                — Latest resolved predictions across all pundits
+  GET /v1/draft/{year}                      — Draft prediction summary for a given year
+  GET /v1/draft/{year}/results              — Draft resolution scoreboard for a given year
   GET /v1/leaderboard                       — Ranked pundits by weighted score / accuracy
   GET /v1/integrity/verify                  — Hash chain integrity check (tamper detection)
 """
 
 import logging
+import math
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from google.cloud.bigquery import DatasetReference, QueryJobConfig, ScalarQueryParameter
 
 from src.cryptographic_ledger import verify_chain_integrity
 from src.db_manager import DBManager
@@ -42,9 +47,21 @@ def _full(table: str) -> str:
     return f"`{project_id}.{table}`"
 
 
+def _parameterized_query(db: DBManager, sql: str, params: List[ScalarQueryParameter]):
+    """Execute a parameterized BigQuery query and return a DataFrame."""
+    dataset_ref = DatasetReference(db.project_id, db.dataset_id)
+    job_config = QueryJobConfig(
+        query_parameters=params,
+        default_dataset=dataset_ref,
+    )
+    job = db.client.query(sql, job_config=job_config)
+    return job.to_dataframe()
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/leaderboard
 # ---------------------------------------------------------------------------
+
 
 @router.get("/leaderboard", summary="Ranked pundits by accuracy")
 def leaderboard(
@@ -74,6 +91,7 @@ def leaderboard(
 # GET /v1/pundits/
 # ---------------------------------------------------------------------------
 
+
 @router.get("/pundits/", summary="List all tracked pundits")
 def list_pundits(
     db: DBManager = Depends(get_db),
@@ -96,6 +114,7 @@ def list_pundits(
 # GET /v1/pundits/{pundit_id}
 # ---------------------------------------------------------------------------
 
+
 @router.get("/pundits/{pundit_id}", summary="Pundit detail with accuracy breakdown")
 def pundit_detail(
     pundit_id: str,
@@ -105,7 +124,6 @@ def pundit_detail(
     Returns a single pundit's accuracy broken down by claim category.
     """
     try:
-        project_id = os.environ.get("GCP_PROJECT_ID")
         query = f"""
             SELECT
                 l.claim_category,
@@ -118,20 +136,26 @@ def pundit_detail(
                 ) AS accuracy_rate,
                 AVG(r.weighted_score) AS avg_weighted_score
             FROM {_full(LEDGER_TABLE)} l
-            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r ON l.prediction_hash = r.prediction_hash
-            WHERE l.pundit_id = '{pundit_id}'
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.pundit_id = @pundit_id
             GROUP BY l.claim_category
             ORDER BY total DESC
         """
-        breakdown_df = db.fetch_df(query)
+        params = [ScalarQueryParameter("pundit_id", "STRING", pundit_id)]
+        breakdown_df = _parameterized_query(db, query, params)
 
         summary_df = get_pundit_accuracy_summary(db=db)
         pundit_row = summary_df[summary_df["pundit_id"] == pundit_id]
         if pundit_row.empty:
-            raise HTTPException(status_code=404, detail=f"Pundit '{pundit_id}' not found")
+            raise HTTPException(
+                status_code=404, detail=f"Pundit '{pundit_id}' not found"
+            )
 
         summary = pundit_row.iloc[0].where(pundit_row.iloc[0].notna(), None).to_dict()
-        breakdown = breakdown_df.where(breakdown_df.notna(), None).to_dict(orient="records")
+        breakdown = breakdown_df.where(breakdown_df.notna(), None).to_dict(
+            orient="records"
+        )
 
         return {"pundit": summary, "accuracy_by_category": breakdown}
     except HTTPException:
@@ -145,12 +169,15 @@ def pundit_detail(
 # GET /v1/pundits/{pundit_id}/predictions
 # ---------------------------------------------------------------------------
 
+
 @router.get("/pundits/{pundit_id}/predictions", summary="Pundit prediction history")
 def pundit_predictions(
     pundit_id: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
-    status: Optional[str] = Query(default=None, description="Filter by resolution_status"),
+    status: Optional[str] = Query(
+        default=None, description="Filter by resolution_status"
+    ),
     db: DBManager = Depends(get_db),
 ) -> Dict[str, Any]:
     """
@@ -158,9 +185,16 @@ def pundit_predictions(
     """
     try:
         offset = (page - 1) * page_size
-        status_filter = f"AND COALESCE(r.resolution_status, 'PENDING') = '{status}'" if status else ""
+        status_clause = ""
+        params: List[ScalarQueryParameter] = [
+            ScalarQueryParameter("pundit_id", "STRING", pundit_id),
+            ScalarQueryParameter("lim", "INT64", page_size),
+            ScalarQueryParameter("off", "INT64", offset),
+        ]
+        if status:
+            status_clause = "AND COALESCE(r.resolution_status, 'PENDING') = @status"
+            params.append(ScalarQueryParameter("status", "STRING", status))
 
-        project_id = os.environ.get("GCP_PROJECT_ID")
         query = f"""
             SELECT
                 l.prediction_hash,
@@ -179,22 +213,24 @@ def pundit_predictions(
                 r.weighted_score,
                 r.outcome_notes
             FROM {_full(LEDGER_TABLE)} l
-            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r ON l.prediction_hash = r.prediction_hash
-            WHERE l.pundit_id = '{pundit_id}'
-            {status_filter}
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.pundit_id = @pundit_id
+            {status_clause}
             ORDER BY l.ingestion_timestamp DESC
-            LIMIT {page_size} OFFSET {offset}
+            LIMIT @lim OFFSET @off
         """
-        df = db.fetch_df(query)
+        df = _parameterized_query(db, query, params)
 
         count_query = f"""
             SELECT COUNT(*) AS total
             FROM {_full(LEDGER_TABLE)} l
-            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r ON l.prediction_hash = r.prediction_hash
-            WHERE l.pundit_id = '{pundit_id}'
-            {status_filter}
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.pundit_id = @pundit_id
+            {status_clause}
         """
-        count_df = db.fetch_df(count_query)
+        count_df = _parameterized_query(db, count_query, params)
         total = int(count_df.iloc[0]["total"]) if not count_df.empty else 0
 
         return {
@@ -203,7 +239,7 @@ def pundit_predictions(
             "page": page,
             "page_size": page_size,
             "total": total,
-            "pages": (total + page_size - 1) // page_size,
+            "pages": max(1, math.ceil(total / page_size)),
         }
     except Exception as e:
         logger.error(f"Pundit predictions error for {pundit_id}: {e}")
@@ -214,17 +250,18 @@ def pundit_predictions(
 # GET /v1/predictions/recent
 # ---------------------------------------------------------------------------
 
-@router.get("/predictions/recent", summary="Latest resolved predictions across all pundits")
+
+@router.get(
+    "/predictions/recent", summary="Latest resolved predictions across all pundits"
+)
 def recent_predictions(
     limit: int = Query(default=20, ge=1, le=100),
     db: DBManager = Depends(get_db),
 ) -> Dict[str, Any]:
     """
     Returns the most recently resolved predictions across all pundits.
-    1-hour cache TTL for historical data.
     """
     try:
-        project_id = os.environ.get("GCP_PROJECT_ID")
         query = f"""
             SELECT
                 l.prediction_hash,
@@ -243,24 +280,277 @@ def recent_predictions(
                 r.weighted_score,
                 r.outcome_notes
             FROM {_full(LEDGER_TABLE)} l
-            INNER JOIN {_full(RESOLUTIONS_TABLE)} r ON l.prediction_hash = r.prediction_hash
+            INNER JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
             WHERE r.resolution_status IN ('CORRECT', 'INCORRECT')
             ORDER BY r.resolved_at DESC
-            LIMIT {limit}
+            LIMIT @lim
         """
-        df = db.fetch_df(query)
+        params = [ScalarQueryParameter("lim", "INT64", limit)]
+        df = _parameterized_query(db, query, params)
         return {
             "predictions": df.where(df.notna(), None).to_dict(orient="records"),
             "count": len(df),
         }
     except Exception as e:
         logger.error(f"Recent predictions error: {e}")
-        raise HTTPException(status_code=500, detail="Failed to fetch recent predictions")
+        raise HTTPException(
+            status_code=500, detail="Failed to fetch recent predictions"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/predictions/  (filterable search with parameterized queries)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/predictions/", summary="Search predictions with filters")
+def search_predictions(
+    category: Optional[str] = Query(default=None, description="claim_category filter"),
+    status: Optional[str] = Query(default=None, description="resolution_status filter"),
+    player: Optional[str] = Query(
+        default=None, description="target_player_name substring match"
+    ),
+    pundit_name: Optional[str] = Query(
+        default=None, description="pundit_name substring match"
+    ),
+    limit: int = Query(default=50, ge=1, le=200),
+    page: int = Query(default=1, ge=1),
+    db: DBManager = Depends(get_db),
+) -> Dict[str, Any]:
+    """
+    Filterable prediction search with parameterized BigQuery queries.
+    Joins prediction_ledger LEFT JOIN prediction_resolutions.
+    """
+    try:
+        offset = (page - 1) * limit
+        where_clauses: List[str] = ["1=1"]
+        params: List[ScalarQueryParameter] = [
+            ScalarQueryParameter("lim", "INT64", limit),
+            ScalarQueryParameter("off", "INT64", offset),
+        ]
+
+        if category:
+            where_clauses.append("l.claim_category = @category")
+            params.append(ScalarQueryParameter("category", "STRING", category))
+        if status:
+            where_clauses.append("COALESCE(r.resolution_status, 'PENDING') = @status")
+            params.append(ScalarQueryParameter("status", "STRING", status))
+        if player:
+            where_clauses.append(
+                "LOWER(COALESCE(l.target_player_name, '')) LIKE "
+                "CONCAT('%', LOWER(@player), '%')"
+            )
+            params.append(ScalarQueryParameter("player", "STRING", player))
+        if pundit_name:
+            where_clauses.append(
+                "LOWER(l.pundit_name) LIKE " "CONCAT('%', LOWER(@pundit_name), '%')"
+            )
+            params.append(ScalarQueryParameter("pundit_name", "STRING", pundit_name))
+
+        where_sql = " AND ".join(where_clauses)
+
+        query = f"""
+            SELECT
+                l.prediction_hash,
+                l.pundit_id,
+                l.pundit_name,
+                l.ingestion_timestamp,
+                l.source_url,
+                l.raw_assertion_text,
+                l.extracted_claim,
+                l.claim_category,
+                l.season_year,
+                l.target_player_id,
+                l.target_player_name,
+                l.target_team,
+                COALESCE(r.resolution_status, 'PENDING') AS resolution_status,
+                r.resolved_at,
+                r.binary_correct,
+                r.brier_score,
+                r.weighted_score,
+                r.outcome_notes
+            FROM {_full(LEDGER_TABLE)} l
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE {where_sql}
+            ORDER BY l.ingestion_timestamp DESC
+            LIMIT @lim OFFSET @off
+        """
+        df = _parameterized_query(db, query, params)
+
+        count_query = f"""
+            SELECT COUNT(*) AS total
+            FROM {_full(LEDGER_TABLE)} l
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE {where_sql}
+        """
+        count_df = _parameterized_query(db, count_query, params)
+        total = int(count_df.iloc[0]["total"]) if not count_df.empty else 0
+
+        return {
+            "predictions": df.where(df.notna(), None).to_dict(orient="records"),
+            "page": page,
+            "limit": limit,
+            "total": total,
+            "pages": max(1, math.ceil(total / limit)),
+        }
+    except Exception as e:
+        logger.error(f"Search predictions error: {e}")
+        raise HTTPException(status_code=500, detail="Failed to search predictions")
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/draft/{year}  — Draft prediction summary
+# ---------------------------------------------------------------------------
+
+
+@router.get("/draft/{year}", summary="Draft prediction summary for a year")
+def draft_summary(
+    year: int,
+    db: DBManager = Depends(get_db),
+) -> Dict[str, Any]:
+    """
+    Returns a summary of draft predictions for a given season year.
+    Filters by claim_category='draft_pick' and the specified season_year.
+    """
+    try:
+        query = f"""
+            SELECT
+                l.prediction_hash,
+                l.pundit_id,
+                l.pundit_name,
+                l.ingestion_timestamp,
+                l.source_url,
+                l.raw_assertion_text,
+                l.extracted_claim,
+                l.season_year,
+                l.target_player_name,
+                l.target_team,
+                COALESCE(r.resolution_status, 'PENDING') AS resolution_status,
+                r.resolved_at,
+                r.binary_correct,
+                r.weighted_score,
+                r.outcome_notes
+            FROM {_full(LEDGER_TABLE)} l
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.claim_category = 'draft_pick'
+              AND l.season_year = @year
+            ORDER BY l.ingestion_timestamp DESC
+        """
+        params = [ScalarQueryParameter("year", "INT64", year)]
+        df = _parameterized_query(db, query, params)
+
+        resolved = 0
+        pending = 0
+        if not df.empty:
+            resolved = int(df["resolution_status"].isin(["CORRECT", "INCORRECT"]).sum())
+            pending = int((df["resolution_status"] == "PENDING").sum())
+
+        return {
+            "year": year,
+            "total": len(df),
+            "resolved": resolved,
+            "pending": pending,
+            "predictions": df.where(df.notna(), None).to_dict(orient="records"),
+        }
+    except Exception as e:
+        logger.error(f"Draft summary error for {year}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch draft summary")
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/draft/{year}/results  — Draft resolution scoreboard
+# ---------------------------------------------------------------------------
+
+
+@router.get("/draft/{year}/results", summary="Draft resolution scoreboard")
+def draft_results(
+    year: int,
+    db: DBManager = Depends(get_db),
+) -> Dict[str, Any]:
+    """
+    Returns draft predictions grouped by resolution status for a given year,
+    including per-pundit accuracy stats.
+    """
+    try:
+        predictions_query = f"""
+            SELECT
+                l.prediction_hash,
+                l.pundit_id,
+                l.pundit_name,
+                l.extracted_claim,
+                l.target_player_name,
+                l.target_team,
+                COALESCE(r.resolution_status, 'PENDING')
+                    AS resolution_status,
+                r.resolved_at,
+                r.binary_correct,
+                r.weighted_score,
+                r.outcome_notes
+            FROM {_full(LEDGER_TABLE)} l
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.claim_category = 'draft_pick'
+              AND l.season_year = @year
+            ORDER BY COALESCE(r.resolution_status, 'PENDING'),
+                     l.pundit_name
+        """
+        params = [ScalarQueryParameter("year", "INT64", year)]
+        pred_df = _parameterized_query(db, predictions_query, params)
+
+        pundit_query = f"""
+            SELECT
+                l.pundit_id,
+                l.pundit_name,
+                COUNT(*) AS total_predictions,
+                COUNTIF(r.resolution_status IN ('CORRECT', 'INCORRECT'))
+                    AS resolved_count,
+                COUNTIF(r.resolution_status = 'CORRECT')
+                    AS correct_count,
+                SAFE_DIVIDE(
+                    COUNTIF(r.resolution_status = 'CORRECT'),
+                    COUNTIF(r.resolution_status IN ('CORRECT', 'INCORRECT'))
+                ) AS accuracy_rate,
+                AVG(r.weighted_score) AS avg_weighted_score
+            FROM {_full(LEDGER_TABLE)} l
+            LEFT JOIN {_full(RESOLUTIONS_TABLE)} r
+                ON l.prediction_hash = r.prediction_hash
+            WHERE l.claim_category = 'draft_pick'
+              AND l.season_year = @year
+            GROUP BY l.pundit_id, l.pundit_name
+            ORDER BY accuracy_rate DESC
+        """
+        pundit_df = _parameterized_query(db, pundit_query, params)
+
+        grouped: Dict[str, list] = {}
+        if not pred_df.empty:
+            for status_val, group in pred_df.groupby("resolution_status"):
+                grouped[str(status_val)] = group.where(group.notna(), None).to_dict(
+                    orient="records"
+                )
+
+        return {
+            "year": year,
+            "total": len(pred_df),
+            "by_status": grouped,
+            "pundit_accuracy": (
+                pundit_df.where(pundit_df.notna(), None).to_dict(orient="records")
+                if not pundit_df.empty
+                else []
+            ),
+        }
+    except Exception as e:
+        logger.error(f"Draft results error for {year}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch draft results")
 
 
 # ---------------------------------------------------------------------------
 # GET /v1/integrity/verify
 # ---------------------------------------------------------------------------
+
 
 @router.get("/integrity/verify", summary="Hash chain integrity check")
 def integrity_check(

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -38,6 +38,6 @@ google-genai
 duckdb
 duckduckgo-search
 pydantic
-youtube-transcript-api
+youtube-transcript-api>=0.6.3,<2.0.0
 readability-lxml
 lxml_html_clean

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -37,6 +37,13 @@ from bs4 import BeautifulSoup
 from google.cloud import bigquery
 from youtube_transcript_api import YouTubeTranscriptApi
 
+try:
+    _yt_client = YouTubeTranscriptApi()
+    _YT_API_V1 = True
+except TypeError:
+    _yt_client = None
+    _YT_API_V1 = False
+
 from src.db_manager import DBManager
 
 logging.basicConfig(
@@ -368,6 +375,16 @@ def _is_youtube_short(url: str) -> bool:
     return "/shorts/" in url
 
 
+def _fetch_transcript(video_id: str) -> str:
+    """Fetch transcript text, compatible with both old and new API versions."""
+    if _YT_API_V1:
+        result = _yt_client.fetch(video_id)
+        return " ".join(snippet.text for snippet in result)
+    else:
+        transcript_data = YouTubeTranscriptApi.get_transcript(video_id)
+        return " ".join(segment["text"] for segment in transcript_data)
+
+
 def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
     """
     Fetches recent videos from a YouTube channel via RSS, then downloads
@@ -390,6 +407,12 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
 
     if feed.bozo and not feed.entries:
         raise ValueError(f"Feed parse error for {source_id}: {feed.bozo_exception}")
+
+    if not feed.entries:
+        logger.warning(
+            f"[{source_id}] YouTube feed returned 0 entries — "
+            f"check channel ID in URL: {url}"
+        )
 
     items = []
     now = datetime.now(timezone.utc)
@@ -421,8 +444,7 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
 
         # Download transcript
         try:
-            transcript_data = YouTubeTranscriptApi.get_transcript(video_id)
-            transcript_text = " ".join(segment["text"] for segment in transcript_data)
+            transcript_text = _fetch_transcript(video_id)
         except Exception as e:
             logger.warning(
                 f"[{source_id}] Transcript unavailable for {video_id} "
@@ -460,6 +482,12 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
                     sport=sport,
                 )
             )
+
+    if not items and feed.entries:
+        logger.warning(
+            f"[{source_id}] Feed had {len(feed.entries)} entries "
+            f"but 0 transcripts succeeded"
+        )
 
     return items
 

--- a/pipeline/tests/test_pundit_api.py
+++ b/pipeline/tests/test_pundit_api.py
@@ -376,16 +376,12 @@ def make_draft_predictions_df():
 
 class TestDraftSummary:
     def test_returns_200(self, client, mock_db):
-        mock_db.client.query.return_value = _mock_bq_job(
-            make_draft_predictions_df()
-        )
+        mock_db.client.query.return_value = _mock_bq_job(make_draft_predictions_df())
         resp = client.get("/v1/draft/2026")
         assert resp.status_code == 200
 
     def test_summary_fields(self, client, mock_db):
-        mock_db.client.query.return_value = _mock_bq_job(
-            make_draft_predictions_df()
-        )
+        mock_db.client.query.return_value = _mock_bq_job(make_draft_predictions_df())
         data = client.get("/v1/draft/2026").json()
         assert data["year"] == 2026
         assert data["total"] == 2

--- a/pipeline/tests/test_pundit_api.py
+++ b/pipeline/tests/test_pundit_api.py
@@ -1,5 +1,5 @@
 """
-Tests for Pundit Scorecard API endpoints (Issue #113).
+Tests for Pundit Scorecard API endpoints (Issue #113, #198, #201).
 Uses FastAPI TestClient with mocked DBManager — no BigQuery required.
 """
 
@@ -19,9 +19,18 @@ FAKE_HASH = "a" * 64
 FAKE_HASH2 = "b" * 64
 
 
+def _mock_bq_job(df):
+    """Create a mock BQ query job that returns a DataFrame via to_dataframe()."""
+    job = MagicMock()
+    job.to_dataframe.return_value = df
+    return job
+
+
 @pytest.fixture
 def mock_db():
     db = MagicMock()
+    db.project_id = "test-project"
+    db.dataset_id = "nfl_dead_money"
     mock_job = MagicMock()
     mock_job.result.return_value = None
     db.client.load_table_from_dataframe.return_value = mock_job
@@ -137,21 +146,22 @@ class TestListPundits:
 
 class TestPunditDetail:
     def test_returns_200_for_known_pundit(self, client, mock_db):
-        mock_db.fetch_df.side_effect = [
-            pd.DataFrame(  # breakdown by category
-                [
-                    {
-                        "claim_category": "player_performance",
-                        "total": 50,
-                        "resolved": 40,
-                        "correct": 30,
-                        "accuracy_rate": 0.75,
-                        "avg_weighted_score": 0.9,
-                    }
-                ]
-            ),
-            make_summary_df(),  # summary for pundit lookup
-        ]
+        # _parameterized_query uses db.client.query() for breakdown
+        breakdown_df = pd.DataFrame(
+            [
+                {
+                    "claim_category": "player_performance",
+                    "total": 50,
+                    "resolved": 40,
+                    "correct": 30,
+                    "accuracy_rate": 0.75,
+                    "avg_weighted_score": 0.9,
+                }
+            ]
+        )
+        mock_db.client.query.return_value = _mock_bq_job(breakdown_df)
+        # get_pundit_accuracy_summary uses db.fetch_df
+        mock_db.fetch_df.return_value = make_summary_df()
         resp = client.get("/v1/pundits/adam_schefter")
         assert resp.status_code == 200
         data = resp.json()
@@ -159,10 +169,8 @@ class TestPunditDetail:
         assert "accuracy_by_category" in data
 
     def test_returns_404_for_unknown_pundit(self, client, mock_db):
-        mock_db.fetch_df.side_effect = [
-            pd.DataFrame(),  # empty breakdown
-            make_summary_df(),  # summary (doesn't contain unknown_pundit)
-        ]
+        mock_db.client.query.return_value = _mock_bq_job(pd.DataFrame())
+        mock_db.fetch_df.return_value = make_summary_df()
         resp = client.get("/v1/pundits/unknown_pundit")
         assert resp.status_code == 404
 
@@ -200,17 +208,17 @@ def make_predictions_df():
 
 class TestPunditPredictions:
     def test_returns_200(self, client, mock_db):
-        mock_db.fetch_df.side_effect = [
-            make_predictions_df(),
-            pd.DataFrame([{"total": 1}]),
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
         ]
         resp = client.get("/v1/pundits/adam_schefter/predictions")
         assert resp.status_code == 200
 
     def test_pagination_fields_present(self, client, mock_db):
-        mock_db.fetch_df.side_effect = [
-            make_predictions_df(),
-            pd.DataFrame([{"total": 1}]),
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
         ]
         data = client.get("/v1/pundits/adam_schefter/predictions").json()
         assert "page" in data
@@ -219,14 +227,81 @@ class TestPunditPredictions:
         assert "pages" in data
         assert "predictions" in data
 
-    def test_status_filter_passed_to_query(self, client, mock_db):
-        mock_db.fetch_df.side_effect = [
-            make_predictions_df(),
-            pd.DataFrame([{"total": 1}]),
+    def test_status_filter_uses_parameterized_query(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
         ]
         client.get("/v1/pundits/adam_schefter/predictions?status=CORRECT")
-        query = mock_db.fetch_df.call_args_list[0][0][0]
-        assert "CORRECT" in query
+        # Verify parameterized query was used (no string interpolation of status)
+        call_args = mock_db.client.query.call_args_list[0]
+        sql = call_args[0][0]
+        assert "@status" in sql
+        # Verify CORRECT is not directly interpolated into SQL
+        assert "= 'CORRECT'" not in sql
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/predictions/  (filterable search)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPredictions:
+    def test_returns_200(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
+        ]
+        resp = client.get("/v1/predictions/")
+        assert resp.status_code == 200
+
+    def test_pagination_fields(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
+        ]
+        data = client.get("/v1/predictions/").json()
+        assert "predictions" in data
+        assert "page" in data
+        assert "limit" in data
+        assert "total" in data
+        assert "pages" in data
+
+    def test_category_filter(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
+        ]
+        client.get("/v1/predictions/?category=draft_pick")
+        sql = mock_db.client.query.call_args_list[0][0][0]
+        assert "@category" in sql
+
+    def test_player_filter(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
+        ]
+        client.get("/v1/predictions/?player=Mahomes")
+        sql = mock_db.client.query.call_args_list[0][0][0]
+        assert "@player" in sql
+
+    def test_pundit_name_filter(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_predictions_df()),
+            _mock_bq_job(pd.DataFrame([{"total": 1}])),
+        ]
+        client.get("/v1/predictions/?pundit_name=Schefter")
+        sql = mock_db.client.query.call_args_list[0][0][0]
+        assert "@pundit_name" in sql
+
+    def test_empty_results(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(pd.DataFrame()),
+            _mock_bq_job(pd.DataFrame([{"total": 0}])),
+        ]
+        data = client.get("/v1/predictions/").json()
+        assert data["predictions"] == []
+        assert data["total"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -236,21 +311,165 @@ class TestPunditPredictions:
 
 class TestRecentPredictions:
     def test_returns_200(self, client, mock_db):
-        mock_db.fetch_df.return_value = make_predictions_df()
+        mock_db.client.query.return_value = _mock_bq_job(make_predictions_df())
         resp = client.get("/v1/predictions/recent")
         assert resp.status_code == 200
 
     def test_count_field_present(self, client, mock_db):
-        mock_db.fetch_df.return_value = make_predictions_df()
+        mock_db.client.query.return_value = _mock_bq_job(make_predictions_df())
         data = client.get("/v1/predictions/recent").json()
         assert "count" in data
         assert data["count"] == 1
 
-    def test_limit_param(self, client, mock_db):
-        mock_db.fetch_df.return_value = pd.DataFrame()
+    def test_limit_param_uses_parameterized_query(self, client, mock_db):
+        mock_db.client.query.return_value = _mock_bq_job(pd.DataFrame())
         client.get("/v1/predictions/recent?limit=5")
-        query = mock_db.fetch_df.call_args[0][0]
-        assert "LIMIT 5" in query
+        sql = mock_db.client.query.call_args[0][0]
+        assert "@lim" in sql
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/draft/{year}
+# ---------------------------------------------------------------------------
+
+
+def make_draft_predictions_df():
+    return pd.DataFrame(
+        [
+            {
+                "prediction_hash": FAKE_HASH,
+                "pundit_id": "adam_schefter",
+                "pundit_name": "Adam Schefter",
+                "ingestion_timestamp": "2026-04-01T12:00:00Z",
+                "source_url": "https://twitter.com/x/456",
+                "raw_assertion_text": "Shedeur Sanders goes #1 to Titans",
+                "extracted_claim": "Shedeur Sanders picked #1 overall",
+                "season_year": 2026,
+                "target_player_name": "Shedeur Sanders",
+                "target_team": "TEN",
+                "resolution_status": "PENDING",
+                "resolved_at": None,
+                "binary_correct": None,
+                "weighted_score": None,
+                "outcome_notes": None,
+            },
+            {
+                "prediction_hash": FAKE_HASH2,
+                "pundit_id": "pat_mcafee",
+                "pundit_name": "Pat McAfee",
+                "ingestion_timestamp": "2026-04-02T12:00:00Z",
+                "source_url": "https://youtube.com/watch?v=abc",
+                "raw_assertion_text": "Cam Ward goes top 5",
+                "extracted_claim": "Cam Ward drafted in top 5",
+                "season_year": 2026,
+                "target_player_name": "Cam Ward",
+                "target_team": None,
+                "resolution_status": "CORRECT",
+                "resolved_at": "2026-04-24T20:00:00Z",
+                "binary_correct": True,
+                "weighted_score": 1.2,
+                "outcome_notes": "Cam Ward picked #2 by CLE",
+            },
+        ]
+    )
+
+
+class TestDraftSummary:
+    def test_returns_200(self, client, mock_db):
+        mock_db.client.query.return_value = _mock_bq_job(
+            make_draft_predictions_df()
+        )
+        resp = client.get("/v1/draft/2026")
+        assert resp.status_code == 200
+
+    def test_summary_fields(self, client, mock_db):
+        mock_db.client.query.return_value = _mock_bq_job(
+            make_draft_predictions_df()
+        )
+        data = client.get("/v1/draft/2026").json()
+        assert data["year"] == 2026
+        assert data["total"] == 2
+        assert data["resolved"] == 1
+        assert data["pending"] == 1
+        assert "predictions" in data
+
+    def test_empty_year(self, client, mock_db):
+        mock_db.client.query.return_value = _mock_bq_job(pd.DataFrame())
+        data = client.get("/v1/draft/2020").json()
+        assert data["total"] == 0
+        assert data["resolved"] == 0
+        assert data["pending"] == 0
+
+    def test_uses_parameterized_year(self, client, mock_db):
+        mock_db.client.query.return_value = _mock_bq_job(pd.DataFrame())
+        client.get("/v1/draft/2026")
+        sql = mock_db.client.query.call_args[0][0]
+        assert "@year" in sql
+        assert "2026" not in sql
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/draft/{year}/results
+# ---------------------------------------------------------------------------
+
+
+class TestDraftResults:
+    def test_returns_200(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_draft_predictions_df()),
+            _mock_bq_job(
+                pd.DataFrame(
+                    [
+                        {
+                            "pundit_id": "adam_schefter",
+                            "pundit_name": "Adam Schefter",
+                            "total_predictions": 1,
+                            "resolved_count": 0,
+                            "correct_count": 0,
+                            "accuracy_rate": None,
+                            "avg_weighted_score": None,
+                        }
+                    ]
+                )
+            ),
+        ]
+        resp = client.get("/v1/draft/2026/results")
+        assert resp.status_code == 200
+
+    def test_result_fields(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(make_draft_predictions_df()),
+            _mock_bq_job(
+                pd.DataFrame(
+                    [
+                        {
+                            "pundit_id": "adam_schefter",
+                            "pundit_name": "Adam Schefter",
+                            "total_predictions": 1,
+                            "resolved_count": 0,
+                            "correct_count": 0,
+                            "accuracy_rate": None,
+                            "avg_weighted_score": None,
+                        }
+                    ]
+                )
+            ),
+        ]
+        data = client.get("/v1/draft/2026/results").json()
+        assert data["year"] == 2026
+        assert data["total"] == 2
+        assert "by_status" in data
+        assert "pundit_accuracy" in data
+
+    def test_empty_results(self, client, mock_db):
+        mock_db.client.query.side_effect = [
+            _mock_bq_job(pd.DataFrame()),
+            _mock_bq_job(pd.DataFrame()),
+        ]
+        data = client.get("/v1/draft/2026/results").json()
+        assert data["total"] == 0
+        assert data["by_status"] == {}
+        assert data["pundit_accuracy"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -260,7 +479,7 @@ class TestRecentPredictions:
 
 class TestIntegrityCheck:
     def test_returns_verified_true_when_ok(self, client, mock_db):
-        mock_db.fetch_df.return_value = pd.DataFrame()  # empty ledger → verified
+        mock_db.fetch_df.return_value = pd.DataFrame()  # empty ledger
         resp = client.get("/v1/integrity/verify")
         assert resp.status_code == 200
         data = resp.json()
@@ -287,3 +506,50 @@ class TestIntegrityCheck:
         assert resp.status_code == 200
         data = resp.json()
         assert data["verified"] is False
+
+
+# ---------------------------------------------------------------------------
+# Trade engine endpoints — should return 503 when trade engine unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestTradeEndpointsGuarded:
+    def test_evaluate_returns_503(self, client):
+        resp = client.post(
+            "/api/trade/evaluate",
+            json={
+                "team_a": "KC",
+                "team_b": "LV",
+                "team_a_assets": [],
+                "team_b_assets": [],
+            },
+        )
+        assert resp.status_code == 503
+
+    def test_counter_returns_503(self, client):
+        resp = client.post(
+            "/api/trade/counter",
+            json={
+                "team_a": "KC",
+                "team_b": "LV",
+                "team_a_assets": [],
+                "team_b_assets": [],
+            },
+        )
+        assert resp.status_code == 503
+
+    def test_vegas_returns_503(self, client):
+        resp = client.post(
+            "/api/analyze/vegas",
+            json={
+                "team_a": "KC",
+                "team_b": "LV",
+                "team_a_assets": [],
+                "team_b_assets": [],
+            },
+        )
+        assert resp.status_code == 503
+
+    def test_find_partner_returns_503(self, client):
+        resp = client.get("/api/trade/find_partner/P_MAHOMES?cap_hit=45.0")
+        assert resp.status_code == 503

--- a/pipeline/tests/test_pundit_api.py
+++ b/pipeline/tests/test_pundit_api.py
@@ -510,6 +510,7 @@ class TestIntegrityCheck:
 
 
 class TestTradeEndpointsGuarded:
+    @patch("api.main._TRADE_AVAILABLE", False)
     def test_evaluate_returns_503(self, client):
         resp = client.post(
             "/api/trade/evaluate",
@@ -522,6 +523,7 @@ class TestTradeEndpointsGuarded:
         )
         assert resp.status_code == 503
 
+    @patch("api.main._TRADE_AVAILABLE", False)
     def test_counter_returns_503(self, client):
         resp = client.post(
             "/api/trade/counter",
@@ -534,6 +536,7 @@ class TestTradeEndpointsGuarded:
         )
         assert resp.status_code == 503
 
+    @patch("api.main._TRADE_AVAILABLE", False)
     def test_vegas_returns_503(self, client):
         resp = client.post(
             "/api/analyze/vegas",
@@ -546,6 +549,7 @@ class TestTradeEndpointsGuarded:
         )
         assert resp.status_code == 503
 
+    @patch("api.main._TRADE_AVAILABLE", False)
     def test_find_partner_returns_503(self, client):
         resp = client.get("/api/trade/find_partner/P_MAHOMES?cap_hit=45.0")
         assert resp.status_code == 503


### PR DESCRIPTION
Fixes #198, fixes #201. Adds draft prediction endpoints, parameterized queries (SQL injection fix), API startup resilience, docker-compose api service, and 18 new tests.