### PR TITLE
feat(extract): draft-pick prompt improvements + seed URL config (#196)

### DIFF
--- a/pipeline/config/draft_seed_urls.yaml
+++ b/pipeline/config/draft_seed_urls.yaml
@@ -1,0 +1,50 @@
+# Search queries for draft prediction article discovery
+# The crawler searches these queries, finds article URLs, and ingests them automatically
+# Run: python -m src.url_ingestor --search [--dry-run]
+
+search_queries:
+  - "2026 NFL mock draft"
+  - "2026 NFL draft predictions round 1"
+  - "2026 NFL mock draft first round picks"
+  - "NFL draft 2026 who goes number 1"
+  - "Fernando Mendoza NFL draft prediction"
+  - "2026 NFL draft big board"
+  - "NFL draft 2026 picks predictions analysis"
+  - "mock draft 2026 NFL final"
+
+# Map domains to source IDs and default pundits
+source_mapping:
+  "espn.com":
+    source_id: espn_nfl
+  "nbcsports.com":
+    source_id: pft_nbc
+  "profootballtalk":
+    source_id: pft_nbc
+  "nfl.com":
+    source_id: nfl_official
+  "cbssports.com":
+    source_id: cbs_nfl
+  "yahoo.com":
+    source_id: yahoo_nfl
+  "si.com":
+    source_id: si_nfl
+  "bleacherreport.com":
+    source_id: bleacher_report
+  "theathletic.com":
+    source_id: theathletic_nfl
+  "theringer.com":
+    source_id: theringer_nfl
+
+# Domains to skip (non-article, aggregators, etc)
+skip_domains:
+  - "youtube.com"
+  - "twitter.com"
+  - "x.com"
+  - "reddit.com"
+  - "facebook.com"
+  - "instagram.com"
+  - "tiktok.com"
+  - "wikipedia.org"
+  - "nflmockdraftdatabase.com"
+  - "drafttek.com"
+  - "walterfootball.com"


### PR DESCRIPTION
## Summary
- Improves `EXTRACTION_PROMPT` to correctly classify mock draft picks as `draft_pick` predictions
- Moves `AUTHOR` field earlier in the prompt (before rules) so LLM has author context while evaluating
- Adds 7 concrete examples covering `draft_pick`, `game_outcome`, and `player_performance` categories
- Adds `target_player` and `claim_category` field guidance in prompt footer
- Trims over-broad rejection rules that were excluding valid predictions (scheme/style, consensus restating)
- Adds `pipeline/config/draft_seed_urls.yaml` — search queries + source domain → source_id mapping for draft article crawling

## Why
NFL Draft is live (2026-04-24 through 2026-04-26). Without explicit mock-draft-pick instructions the LLM was not extracting draft predictions as `draft_pick` assertions, so they couldn't be resolved by the draft pick resolver (#176).

## Test plan
- [x] 525 unit tests pass (`make check`)
- [x] Prompt renders correctly (AUTHOR, new rules, examples all present)
- [x] `draft_seed_urls.yaml` YAML parses correctly

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)