### PR TITLE
fix(extract): cross-article dedup for same-pundit predictions (#210)

### DIFF
--- a/pipeline/src/cross_article_dedup.py
+++ b/pipeline/src/cross_article_dedup.py
@@ -1,0 +1,211 @@
+"""
+Cross-Article Deduplication for the Prediction Ledger (Issue #210)
+
+When multiple articles quote the same pundit making the same prediction,
+the extractor creates duplicate ledger entries. This module detects and
+voids those duplicates by comparing PENDING predictions grouped by
+(pundit_id, claim_category, target_player_name) using SequenceMatcher.
+
+Usage (inside Docker):
+    python -m src.cross_article_dedup              # void duplicates
+    python -m src.cross_article_dedup --dry-run     # preview without voiding
+"""
+
+import argparse
+import logging
+import os
+from difflib import SequenceMatcher
+from typing import Optional
+
+import pandas as pd
+
+from src.db_manager import DBManager
+from src.resolution_engine import void_prediction
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+LEDGER_TABLE = "gold_layer.prediction_ledger"
+RESOLUTIONS_TABLE = "gold_layer.prediction_resolutions"
+
+SIMILARITY_THRESHOLD = 0.75
+
+
+def _get_pending_predictions(db: DBManager) -> pd.DataFrame:
+    """
+    Fetches all PENDING predictions from the ledger that have not yet
+    been resolved or voided. Returns columns needed for dedup grouping.
+    """
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    query = f"""
+        SELECT
+            l.prediction_hash,
+            l.pundit_id,
+            l.extracted_claim,
+            l.claim_category,
+            l.target_player_name,
+            l.ingestion_timestamp
+        FROM `{project_id}.{LEDGER_TABLE}` l
+        LEFT JOIN `{project_id}.{RESOLUTIONS_TABLE}` r
+            ON l.prediction_hash = r.prediction_hash
+        WHERE r.prediction_hash IS NULL
+           OR r.resolution_status = 'PENDING'
+        ORDER BY l.ingestion_timestamp ASC
+    """
+    return db.fetch_df(query)
+
+
+def _find_duplicates_in_group(group_df: pd.DataFrame) -> list[str]:
+    """
+    Within a group of predictions from the same pundit/category/player,
+    compare extracted_claim pairwise. When two claims have
+    SequenceMatcher ratio >= SIMILARITY_THRESHOLD, keep the earliest
+    (by ingestion_timestamp) and mark the later one as a duplicate.
+
+    Returns a list of prediction_hashes to void.
+    """
+    if len(group_df) <= 1:
+        return []
+
+    # Sort by ingestion_timestamp ascending so earliest is first
+    sorted_df = group_df.sort_values("ingestion_timestamp").reset_index(drop=True)
+
+    to_void = set()
+    kept_indices = []
+
+    for idx, row in sorted_df.iterrows():
+        if row["prediction_hash"] in to_void:
+            continue
+
+        claim = (row.get("extracted_claim") or "").lower()
+        is_dup = False
+
+        for kept_idx in kept_indices:
+            kept_row = sorted_df.iloc[kept_idx]
+            kept_claim = (kept_row.get("extracted_claim") or "").lower()
+            ratio = SequenceMatcher(None, claim, kept_claim).ratio()
+            if ratio >= SIMILARITY_THRESHOLD:
+                # This row is a duplicate of an earlier one -- void it
+                to_void.add(row["prediction_hash"])
+                is_dup = True
+                break
+
+        if not is_dup:
+            kept_indices.append(idx)
+
+    return list(to_void)
+
+
+def cross_article_dedup(db: Optional[DBManager] = None, dry_run: bool = False) -> dict:
+    """
+    Main dedup entry point.
+
+    1. Query all PENDING predictions
+    2. Group by (pundit_id, claim_category, target_player_name)
+    3. Within each group, compare extracted_claim pairwise
+    4. Keep the earliest entry, void the rest as cross_article_duplicate
+
+    Returns a summary dict with counts.
+    """
+    close_db = db is None
+    if db is None:
+        db = DBManager()
+
+    summary = {
+        "total_pending": 0,
+        "groups_checked": 0,
+        "duplicates_found": 0,
+        "duplicates_voided": 0,
+        "dry_run": dry_run,
+    }
+
+    try:
+        pending_df = _get_pending_predictions(db)
+        summary["total_pending"] = len(pending_df)
+
+        if pending_df.empty:
+            logger.info("No pending predictions to check for duplicates.")
+            return summary
+
+        logger.info(
+            f"Checking {len(pending_df)} pending predictions for "
+            f"cross-article duplicates..."
+        )
+
+        # Normalize target_player_name for grouping (treat None as empty string)
+        pending_df["_group_player"] = (
+            pending_df["target_player_name"].fillna("").str.lower().str.strip()
+        )
+        pending_df["_group_category"] = (
+            pending_df["claim_category"].fillna("").str.lower().str.strip()
+        )
+
+        grouped = pending_df.groupby(["pundit_id", "_group_category", "_group_player"])
+
+        all_to_void = []
+        for group_key, group_df in grouped:
+            if len(group_df) <= 1:
+                continue
+
+            summary["groups_checked"] += 1
+            duplicates = _find_duplicates_in_group(group_df)
+
+            if duplicates:
+                pundit_id, category, player = group_key
+                logger.info(
+                    f"Found {len(duplicates)} duplicate(s) in group "
+                    f"pundit={pundit_id}, category={category}, "
+                    f"player={player or '(none)'}"
+                )
+                all_to_void.extend(duplicates)
+
+        summary["duplicates_found"] = len(all_to_void)
+
+        if not all_to_void:
+            logger.info("No cross-article duplicates found.")
+            return summary
+
+        for pred_hash in all_to_void:
+            if dry_run:
+                logger.info(f"DRY RUN: would void {pred_hash[:16]}...")
+            else:
+                void_prediction(
+                    prediction_hash=pred_hash,
+                    reason="cross_article_duplicate",
+                    db=db,
+                )
+                summary["duplicates_voided"] += 1
+                logger.info(f"Voided duplicate: {pred_hash[:16]}...")
+
+        logger.info(
+            f"Cross-article dedup complete: "
+            f"{summary['duplicates_found']} duplicates found, "
+            f"{summary['duplicates_voided']} voided."
+        )
+        return summary
+    finally:
+        if close_db:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Cross-Article Deduplication for Prediction Ledger"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview duplicates without voiding them",
+    )
+    args = parser.parse_args()
+
+    import json
+
+    result = cross_article_dedup(dry_run=args.dry_run)
+    print(json.dumps(result, indent=2))

--- a/pipeline/src/cross_article_dedup.py
+++ b/pipeline/src/cross_article_dedup.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 LEDGER_TABLE = "gold_layer.prediction_ledger"
 RESOLUTIONS_TABLE = "gold_layer.prediction_resolutions"
 
-SIMILARITY_THRESHOLD = 0.75
+SIMILARITY_THRESHOLD = 0.65
 
 
 def _get_pending_predictions(db: DBManager) -> pd.DataFrame:

--- a/pipeline/src/run_daily.py
+++ b/pipeline/src/run_daily.py
@@ -138,6 +138,7 @@ def main():
         ),
         ("media_ingest", "python -m src.media_ingestor"),
         ("assertion_extract", "python -m src.assertion_extractor --limit 50"),
+        ("cross_article_dedup", "python -m src.cross_article_dedup"),
         ("silver_transform", "python -m src.silver_sportsdataio_transform"),
         ("feature_factory", "python src/feature_factory.py"),
         ("train_model", "python src/train_model.py"),

--- a/pipeline/tests/test_cross_article_dedup.py
+++ b/pipeline/tests/test_cross_article_dedup.py
@@ -1,0 +1,348 @@
+"""
+Tests for Cross-Article Deduplication (Issue #210).
+Unit tests only — no BigQuery required.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+from src.cross_article_dedup import (
+    SIMILARITY_THRESHOLD,
+    _find_duplicates_in_group,
+    _get_pending_predictions,
+    cross_article_dedup,
+)
+
+FAKE_HASH_1 = "a" * 64
+FAKE_HASH_2 = "b" * 64
+FAKE_HASH_3 = "c" * 64
+
+BASE_TS = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.fetch_df.return_value = pd.DataFrame()
+    return db
+
+
+def _make_prediction_row(
+    prediction_hash: str,
+    pundit_id: str,
+    extracted_claim: str,
+    claim_category: str = "player_performance",
+    target_player_name: str = "Patrick Mahomes",
+    ingestion_timestamp: datetime = None,
+):
+    return {
+        "prediction_hash": prediction_hash,
+        "pundit_id": pundit_id,
+        "extracted_claim": extracted_claim,
+        "claim_category": claim_category,
+        "target_player_name": target_player_name,
+        "ingestion_timestamp": ingestion_timestamp or BASE_TS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _find_duplicates_in_group
+# ---------------------------------------------------------------------------
+
+
+class TestFindDuplicatesInGroup:
+    def test_single_entry_returns_empty(self):
+        df = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Mahomes will win MVP in 2025",
+                )
+            ]
+        )
+        assert _find_duplicates_in_group(df) == []
+
+    def test_empty_group_returns_empty(self):
+        df = pd.DataFrame(
+            columns=[
+                "prediction_hash",
+                "pundit_id",
+                "extracted_claim",
+                "claim_category",
+                "target_player_name",
+                "ingestion_timestamp",
+            ]
+        )
+        assert _find_duplicates_in_group(df) == []
+
+    def test_two_similar_claims_voids_later_one(self):
+        """Two articles from different sources, same pundit, same claim."""
+        df = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in the 2025 season",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Mahomes will win the MVP in 2025",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=2),
+                ),
+            ]
+        )
+        to_void = _find_duplicates_in_group(df)
+        assert len(to_void) == 1
+        assert FAKE_HASH_2 in to_void  # later one gets voided
+
+    def test_two_different_claims_both_kept(self):
+        """Two articles, same pundit, different claims -- both kept."""
+        df = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in 2025",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "The Chiefs will trade Kelce before the deadline",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=2),
+                ),
+            ]
+        )
+        to_void = _find_duplicates_in_group(df)
+        assert len(to_void) == 0
+
+    def test_three_articles_two_similar_one_different(self):
+        """Three articles: two have similar claims, one is different.
+        One should be voided, two should remain."""
+        df = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in the 2025 season",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "The Bears will make the playoffs in 2025",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=1),
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_3,
+                    "adam_schefter",
+                    "Mahomes will win the 2025 MVP award",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=3),
+                ),
+            ]
+        )
+        to_void = _find_duplicates_in_group(df)
+        assert len(to_void) == 1
+        assert FAKE_HASH_3 in to_void  # third is duplicate of first
+        assert FAKE_HASH_1 not in to_void  # earliest kept
+        assert FAKE_HASH_2 not in to_void  # different claim kept
+
+    def test_keeps_earliest_by_timestamp(self):
+        """Even if the later entry was ingested first in the list,
+        sorting by ingestion_timestamp keeps the earliest."""
+        df = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Mahomes will win the MVP in 2025",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=5),
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in 2025 season",
+                    ingestion_timestamp=BASE_TS,
+                ),
+            ]
+        )
+        to_void = _find_duplicates_in_group(df)
+        assert len(to_void) == 1
+        assert FAKE_HASH_2 in to_void  # later timestamp gets voided
+
+
+# ---------------------------------------------------------------------------
+# cross_article_dedup (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossArticleDedup:
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_voids_duplicates(self, mock_void, mock_db):
+        """End-to-end: two similar claims from same pundit get one voided."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in 2025",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Mahomes will win the MVP in the 2025 season",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=3),
+                ),
+            ]
+        )
+
+        result = cross_article_dedup(db=mock_db, dry_run=False)
+
+        assert result["duplicates_found"] == 1
+        assert result["duplicates_voided"] == 1
+        mock_void.assert_called_once_with(
+            prediction_hash=FAKE_HASH_2,
+            reason="cross_article_duplicate",
+            db=mock_db,
+        )
+
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_dry_run_does_not_void(self, mock_void, mock_db):
+        """Dry run finds duplicates but does not void them."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in 2025",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Mahomes will win the MVP in the 2025 season",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=3),
+                ),
+            ]
+        )
+
+        result = cross_article_dedup(db=mock_db, dry_run=True)
+
+        assert result["duplicates_found"] == 1
+        assert result["duplicates_voided"] == 0
+        mock_void.assert_not_called()
+
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_different_pundits_not_deduped(self, mock_void, mock_db):
+        """Same claim from different pundits should NOT be deduplicated."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Patrick Mahomes will win MVP in 2025",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "pat_mcafee",
+                    "Patrick Mahomes will win MVP in 2025",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=3),
+                ),
+            ]
+        )
+
+        result = cross_article_dedup(db=mock_db, dry_run=False)
+
+        assert result["duplicates_found"] == 0
+        mock_void.assert_not_called()
+
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_different_categories_not_deduped(self, mock_void, mock_db):
+        """Same pundit, similar claim text but different category -- kept."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "Mahomes will have a great 2025",
+                    claim_category="player_performance",
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Mahomes will have a great 2025",
+                    claim_category="game_outcome",
+                    ingestion_timestamp=BASE_TS + timedelta(hours=3),
+                ),
+            ]
+        )
+
+        result = cross_article_dedup(db=mock_db, dry_run=False)
+
+        assert result["duplicates_found"] == 0
+        mock_void.assert_not_called()
+
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_no_pending_predictions(self, mock_void, mock_db):
+        """No pending predictions means nothing to do."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+
+        result = cross_article_dedup(db=mock_db)
+
+        assert result["total_pending"] == 0
+        assert result["duplicates_found"] == 0
+        mock_void.assert_not_called()
+
+    @patch("src.cross_article_dedup.void_prediction")
+    def test_null_player_name_grouped_together(self, mock_void, mock_db):
+        """Predictions with None target_player_name are grouped together."""
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                _make_prediction_row(
+                    FAKE_HASH_1,
+                    "adam_schefter",
+                    "The Bears will make the playoffs in 2025",
+                    target_player_name=None,
+                    ingestion_timestamp=BASE_TS,
+                ),
+                _make_prediction_row(
+                    FAKE_HASH_2,
+                    "adam_schefter",
+                    "Bears will make the 2025 playoffs",
+                    target_player_name=None,
+                    ingestion_timestamp=BASE_TS + timedelta(hours=2),
+                ),
+            ]
+        )
+
+        result = cross_article_dedup(db=mock_db, dry_run=False)
+
+        assert result["duplicates_found"] == 1
+        assert result["duplicates_voided"] == 1
+
+
+class TestGetPendingPredictions:
+    def test_queries_both_tables(self, mock_db):
+        _get_pending_predictions(mock_db)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "prediction_ledger" in query
+        assert "prediction_resolutions" in query
+
+    def test_filters_for_pending(self, mock_db):
+        _get_pending_predictions(mock_db)
+        query = mock_db.fetch_df.call_args[0][0]
+        assert "PENDING" in query


### PR DESCRIPTION
Fixes #210. Voids duplicate predictions when the same pundit makes the same claim across multiple source articles. Keeps earliest entry, voids rest with reason cross_article_duplicate. Wired into run_daily.py after extraction. 8 unit tests.