### PR TITLE
feat(resolve): game_outcome + player_performance resolvers (#191)

### DIFF
--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -495,9 +495,7 @@ def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
             # Head-to-head win prediction
             team_a, team_b = parsed["team_a"], parsed["team_b"]
             matchups = scores_df[
-                (
-                    (scores_df["HomeTeam"] == team_a) & (scores_df["AwayTeam"] == team_b)
-                )
+                ((scores_df["HomeTeam"] == team_a) & (scores_df["AwayTeam"] == team_b))
                 | (
                     (scores_df["HomeTeam"] == team_b)
                     & (scores_df["AwayTeam"] == team_a)
@@ -534,10 +532,7 @@ def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
             team = parsed["team_focus"]
             expected_playoff = parsed["playoff_prediction"]
             playoff_games = scores_df[
-                (
-                    (scores_df["HomeTeam"] == team)
-                    | (scores_df["AwayTeam"] == team)
-                )
+                ((scores_df["HomeTeam"] == team) | (scores_df["AwayTeam"] == team))
                 & (scores_df["IsPlayoffGame"] == True)  # noqa: E712
             ]
             actually_made_playoffs = len(playoff_games) > 0
@@ -551,10 +546,7 @@ def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
             # Super Bowl win prediction
             team = parsed["team_focus"]
             sb_games = scores_df[
-                (
-                    (scores_df["HomeTeam"] == team)
-                    | (scores_df["AwayTeam"] == team)
-                )
+                ((scores_df["HomeTeam"] == team) | (scores_df["AwayTeam"] == team))
                 & (scores_df["IsPlayoffGame"] == True)  # noqa: E712
             ]
             if sb_games.empty:
@@ -752,18 +744,14 @@ def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
             now.year == season_end_year and now.month > 2
         )
         if not season_complete:
-            logger.info(
-                f"  SKIP {phash[:12]}… — {season_year} season not complete"
-            )
+            logger.info(f"  SKIP {phash[:12]}… — {season_year} season not complete")
             summary["skipped"] += 1
             continue
 
         parsed = _extract_player_stat_claim(claim)
 
         if "stat_column" not in parsed or "threshold" not in parsed:
-            logger.info(
-                f"  VOID {phash[:12]}… — can't parse stat claim: {claim[:60]}"
-            )
+            logger.info(f"  VOID {phash[:12]}… — can't parse stat claim: {claim[:60]}")
             if not dry_run:
                 void_prediction(phash, "unparseable_stat_claim", db=db)
             summary["voided"] += 1
@@ -807,9 +795,7 @@ def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
         actual_val = player_row.get(stat_col)
 
         if pd.isna(actual_val):
-            logger.info(
-                f"  SKIP {phash[:12]}… — {stat_col} is NULL for {player_name}"
-            )
+            logger.info(f"  SKIP {phash[:12]}… — {stat_col} is NULL for {player_name}")
             summary["skipped"] += 1
             continue
 

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -1,18 +1,18 @@
 """
-Daily Prediction Resolution Engine (Issue #169)
+Daily Prediction Resolution Engine (Issue #169, #191)
 
 Matches PENDING predictions from gold_layer.prediction_ledger against actual
 NFL outcomes to automatically score pundit accuracy.
 
-Handles three easy-win categories:
+Handles three categories:
   1. draft_pick — resolved against bronze_sportsdataio_players draft data
-  2. game_outcome — resolved against silver_pfr_game_logs (future)
-  3. player_performance for completed seasons — resolved against season stats (future)
+  2. game_outcome — resolved against bronze_sportsdataio_scores
+  3. player_performance — resolved against bronze_sportsdataio_player_season_stats
 
 Usage (inside Docker):
-    python -m src.resolve_daily                     # resolve all pending
-    python -m src.resolve_daily --category draft_pick  # single category
-    python -m src.resolve_daily --dry-run           # preview without writing
+    python -m src.resolve_daily                         # resolve all pending
+    python -m src.resolve_daily --category draft_pick   # single category
+    python -m src.resolve_daily --dry-run               # preview without writing
 """
 
 import argparse
@@ -22,6 +22,7 @@ import re
 from typing import Optional
 
 import pandas as pd
+from google.api_core.exceptions import NotFound
 
 from src.db_manager import DBManager
 from src.resolution_engine import (
@@ -254,6 +255,602 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Game outcome resolver
+# ---------------------------------------------------------------------------
+
+# NFL team abbreviation aliases (long name → abbreviation)
+_TEAM_ALIASES: dict[str, str] = {
+    "chiefs": "KC",
+    "kansas city": "KC",
+    "eagles": "PHI",
+    "philadelphia": "PHI",
+    "cowboys": "DAL",
+    "dallas": "DAL",
+    "patriots": "NE",
+    "new england": "NE",
+    "bills": "BUF",
+    "buffalo": "BUF",
+    "ravens": "BAL",
+    "baltimore": "BAL",
+    "49ers": "SF",
+    "san francisco": "SF",
+    "lions": "DET",
+    "detroit": "DET",
+    "bears": "CHI",
+    "chicago": "CHI",
+    "bengals": "CIN",
+    "cincinnati": "CIN",
+    "browns": "CLE",
+    "cleveland": "CLE",
+    "broncos": "DEN",
+    "denver": "DEN",
+    "texans": "HOU",
+    "houston": "HOU",
+    "colts": "IND",
+    "indianapolis": "IND",
+    "jaguars": "JAX",
+    "jacksonville": "JAX",
+    "titans": "TEN",
+    "tennessee": "TEN",
+    "raiders": "LV",
+    "las vegas": "LV",
+    "chargers": "LAC",
+    "los angeles chargers": "LAC",
+    "rams": "LAR",
+    "los angeles rams": "LAR",
+    "dolphins": "MIA",
+    "miami": "MIA",
+    "vikings": "MIN",
+    "minnesota": "MIN",
+    "giants": "NYG",
+    "new york giants": "NYG",
+    "jets": "NYJ",
+    "new york jets": "NYJ",
+    "steelers": "PIT",
+    "pittsburgh": "PIT",
+    "seahawks": "SEA",
+    "seattle": "SEA",
+    "buccaneers": "TB",
+    "tampa bay": "TB",
+    "commanders": "WAS",
+    "washington": "WAS",
+    "falcons": "ATL",
+    "atlanta": "ATL",
+    "panthers": "CAR",
+    "carolina": "CAR",
+    "saints": "NO",
+    "new orleans": "NO",
+    "cardinals": "ARI",
+    "arizona": "ARI",
+    "packers": "GB",
+    "green bay": "GB",
+}
+
+
+def _normalize_team(name: str) -> Optional[str]:
+    """Map a team name/nickname to its SportsData.io abbreviation."""
+    name_lower = name.lower().strip()
+    # Direct abbreviation match (e.g. "KC", "PHI")
+    for alias, abbr in _TEAM_ALIASES.items():
+        if alias in name_lower:
+            return abbr
+    # Already an abbreviation?
+    if len(name_lower) <= 3:
+        return name.upper()
+    return None
+
+
+def _extract_game_claim(claim: str) -> dict:
+    """
+    Parse a game_outcome claim to extract structured components.
+    Returns dict with keys: team_a, team_b, season_year, win_prediction (bool or None),
+    playoff_prediction (bool or None), team_focus.
+    """
+    claim_lower = claim.lower()
+    result: dict = {}
+
+    # Extract season year
+    year_match = re.search(r"20\d{2}", claim)
+    if year_match:
+        result["season_year"] = int(year_match.group())
+
+    # Win/defeat prediction: "Chiefs beat/defeat/top Eagles"
+    win_patterns = [
+        r"([a-z ]+?)\s+(?:will\s+)?(?:beat|defeat|top|win against|beat out)\s+(?:the\s+)?([a-z ]+?)(?:\s+in|\s+during|\s*$)",
+        r"([a-z ]+?)\s+(?:over|vs\.?)\s+([a-z ]+?)(?:\s+in|\s*$)",
+    ]
+    for pattern in win_patterns:
+        m = re.search(pattern, claim_lower)
+        if m:
+            team_a = _normalize_team(m.group(1).strip())
+            team_b = _normalize_team(m.group(2).strip())
+            if team_a and team_b:
+                result["team_a"] = team_a
+                result["team_b"] = team_b
+                result["win_prediction"] = True  # team_a beats team_b
+                break
+
+    # Playoff prediction: "Bears will make playoffs" / "Bears miss playoffs"
+    playoff_make = re.search(
+        r"([a-z ]+?)\s+(?:will\s+)?(?:make|reach|qualify for|get to)\s+(?:the\s+)?playoffs",
+        claim_lower,
+    )
+    if playoff_make:
+        team = _normalize_team(playoff_make.group(1).strip())
+        if team:
+            result["team_focus"] = team
+            result["playoff_prediction"] = True
+
+    playoff_miss = re.search(
+        r"([a-z ]+?)\s+(?:will\s+)?(?:miss|fail to make|not make)\s+(?:the\s+)?playoffs",
+        claim_lower,
+    )
+    if playoff_miss:
+        team = _normalize_team(playoff_miss.group(1).strip())
+        if team:
+            result["team_focus"] = team
+            result["playoff_prediction"] = False
+
+    # Super Bowl win: "Chiefs win Super Bowl"
+    sb_win = re.search(
+        r"([a-z ]+?)\s+(?:will\s+)?win\s+(?:the\s+)?super bowl", claim_lower
+    )
+    if sb_win:
+        team = _normalize_team(sb_win.group(1).strip())
+        if team:
+            result["team_focus"] = team
+            result["super_bowl_win"] = True
+
+    return result
+
+
+def _load_game_scores(db: DBManager, season_year: int) -> pd.DataFrame:
+    """
+    Load game scores for a season from bronze_sportsdataio_scores.
+    Returns empty DataFrame if table doesn't exist.
+    """
+    project_id = os.environ["GCP_PROJECT_ID"]
+    query = f"""
+        SELECT
+            HomeTeam, AwayTeam, Season, Week,
+            HomeScore, AwayScore,
+            IsPlayoffGame
+        FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_scores`
+        WHERE Season = {season_year}
+          AND HomeScore IS NOT NULL
+          AND AwayScore IS NOT NULL
+    """
+    try:
+        return db.fetch_df(query)
+    except (NotFound, Exception) as e:
+        logger.warning(f"Game scores not available (season {season_year}): {e}")
+        return pd.DataFrame()
+
+
+def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
+    """
+    Resolve game_outcome predictions against actual game results.
+    Data source: bronze_sportsdataio_scores (HomeTeam, AwayTeam, HomeScore, AwayScore).
+    """
+    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
+
+    pending = get_pending_predictions(sport="NFL", db=db)
+    game_preds = pending[pending["claim_category"] == "game_outcome"]
+
+    if game_preds.empty:
+        logger.info("No pending game_outcome predictions to resolve.")
+        return summary
+
+    current_year = pd.Timestamp.now().year
+    # NFL regular season ends in January; postseason in February
+    # Only resolve predictions for seasons that have fully concluded
+    # (i.e. prior year, or current year after February)
+    season_data_cache: dict[int, pd.DataFrame] = {}
+
+    for _, pred in game_preds.iterrows():
+        summary["checked"] += 1
+        claim = pred["extracted_claim"]
+        phash = pred["prediction_hash"]
+        season_year = pred.get("season_year")
+
+        if pd.isna(season_year):
+            logger.info(f"  SKIP {phash[:12]}… — no season_year in metadata")
+            summary["skipped"] += 1
+            continue
+
+        season_year = int(season_year)
+
+        # NFL season YYYY ends with the Super Bowl in February of YYYY+1.
+        # Only resolve if we are past February of season_year+1.
+        season_end_year = season_year + 1
+        now = pd.Timestamp.now()
+        season_complete = now.year > season_end_year or (
+            now.year == season_end_year and now.month > 2
+        )
+        if not season_complete:
+            logger.info(f"  SKIP {phash[:12]}… — {season_year} season not complete")
+            summary["skipped"] += 1
+            continue
+
+        parsed = _extract_game_claim(claim)
+        if not parsed:
+            logger.info(f"  SKIP {phash[:12]}… — can't parse game claim: {claim[:60]}")
+            summary["skipped"] += 1
+            continue
+
+        # Load season data (cached per season)
+        if season_year not in season_data_cache:
+            season_data_cache[season_year] = _load_game_scores(db, season_year)
+        scores_df = season_data_cache[season_year]
+
+        if scores_df.empty:
+            logger.info(f"  SKIP {phash[:12]}… — no game score data for {season_year}")
+            summary["skipped"] += 1
+            continue
+
+        correct: Optional[bool] = None
+        notes_parts: list[str] = []
+
+        if "team_a" in parsed and "team_b" in parsed:
+            # Head-to-head win prediction
+            team_a, team_b = parsed["team_a"], parsed["team_b"]
+            matchups = scores_df[
+                (
+                    (scores_df["HomeTeam"] == team_a) & (scores_df["AwayTeam"] == team_b)
+                )
+                | (
+                    (scores_df["HomeTeam"] == team_b)
+                    & (scores_df["AwayTeam"] == team_a)
+                )
+            ]
+            if matchups.empty:
+                logger.info(
+                    f"  SKIP {phash[:12]}… — no {team_a} vs {team_b} games found"
+                )
+                summary["skipped"] += 1
+                continue
+
+            # Check if team_a won in any matchup (or most matchups if multiple)
+            team_a_wins = 0
+            team_b_wins = 0
+            for _, game in matchups.iterrows():
+                if game["HomeTeam"] == team_a:
+                    if game["HomeScore"] > game["AwayScore"]:
+                        team_a_wins += 1
+                    else:
+                        team_b_wins += 1
+                else:
+                    if game["AwayScore"] > game["HomeScore"]:
+                        team_a_wins += 1
+                    else:
+                        team_b_wins += 1
+            correct = team_a_wins > team_b_wins
+            notes_parts.append(
+                f"{team_a} vs {team_b}: {team_a} won {team_a_wins}, lost {team_b_wins}"
+            )
+
+        elif "team_focus" in parsed and "playoff_prediction" in parsed:
+            # Playoff prediction
+            team = parsed["team_focus"]
+            expected_playoff = parsed["playoff_prediction"]
+            playoff_games = scores_df[
+                (
+                    (scores_df["HomeTeam"] == team)
+                    | (scores_df["AwayTeam"] == team)
+                )
+                & (scores_df["IsPlayoffGame"] == True)  # noqa: E712
+            ]
+            actually_made_playoffs = len(playoff_games) > 0
+            correct = actually_made_playoffs == expected_playoff
+            notes_parts.append(
+                f"{team} playoff: expected={'made' if expected_playoff else 'missed'}, "
+                f"actual={'made' if actually_made_playoffs else 'missed'}"
+            )
+
+        elif "team_focus" in parsed and "super_bowl_win" in parsed:
+            # Super Bowl win prediction
+            team = parsed["team_focus"]
+            sb_games = scores_df[
+                (
+                    (scores_df["HomeTeam"] == team)
+                    | (scores_df["AwayTeam"] == team)
+                )
+                & (scores_df["IsPlayoffGame"] == True)  # noqa: E712
+            ]
+            if sb_games.empty:
+                summary["skipped"] += 1
+                continue
+            # Super Bowl is the last playoff game; check if team won it
+            last_game = sb_games.iloc[-1]
+            if last_game["HomeTeam"] == team:
+                correct = last_game["HomeScore"] > last_game["AwayScore"]
+            else:
+                correct = last_game["AwayScore"] > last_game["HomeScore"]
+            notes_parts.append(f"{team} Super Bowl win: {correct}")
+
+        else:
+            logger.info(
+                f"  VOID {phash[:12]}… — can't resolve game claim: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "unparseable_game_claim", db=db)
+            summary["voided"] += 1
+            continue
+
+        if correct is None:
+            summary["skipped"] += 1
+            continue
+
+        outcome_notes = "; ".join(notes_parts)
+        status = "CORRECT" if correct else "INCORRECT"
+        logger.info(f"  {status} {phash[:12]}… — {outcome_notes}")
+
+        if not dry_run:
+            resolve_binary(
+                prediction_hash=phash,
+                correct=correct,
+                outcome_source="sportsdataio_scores",
+                outcome_notes=outcome_notes,
+                db=db,
+            )
+        summary["resolved"] += 1
+
+    logger.info(
+        f"Game outcome resolution: {summary['resolved']} resolved, "
+        f"{summary['voided']} voided, {summary['skipped']} skipped"
+    )
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Player performance resolver
+# ---------------------------------------------------------------------------
+
+# Mapping from common stat phrases → column names in bronze_sportsdataio_player_season_stats
+_STAT_ALIASES: dict[str, str] = {
+    "passing yards": "PassingYards",
+    "passing yard": "PassingYards",
+    "pass yards": "PassingYards",
+    "passing touchdowns": "PassingTouchdowns",
+    "passing tds": "PassingTouchdowns",
+    "passing td": "PassingTouchdowns",
+    "tds": "PassingTouchdowns",  # default to passing (resolved by position context)
+    "interceptions": "Interceptions",
+    "rushing yards": "RushingYards",
+    "rushing yard": "RushingYards",
+    "rush yards": "RushingYards",
+    "rushes for": "RushingYards",
+    "rush for": "RushingYards",
+    "rushing touchdowns": "RushingTouchdowns",
+    "rushing tds": "RushingTouchdowns",
+    "receiving yards": "ReceivingYards",
+    "receiving yard": "ReceivingYards",
+    "rec yards": "ReceivingYards",
+    "receiving touchdowns": "ReceivingTouchdowns",
+    "receiving tds": "ReceivingTouchdowns",
+    "receptions": "Receptions",
+    "catches": "Receptions",
+    "sacks": "Sacks",
+    "tackles": "Tackles",
+}
+
+
+def _extract_player_stat_claim(claim: str) -> dict:
+    """
+    Parse a player_performance claim to extract structured components.
+    Returns dict with keys: player_name, stat_column, threshold, operator, season_year.
+    operator is ">=" (at least), ">" (more than), "==" (exactly), "<=" (at most).
+    """
+    claim_lower = claim.lower()
+    result: dict = {}
+
+    # Extract season year
+    year_match = re.search(r"20\d{2}", claim)
+    if year_match:
+        result["season_year"] = int(year_match.group())
+
+    # Extract numeric threshold — patterns like "40+", "40 or more", "at least 40",
+    # "over 40", "more than 40", "1,500", "1500"
+    threshold_patterns = [
+        (r"(?:at least|minimum)\s+([\d,]+)\+?", ">="),
+        (r"(?:over|more than|greater than)\s+([\d,]+)", ">"),
+        (r"([\d,]+)\+\s*(?:or more)?", ">="),
+        (r"([\d,]+)\s+or more", ">="),
+        (r"fewer than\s+([\d,]+)", "<"),
+        (r"under\s+([\d,]+)", "<"),
+        (r"at most\s+([\d,]+)", "<="),
+        (r"exactly\s+([\d,]+)", "=="),
+        (r"(?:at least\s+)?([\d,]+)", ">="),  # bare number — assume "at least"
+    ]
+    for pattern, operator in threshold_patterns:
+        m = re.search(pattern, claim_lower)
+        if m:
+            val_str = m.group(1).replace(",", "")
+            try:
+                result["threshold"] = int(val_str)
+                result["operator"] = operator
+                break
+            except ValueError:
+                continue
+
+    # Extract stat category
+    for phrase, col in sorted(_STAT_ALIASES.items(), key=lambda x: -len(x[0])):
+        if phrase in claim_lower:
+            result["stat_column"] = col
+            break
+
+    # Extract player name — heuristic: words before the verb "will"/"throws"/"records"
+    # Look for capitalized words at start (common for player names)
+    name_match = re.match(
+        r"^([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\s+(?:will|throws?|records?|rushes?|catches?|has|posts?)",
+        claim,
+    )
+    if name_match:
+        result["player_name"] = name_match.group(1)
+
+    return result
+
+
+def _load_player_season_stats(db: DBManager, season_year: int) -> pd.DataFrame:
+    """
+    Load player season stats from bronze_sportsdataio_player_season_stats.
+    Returns empty DataFrame if table doesn't exist.
+    """
+    project_id = os.environ["GCP_PROJECT_ID"]
+    query = f"""
+        SELECT
+            Name, Season,
+            PassingYards, PassingTouchdowns, Interceptions,
+            RushingYards, RushingTouchdowns,
+            ReceivingYards, ReceivingTouchdowns, Receptions,
+            Sacks, Tackles
+        FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_player_season_stats`
+        WHERE Season = {season_year}
+    """
+    try:
+        return db.fetch_df(query)
+    except (NotFound, Exception) as e:
+        logger.warning(f"Player season stats not available (season {season_year}): {e}")
+        return pd.DataFrame()
+
+
+def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
+    """
+    Resolve player_performance predictions against actual season stats.
+    Data source: bronze_sportsdataio_player_season_stats.
+    Only resolves predictions for completed seasons.
+    """
+    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
+
+    pending = get_pending_predictions(sport="NFL", db=db)
+    perf_preds = pending[pending["claim_category"] == "player_performance"]
+
+    if perf_preds.empty:
+        logger.info("No pending player_performance predictions to resolve.")
+        return summary
+
+    current_year = pd.Timestamp.now().year
+    stats_cache: dict[int, pd.DataFrame] = {}
+
+    for _, pred in perf_preds.iterrows():
+        summary["checked"] += 1
+        claim = pred["extracted_claim"]
+        phash = pred["prediction_hash"]
+        season_year = pred.get("season_year")
+
+        if pd.isna(season_year):
+            logger.info(f"  SKIP {phash[:12]}… — no season_year")
+            summary["skipped"] += 1
+            continue
+
+        season_year = int(season_year)
+
+        # NFL season YYYY ends with the Super Bowl in February of YYYY+1.
+        season_end_year = season_year + 1
+        now = pd.Timestamp.now()
+        season_complete = now.year > season_end_year or (
+            now.year == season_end_year and now.month > 2
+        )
+        if not season_complete:
+            logger.info(
+                f"  SKIP {phash[:12]}… — {season_year} season not complete"
+            )
+            summary["skipped"] += 1
+            continue
+
+        parsed = _extract_player_stat_claim(claim)
+
+        if "stat_column" not in parsed or "threshold" not in parsed:
+            logger.info(
+                f"  VOID {phash[:12]}… — can't parse stat claim: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "unparseable_stat_claim", db=db)
+            summary["voided"] += 1
+            continue
+
+        # Load stats (cached per season)
+        if season_year not in stats_cache:
+            stats_cache[season_year] = _load_player_season_stats(db, season_year)
+        stats_df = stats_cache[season_year]
+
+        if stats_df.empty:
+            logger.info(
+                f"  SKIP {phash[:12]}… — no player stats data for {season_year}"
+            )
+            summary["skipped"] += 1
+            continue
+
+        # Find the player
+        player_name = parsed.get("player_name") or pred.get("target_player_name") or ""
+        player_name_lower = _normalize_name(player_name)
+
+        if not player_name_lower:
+            logger.info(f"  SKIP {phash[:12]}… — no player name: {claim[:60]}")
+            summary["skipped"] += 1
+            continue
+
+        stats_df["name_lower"] = stats_df["Name"].str.lower().str.strip()
+        player_rows = stats_df[
+            stats_df["name_lower"].str.contains(player_name_lower, na=False)
+        ]
+
+        if player_rows.empty:
+            logger.info(
+                f"  SKIP {phash[:12]}… — player '{player_name}' not found in {season_year} stats"
+            )
+            summary["skipped"] += 1
+            continue
+
+        player_row = player_rows.iloc[0]
+        stat_col = parsed["stat_column"]
+        actual_val = player_row.get(stat_col)
+
+        if pd.isna(actual_val):
+            logger.info(
+                f"  SKIP {phash[:12]}… — {stat_col} is NULL for {player_name}"
+            )
+            summary["skipped"] += 1
+            continue
+
+        actual_val = float(actual_val)
+        threshold = float(parsed["threshold"])
+        operator = parsed["operator"]
+
+        op_map = {
+            ">=": actual_val >= threshold,
+            ">": actual_val > threshold,
+            "==": actual_val == threshold,
+            "<=": actual_val <= threshold,
+            "<": actual_val < threshold,
+        }
+        correct = op_map.get(operator, False)
+
+        outcome_notes = (
+            f"{player_name} {stat_col}: actual={actual_val:.0f}, "
+            f"claimed {operator}{threshold:.0f} in {season_year}"
+        )
+        status = "CORRECT" if correct else "INCORRECT"
+        logger.info(f"  {status} {phash[:12]}… — {outcome_notes}")
+
+        if not dry_run:
+            resolve_binary(
+                prediction_hash=phash,
+                correct=correct,
+                outcome_source="sportsdataio_player_stats",
+                outcome_notes=outcome_notes,
+                db=db,
+            )
+        summary["resolved"] += 1
+
+    logger.info(
+        f"Player performance resolution: {summary['resolved']} resolved, "
+        f"{summary['voided']} voided, {summary['skipped']} skipped"
+    )
+    return summary
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -274,7 +871,13 @@ def resolve_all(
         if not category or category == "draft_pick":
             summaries["draft_pick"] = resolve_draft_picks(db, dry_run=dry_run)
 
-        # Future: game_outcome, player_performance resolvers
+        if not category or category == "game_outcome":
+            summaries["game_outcome"] = resolve_game_outcomes(db, dry_run=dry_run)
+
+        if not category or category == "player_performance":
+            summaries["player_performance"] = resolve_player_performance(
+                db, dry_run=dry_run
+            )
 
         # Combined summary
         total = {

--- a/pipeline/tests/test_resolve_daily.py
+++ b/pipeline/tests/test_resolve_daily.py
@@ -83,31 +83,23 @@ class TestNormalizeTeam:
 
 class TestExtractGameClaim:
     def test_win_prediction(self):
-        result = _extract_game_claim(
-            "Chiefs will beat Eagles in 2026 Super Bowl"
-        )
+        result = _extract_game_claim("Chiefs will beat Eagles in 2026 Super Bowl")
         assert result.get("team_a") == "KC"
         assert result.get("team_b") == "PHI"
         assert result.get("win_prediction") is True
 
     def test_playoff_make_prediction(self):
-        result = _extract_game_claim(
-            "Bears will make the playoffs in 2026"
-        )
+        result = _extract_game_claim("Bears will make the playoffs in 2026")
         assert result.get("team_focus") == "CHI"
         assert result.get("playoff_prediction") is True
 
     def test_playoff_miss_prediction(self):
-        result = _extract_game_claim(
-            "Browns will miss the playoffs in 2026"
-        )
+        result = _extract_game_claim("Browns will miss the playoffs in 2026")
         assert result.get("team_focus") == "CLE"
         assert result.get("playoff_prediction") is False
 
     def test_super_bowl_win_prediction(self):
-        result = _extract_game_claim(
-            "Lions will win the Super Bowl in 2026"
-        )
+        result = _extract_game_claim("Lions will win the Super Bowl in 2026")
         assert result.get("team_focus") == "DET"
         assert result.get("super_bowl_win") is True
 
@@ -139,9 +131,7 @@ class TestExtractPlayerStatClaim:
         assert result.get("operator") == ">="
 
     def test_passing_tds(self):
-        result = _extract_player_stat_claim(
-            "Josh Allen throws 40+ passing TDs in 2026"
-        )
+        result = _extract_player_stat_claim("Josh Allen throws 40+ passing TDs in 2026")
         assert result.get("stat_column") in ("PassingTouchdowns", "PassingTDs")
         # stat_column should be one of the mapped aliases
         assert result.get("threshold") == 40
@@ -168,9 +158,7 @@ class TestExtractPlayerStatClaim:
         assert result.get("operator") == "<"
 
     def test_season_year_extracted(self):
-        result = _extract_player_stat_claim(
-            "Mahomes passes for 4800 yards in 2025"
-        )
+        result = _extract_player_stat_claim("Mahomes passes for 4800 yards in 2025")
         assert result.get("season_year") == 2025
 
     def test_player_name_extracted(self):
@@ -180,9 +168,7 @@ class TestExtractPlayerStatClaim:
         assert result.get("player_name") == "Patrick Mahomes"
 
     def test_no_stat_returns_incomplete(self):
-        result = _extract_player_stat_claim(
-            "Mahomes will be great in 2026"
-        )
+        result = _extract_player_stat_claim("Mahomes will be great in 2026")
         assert "stat_column" not in result or "threshold" not in result
 
 
@@ -238,7 +224,9 @@ class TestResolveGameOutcomes:
     @patch("src.resolve_daily._load_game_scores")
     @patch("src.resolve_daily.get_pending_predictions")
     @patch("src.resolve_daily.resolve_binary")
-    def test_correct_win_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+    def test_correct_win_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
         """Chiefs beat Eagles correctly resolved when Chiefs won."""
         preds = _make_pending_df(
             "game_outcome",
@@ -256,7 +244,9 @@ class TestResolveGameOutcomes:
     @patch("src.resolve_daily._load_game_scores")
     @patch("src.resolve_daily.get_pending_predictions")
     @patch("src.resolve_daily.resolve_binary")
-    def test_incorrect_win_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+    def test_incorrect_win_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
         """Chiefs beat Eagles incorrectly when Eagles actually won."""
         preds = _make_pending_df(
             "game_outcome",
@@ -277,7 +267,12 @@ class TestResolveGameOutcomes:
         current_year = pd.Timestamp.now().year
         preds = _make_pending_df(
             "game_outcome",
-            [{"claim": f"Chiefs beat Eagles in {current_year}", "season_year": current_year}],
+            [
+                {
+                    "claim": f"Chiefs beat Eagles in {current_year}",
+                    "season_year": current_year,
+                }
+            ],
         )
         mock_pending.return_value = preds
 
@@ -338,7 +333,12 @@ class TestResolveGameOutcomes:
     @patch("src.resolve_daily.get_pending_predictions")
     def test_empty_predictions(self, mock_pending, mock_db):
         mock_pending.return_value = pd.DataFrame(
-            columns=["prediction_hash", "extracted_claim", "claim_category", "season_year"]
+            columns=[
+                "prediction_hash",
+                "extracted_claim",
+                "claim_category",
+                "season_year",
+            ]
         )
         summary = resolve_game_outcomes(mock_db, dry_run=False)
         assert summary["checked"] == 0
@@ -392,7 +392,9 @@ class TestResolvePlayerPerformance:
     @patch("src.resolve_daily._load_player_season_stats")
     @patch("src.resolve_daily.get_pending_predictions")
     @patch("src.resolve_daily.resolve_binary")
-    def test_correct_stat_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+    def test_correct_stat_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
         """Mahomes throws 5000+ yards — correct when actual is 5100."""
         preds = _make_pending_df(
             "player_performance",
@@ -416,7 +418,9 @@ class TestResolvePlayerPerformance:
     @patch("src.resolve_daily._load_player_season_stats")
     @patch("src.resolve_daily.get_pending_predictions")
     @patch("src.resolve_daily.resolve_binary")
-    def test_incorrect_stat_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+    def test_incorrect_stat_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
         """Mahomes throws 5000+ yards — incorrect when actual is 4200."""
         preds = _make_pending_df(
             "player_performance",
@@ -481,7 +485,9 @@ class TestResolvePlayerPerformance:
     @patch("src.resolve_daily._load_player_season_stats")
     @patch("src.resolve_daily.get_pending_predictions")
     @patch("src.resolve_daily.void_prediction")
-    def test_voids_unparseable_stat_claim(self, mock_void, mock_pending, mock_load, mock_db):
+    def test_voids_unparseable_stat_claim(
+        self, mock_void, mock_pending, mock_load, mock_db
+    ):
         """Claims without a parseable stat threshold are voided."""
         preds = _make_pending_df(
             "player_performance",
@@ -524,7 +530,12 @@ class TestResolvePlayerPerformance:
     @patch("src.resolve_daily.get_pending_predictions")
     def test_empty_predictions(self, mock_pending, mock_db):
         mock_pending.return_value = pd.DataFrame(
-            columns=["prediction_hash", "extracted_claim", "claim_category", "season_year"]
+            columns=[
+                "prediction_hash",
+                "extracted_claim",
+                "claim_category",
+                "season_year",
+            ]
         )
         summary = resolve_player_performance(mock_db, dry_run=False)
         assert summary["checked"] == 0

--- a/pipeline/tests/test_resolve_daily.py
+++ b/pipeline/tests/test_resolve_daily.py
@@ -1,0 +1,530 @@
+"""
+Tests for the Daily Prediction Resolution Engine (Issue #191).
+Unit tests — no BigQuery required. All DB calls are mocked.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.resolve_daily import (
+    _extract_draft_claim,
+    _extract_game_claim,
+    _extract_player_stat_claim,
+    _normalize_name,
+    _normalize_team,
+    resolve_draft_picks,
+    resolve_game_outcomes,
+    resolve_player_performance,
+)
+
+FAKE_HASH = "b" * 64
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.fetch_df.return_value = pd.DataFrame()
+    return db
+
+
+def _make_pending_df(category: str, claims: list[dict]) -> pd.DataFrame:
+    rows = []
+    for i, c in enumerate(claims):
+        rows.append(
+            {
+                "prediction_hash": f"{'a' * 60}{i:04d}",
+                "extracted_claim": c.get("claim", ""),
+                "claim_category": category,
+                "season_year": c.get("season_year", 2024),
+                "target_player_id": c.get("target_player_id"),
+                "target_player_name": c.get("player_name"),
+                "ingestion_timestamp": datetime(2024, 9, 1, tzinfo=timezone.utc),
+                "sport": "NFL",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_team
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTeam:
+    def test_long_name_chiefs(self):
+        assert _normalize_team("Kansas City Chiefs") == "KC"
+
+    def test_nickname_only_eagles(self):
+        assert _normalize_team("Eagles") == "PHI"
+
+    def test_partial_match_bears(self):
+        assert _normalize_team("Chicago Bears") == "CHI"
+
+    def test_unknown_returns_none(self):
+        assert _normalize_team("Unknown Football Club") is None
+
+    def test_abbreviation_passthrough(self):
+        result = _normalize_team("KC")
+        assert result == "KC"
+
+
+# ---------------------------------------------------------------------------
+# _extract_game_claim
+# ---------------------------------------------------------------------------
+
+
+class TestExtractGameClaim:
+    def test_win_prediction(self):
+        result = _extract_game_claim(
+            "Chiefs will beat Eagles in 2026 Super Bowl"
+        )
+        assert result.get("team_a") == "KC"
+        assert result.get("team_b") == "PHI"
+        assert result.get("win_prediction") is True
+
+    def test_playoff_make_prediction(self):
+        result = _extract_game_claim(
+            "Bears will make the playoffs in 2026"
+        )
+        assert result.get("team_focus") == "CHI"
+        assert result.get("playoff_prediction") is True
+
+    def test_playoff_miss_prediction(self):
+        result = _extract_game_claim(
+            "Browns will miss the playoffs in 2026"
+        )
+        assert result.get("team_focus") == "CLE"
+        assert result.get("playoff_prediction") is False
+
+    def test_super_bowl_win_prediction(self):
+        result = _extract_game_claim(
+            "Lions will win the Super Bowl in 2026"
+        )
+        assert result.get("team_focus") == "DET"
+        assert result.get("super_bowl_win") is True
+
+    def test_season_year_extracted(self):
+        result = _extract_game_claim("Chiefs beat Ravens in 2025")
+        assert result.get("season_year") == 2025
+
+    def test_unparseable_returns_empty(self):
+        result = _extract_game_claim(
+            "The game will be close but someone will win eventually"
+        )
+        # No team identified → no structured output
+        assert "team_a" not in result
+        assert "team_focus" not in result
+
+
+# ---------------------------------------------------------------------------
+# _extract_player_stat_claim
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPlayerStatClaim:
+    def test_passing_yards(self):
+        result = _extract_player_stat_claim(
+            "Patrick Mahomes throws 5000+ passing yards in 2026"
+        )
+        assert result.get("stat_column") == "PassingYards"
+        assert result.get("threshold") == 5000
+        assert result.get("operator") == ">="
+
+    def test_passing_tds(self):
+        result = _extract_player_stat_claim(
+            "Josh Allen throws 40+ passing TDs in 2026"
+        )
+        assert result.get("stat_column") in ("PassingTouchdowns", "PassingTDs")
+        # stat_column should be one of the mapped aliases
+        assert result.get("threshold") == 40
+
+    def test_receiving_yards(self):
+        result = _extract_player_stat_claim(
+            "CeeDee Lamb records 1500 receiving yards in 2026"
+        )
+        assert result.get("stat_column") == "ReceivingYards"
+        assert result.get("threshold") == 1500
+
+    def test_rushing_yards(self):
+        result = _extract_player_stat_claim(
+            "Derrick Henry rushes for 1200+ yards in 2026"
+        )
+        assert result.get("stat_column") == "RushingYards"
+        assert result.get("threshold") == 1200
+
+    def test_fewer_than_operator(self):
+        result = _extract_player_stat_claim(
+            "Justin Fields throws fewer than 10 passing touchdowns in 2026"
+        )
+        assert result.get("threshold") == 10
+        assert result.get("operator") == "<"
+
+    def test_season_year_extracted(self):
+        result = _extract_player_stat_claim(
+            "Mahomes passes for 4800 yards in 2025"
+        )
+        assert result.get("season_year") == 2025
+
+    def test_player_name_extracted(self):
+        result = _extract_player_stat_claim(
+            "Patrick Mahomes throws 45 passing TDs in 2026"
+        )
+        assert result.get("player_name") == "Patrick Mahomes"
+
+    def test_no_stat_returns_incomplete(self):
+        result = _extract_player_stat_claim(
+            "Mahomes will be great in 2026"
+        )
+        assert "stat_column" not in result or "threshold" not in result
+
+
+# ---------------------------------------------------------------------------
+# resolve_game_outcomes
+# ---------------------------------------------------------------------------
+
+
+_SCORES_2024 = pd.DataFrame(
+    [
+        {
+            "HomeTeam": "KC",
+            "AwayTeam": "PHI",
+            "Season": 2024,
+            "Week": 11,
+            "HomeScore": 21,
+            "AwayScore": 17,
+            "IsPlayoffGame": False,
+        }
+    ]
+)
+
+_SCORES_2024_EAGLES_WIN = pd.DataFrame(
+    [
+        {
+            "HomeTeam": "PHI",
+            "AwayTeam": "KC",
+            "Season": 2024,
+            "Week": 11,
+            "HomeScore": 24,
+            "AwayScore": 14,
+            "IsPlayoffGame": False,
+        }
+    ]
+)
+
+_BEARS_PLAYOFF_2024 = pd.DataFrame(
+    [
+        {
+            "HomeTeam": "CHI",
+            "AwayTeam": "GB",
+            "Season": 2024,
+            "Week": 18,
+            "HomeScore": 27,
+            "AwayScore": 20,
+            "IsPlayoffGame": True,
+        }
+    ]
+)
+
+
+class TestResolveGameOutcomes:
+    @patch("src.resolve_daily._load_game_scores")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_correct_win_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Chiefs beat Eagles correctly resolved when Chiefs won."""
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": "Chiefs beat Eagles in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _SCORES_2024
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily._load_game_scores")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_incorrect_win_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Chiefs beat Eagles incorrectly when Eagles actually won."""
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": "Chiefs beat Eagles in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _SCORES_2024_EAGLES_WIN
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is False
+
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skips_current_season(self, mock_pending, mock_db):
+        """Predictions for the current (incomplete) season are skipped."""
+        current_year = pd.Timestamp.now().year
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": f"Chiefs beat Eagles in {current_year}", "season_year": current_year}],
+        )
+        mock_pending.return_value = preds
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+        assert summary["resolved"] == 0
+
+    @patch("src.resolve_daily._load_game_scores")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skips_missing_data(self, mock_pending, mock_load, mock_db):
+        """Predictions skipped gracefully when scores table returns empty."""
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": "Chiefs beat Eagles in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = pd.DataFrame()
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+
+    @patch("src.resolve_daily._load_game_scores")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.void_prediction")
+    def test_voids_unparseable_claim(self, mock_void, mock_pending, mock_load, mock_db):
+        """Claims that can't be parsed are voided."""
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": "The game will be entertaining in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _SCORES_2024
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["voided"] == 1
+
+    @patch("src.resolve_daily._load_game_scores")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_playoff_make_correct(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Bears making playoffs correctly resolved when Bears appear in playoff games."""
+        preds = _make_pending_df(
+            "game_outcome",
+            [{"claim": "Bears will make the playoffs in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _BEARS_PLAYOFF_2024
+
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_empty_predictions(self, mock_pending, mock_db):
+        mock_pending.return_value = pd.DataFrame(
+            columns=["prediction_hash", "extracted_claim", "claim_category", "season_year"]
+        )
+        summary = resolve_game_outcomes(mock_db, dry_run=False)
+        assert summary["checked"] == 0
+
+
+# ---------------------------------------------------------------------------
+# resolve_player_performance
+# ---------------------------------------------------------------------------
+
+
+_MAHOMES_STATS_2024 = pd.DataFrame(
+    [
+        {
+            "Name": "Patrick Mahomes",
+            "Season": 2024,
+            "PassingYards": 5100,
+            "PassingTouchdowns": 41,
+            "Interceptions": 11,
+            "RushingYards": 360,
+            "RushingTouchdowns": 4,
+            "ReceivingYards": None,
+            "ReceivingTouchdowns": None,
+            "Receptions": None,
+            "Sacks": None,
+            "Tackles": None,
+        }
+    ]
+)
+
+_MAHOMES_LOW_STATS_2024 = pd.DataFrame(
+    [
+        {
+            "Name": "Patrick Mahomes",
+            "Season": 2024,
+            "PassingYards": 4200,
+            "PassingTouchdowns": 35,
+            "Interceptions": 10,
+            "RushingYards": 290,
+            "RushingTouchdowns": 3,
+            "ReceivingYards": None,
+            "ReceivingTouchdowns": None,
+            "Receptions": None,
+            "Sacks": None,
+            "Tackles": None,
+        }
+    ]
+)
+
+
+class TestResolvePlayerPerformance:
+    @patch("src.resolve_daily._load_player_season_stats")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_correct_stat_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Mahomes throws 5000+ yards — correct when actual is 5100."""
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": "Patrick Mahomes throws 5000+ passing yards in 2024",
+                    "season_year": 2024,
+                    "player_name": "Patrick Mahomes",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _MAHOMES_STATS_2024
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily._load_player_season_stats")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_incorrect_stat_prediction(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Mahomes throws 5000+ yards — incorrect when actual is 4200."""
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": "Patrick Mahomes throws 5000+ passing yards in 2024",
+                    "season_year": 2024,
+                    "player_name": "Patrick Mahomes",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _MAHOMES_LOW_STATS_2024
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is False
+
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skips_current_season(self, mock_pending, mock_db):
+        """Incomplete seasons are skipped."""
+        current_year = pd.Timestamp.now().year
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": f"Mahomes throws 5000 yards in {current_year}",
+                    "season_year": current_year,
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+        assert summary["resolved"] == 0
+
+    @patch("src.resolve_daily._load_player_season_stats")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skips_missing_stats_data(self, mock_pending, mock_load, mock_db):
+        """Skips gracefully when stats table is empty."""
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": "Mahomes throws 5000 passing yards in 2024",
+                    "season_year": 2024,
+                    "player_name": "Patrick Mahomes",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = pd.DataFrame()
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+
+    @patch("src.resolve_daily._load_player_season_stats")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.void_prediction")
+    def test_voids_unparseable_stat_claim(self, mock_void, mock_pending, mock_load, mock_db):
+        """Claims without a parseable stat threshold are voided."""
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": "Mahomes will be great in 2024",
+                    "season_year": 2024,
+                    "player_name": "Patrick Mahomes",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _MAHOMES_STATS_2024
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["voided"] == 1
+
+    @patch("src.resolve_daily._load_player_season_stats")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skips_player_not_found(self, mock_pending, mock_load, mock_db):
+        """Skips when player name not found in stats table."""
+        preds = _make_pending_df(
+            "player_performance",
+            [
+                {
+                    "claim": "Joe Schmoe throws 5000 passing yards in 2024",
+                    "season_year": 2024,
+                    "player_name": "Joe Schmoe",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _MAHOMES_STATS_2024  # Only Mahomes in table
+
+        summary = resolve_player_performance(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_empty_predictions(self, mock_pending, mock_db):
+        mock_pending.return_value = pd.DataFrame(
+            columns=["prediction_hash", "extracted_claim", "claim_category", "season_year"]
+        )
+        summary = resolve_player_performance(mock_db, dry_run=False)
+        assert summary["checked"] == 0


### PR DESCRIPTION
## Summary

Closes #191. Implements `game_outcome` and `player_performance` resolvers in `resolve_daily.py`, completing the three-resolver suite.

## Resolvers

### game_outcome
- Regex-based parsing: head-to-head wins, playoff qualification, Super Bowl
- NFL season boundary: season N ends Feb N+1 (avoids false positives on in-progress seasons)
- Data source: `bronze_sportsdataio_scores` (HomeTeam, AwayTeam, HomeScore, AwayScore, IsPlayoffGame)
- Graceful skip when table missing or no matching games found

### player_performance
- Parses stat thresholds: `>=`, `>`, `==`, `<=`, `<`
- Handles natural language: "5000+", "at least 40 TDs", "fewer than 10 picks", "rushes for 1200 yards"
- Data source: `bronze_sportsdataio_player_season_stats`
- Only resolves completed seasons; gracefully skips missing data

### Wire-up
Both resolvers registered in `resolve_all()` and reachable via:
```bash
python -m src.resolve_daily --category game_outcome
python -m src.resolve_daily --category player_performance
```

## Test plan

- [x] 33 new tests pass in `test_resolve_daily.py` (6 game_outcome, 7 player_performance, parsing units)
- [x] 363 total pass, 20 skipped (BQ/API integration)
- [x] `_normalize_team` maps 32 teams + aliases
- [x] `_extract_game_claim` covers win, playoff, Super Bowl patterns
- [x] `_extract_player_stat_claim` covers 5 operator forms and 10 stat categories
- [x] Both resolvers handle missing BQ table gracefully (skip, not error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)