### PR TITLE
feat(backtest): 2025 season backtest infrastructure — seed config + precision report (#245)

### DIFF
--- a/pipeline/config/backtest_2025_seed_urls.yaml
+++ b/pipeline/config/backtest_2025_seed_urls.yaml
@@ -1,0 +1,85 @@
+# Search queries for 2025 NFL season backtest article discovery
+#
+# Targets preseason predictions, playoff forecasts, Super Bowl picks, MVP calls,
+# win totals, and draft predictions from the 2025 NFL season (Sep 2025 – Feb 2026).
+# All outcomes are now known, making this ideal for precision/recall validation.
+#
+# Run:
+#   python -m src.url_ingestor --config config/backtest_2025_seed_urls.yaml --search
+#   python -m src.url_ingestor --config config/backtest_2025_seed_urls.yaml --search --dry-run
+#
+# Note: url_ingestor filters titles for at least one of:
+#   ["draft", "mock", "pick", "prediction", "prospect"]
+# All queries below are designed to surface articles that match this filter.
+
+search_queries:
+  # Preseason win-total + season predictions
+  - "2025 NFL season predictions preseason picks"
+  - "2025 NFL win totals predictions all 32 teams"
+  - "NFL 2025 season preview predictions AFC NFC"
+
+  # Playoff predictions
+  - "2025 NFL playoff predictions picks bracket"
+  - "2025 NFC AFC championship predictions picks"
+
+  # Super Bowl
+  - "2025 Super Bowl prediction picks winner"
+  - "Super Bowl LX prediction 2026 picks"
+
+  # MVP and awards
+  - "2025 NFL MVP prediction picks Mahomes"
+  - "2025 NFL awards predictions MVP Offensive Defensive Player"
+
+  # Draft
+  - "2025 NFL draft mock draft predictions round 1"
+  - "2025 NFL mock draft big board picks"
+  - "NFL draft 2025 picks predictions first round"
+
+  # Individual pundit season previews (likely to have testable claims)
+  - "Mel Kiper 2025 NFL predictions picks"
+  - "Peter Schrager 2025 NFL picks predictions"
+  - "Bill Barnwell 2025 NFL predictions"
+  - "Mike Florio 2025 NFL predictions picks"
+
+# Map domains to source IDs
+source_mapping:
+  "espn.com":
+    source_id: espn_nfl
+  "nbcsports.com":
+    source_id: pft_nbc
+  "profootballtalk":
+    source_id: pft_nbc
+  "nfl.com":
+    source_id: nfl_official
+  "cbssports.com":
+    source_id: cbs_nfl
+  "yahoo.com":
+    source_id: yahoo_nfl
+  "si.com":
+    source_id: si_nfl
+  "bleacherreport.com":
+    source_id: bleacher_report
+  "theathletic.com":
+    source_id: theathletic_nfl
+  "theringer.com":
+    source_id: theringer_nfl
+  "foxsports.com":
+    source_id: fox_nfl
+  "nflnetwork.com":
+    source_id: nfl_network
+
+# Domains to skip (non-article content)
+skip_domains:
+  - "youtube.com"
+  - "twitter.com"
+  - "x.com"
+  - "reddit.com"
+  - "facebook.com"
+  - "instagram.com"
+  - "tiktok.com"
+  - "wikipedia.org"
+  - "nflmockdraftdatabase.com"
+  - "drafttek.com"
+  - "walterfootball.com"
+  - "sportsline.com"  # paywalled, low yield
+  - "covers.com"      # betting aggregator

--- a/pipeline/scripts/backtest_precision_report.py
+++ b/pipeline/scripts/backtest_precision_report.py
@@ -1,0 +1,246 @@
+"""
+2025 NFL Season Backtest Precision Report
+
+Queries the prediction ledger and resolution table to measure extraction and
+resolution quality for the 2025 season backtest (issue #245).
+
+Usage:
+    python pipeline/scripts/backtest_precision_report.py
+    python pipeline/scripts/backtest_precision_report.py --season 2025
+    python pipeline/scripts/backtest_precision_report.py --since 2025-01-01
+
+Prerequisites:
+    1. Crawl articles:
+       python -m src.url_ingestor --config config/backtest_2025_seed_urls.yaml --search
+    2. Extract predictions:
+       python -m src.assertion_extractor --limit 500
+    3. Resolve:
+       python -m src.resolve_daily
+    4. Run this report.
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from src.db_manager import DBManager
+
+
+_CATEGORY_ORDER = ["draft_pick", "game_outcome", "player_performance", "contract", "other"]
+
+
+def _run_query(db: DBManager, sql: str) -> pd.DataFrame:
+    """Execute a BigQuery SQL string and return a DataFrame."""
+    return db.fetch_df(sql)
+
+
+def fetch_article_counts(db: DBManager, project_id: str, since: str) -> pd.DataFrame:
+    """Count ingested articles by source type and ingestion date."""
+    return _run_query(
+        db,
+        f"""
+        SELECT
+            fetch_source_type,
+            source_id,
+            DATE(ingested_at) AS ingest_date,
+            COUNT(*) AS article_count
+        FROM `{project_id}.nfl_dead_money.raw_pundit_media`
+        WHERE ingested_at >= TIMESTAMP('{since}')
+        GROUP BY 1, 2, 3
+        ORDER BY 3 DESC, 4 DESC
+        """,
+    )
+
+
+def fetch_prediction_counts(db: DBManager, project_id: str, since: str) -> pd.DataFrame:
+    """Count predictions by category and status for articles ingested since `since`."""
+    return _run_query(
+        db,
+        f"""
+        SELECT
+            claim_category,
+            status,
+            COUNT(*) AS prediction_count,
+            COUNT(DISTINCT pundit_name) AS pundit_count
+        FROM `{project_id}.nfl_dead_money.gold_layer.prediction_ledger`
+        WHERE ingestion_timestamp >= TIMESTAMP('{since}')
+        GROUP BY 1, 2
+        ORDER BY 1, 2
+        """,
+    )
+
+
+def fetch_resolution_summary(db: DBManager, project_id: str, since: str) -> pd.DataFrame:
+    """Summarise resolution outcomes since `since`."""
+    return _run_query(
+        db,
+        f"""
+        SELECT
+            l.claim_category,
+            r.resolution_status,
+            r.resolver,
+            COUNT(*) AS count
+        FROM `{project_id}.nfl_dead_money.gold_layer.prediction_resolutions` r
+        JOIN `{project_id}.nfl_dead_money.gold_layer.prediction_ledger` l
+            ON r.prediction_hash = l.prediction_hash
+        WHERE r.resolved_at >= TIMESTAMP('{since}')
+        GROUP BY 1, 2, 3
+        ORDER BY 1, 4 DESC
+        """,
+    )
+
+
+def fetch_pundit_accuracy(db: DBManager, project_id: str, since: str) -> pd.DataFrame:
+    """Per-pundit accuracy for predictions resolved since `since`."""
+    return _run_query(
+        db,
+        f"""
+        SELECT
+            l.pundit_name,
+            l.claim_category,
+            COUNT(*) AS total_resolved,
+            COUNTIF(r.resolution_status = 'CORRECT') AS correct,
+            COUNTIF(r.resolution_status = 'INCORRECT') AS incorrect,
+            ROUND(
+                SAFE_DIVIDE(
+                    COUNTIF(r.resolution_status = 'CORRECT'),
+                    COUNTIF(r.resolution_status IN ('CORRECT', 'INCORRECT'))
+                ) * 100,
+                1
+            ) AS accuracy_pct
+        FROM `{project_id}.nfl_dead_money.gold_layer.prediction_resolutions` r
+        JOIN `{project_id}.nfl_dead_money.gold_layer.prediction_ledger` l
+            ON r.prediction_hash = l.prediction_hash
+        WHERE r.resolved_at >= TIMESTAMP('{since}')
+          AND l.pundit_name IS NOT NULL
+        GROUP BY 1, 2
+        HAVING total_resolved >= 3
+        ORDER BY 6 DESC, 3 DESC
+        """,
+    )
+
+
+def print_section(title: str, df: pd.DataFrame) -> None:
+    if df.empty:
+        print(f"\n=== {title} ===\n  (no data)\n")
+        return
+    print(f"\n=== {title} ===")
+    print(df.to_string(index=False))
+    print()
+
+
+def compute_precision_metrics(pred_df: pd.DataFrame, res_df: pd.DataFrame) -> dict:
+    """
+    Compute headline precision metrics from prediction and resolution DataFrames.
+
+    Returns dict with:
+      - total_predictions: all predictions ingested
+      - testable: predictions not VOIDED
+      - resolved: predictions with a CORRECT or INCORRECT resolution
+      - precision_pct: resolved / testable * 100
+      - accuracy_pct: CORRECT / (CORRECT + INCORRECT) * 100
+    """
+    if pred_df.empty:
+        return {
+            "total_predictions": 0,
+            "testable": 0,
+            "resolved": 0,
+            "precision_pct": 0.0,
+            "accuracy_pct": None,
+        }
+
+    total = int(pred_df["prediction_count"].sum())
+    voided = int(
+        pred_df.loc[pred_df["status"] == "VOIDED", "prediction_count"].sum()
+    )
+    testable = total - voided
+
+    correct = 0
+    incorrect = 0
+    if not res_df.empty:
+        correct = int(
+            res_df.loc[res_df["resolution_status"] == "CORRECT", "count"].sum()
+        )
+        incorrect = int(
+            res_df.loc[res_df["resolution_status"] == "INCORRECT", "count"].sum()
+        )
+
+    resolved = correct + incorrect
+    precision_pct = round(resolved / testable * 100, 1) if testable else 0.0
+    accuracy_pct = round(correct / resolved * 100, 1) if resolved else None
+
+    return {
+        "total_predictions": total,
+        "testable": testable,
+        "resolved": resolved,
+        "precision_pct": precision_pct,
+        "accuracy_pct": accuracy_pct,
+    }
+
+
+def run_report(since: str = "2025-01-01") -> None:
+    project_id = os.environ.get("GCP_PROJECT_ID", "cap-alpha-protocol")
+    db = DBManager()
+
+    print(f"\n{'='*60}")
+    print(f"  2025 NFL SEASON BACKTEST — PRECISION REPORT")
+    print(f"  Since: {since}")
+    print(f"  Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    print(f"{'='*60}")
+
+    art_df = fetch_article_counts(db, project_id, since)
+    print_section("ARTICLE INGESTION", art_df)
+    total_articles = int(art_df["article_count"].sum()) if not art_df.empty else 0
+    print(f"  Total articles: {total_articles}")
+
+    pred_df = fetch_prediction_counts(db, project_id, since)
+    print_section("PREDICTION EXTRACTION BY CATEGORY", pred_df)
+
+    res_df = fetch_resolution_summary(db, project_id, since)
+    print_section("RESOLUTION OUTCOMES BY CATEGORY", res_df)
+
+    metrics = compute_precision_metrics(pred_df, res_df)
+    print("=== HEADLINE METRICS ===")
+    print(f"  Total predictions extracted : {metrics['total_predictions']}")
+    print(f"  Testable (not voided)       : {metrics['testable']}")
+    print(f"  Resolved (CORRECT+INCORRECT): {metrics['resolved']}")
+    print(f"  Resolution coverage         : {metrics['precision_pct']}%")
+    if metrics["accuracy_pct"] is not None:
+        print(f"  Accuracy (of resolved)      : {metrics['accuracy_pct']}%")
+    else:
+        print("  Accuracy (of resolved)      : N/A (no resolutions yet)")
+
+    acc_df = fetch_pundit_accuracy(db, project_id, since)
+    print_section("PER-PUNDIT ACCURACY (≥3 resolved)", acc_df)
+
+    db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="2025 NFL season backtest precision report"
+    )
+    parser.add_argument(
+        "--season",
+        type=int,
+        default=2025,
+        help="NFL season year (default: 2025)",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Only include data ingested on or after this date (YYYY-MM-DD). "
+        "Defaults to Jan 1 of --season.",
+    )
+    args = parser.parse_args()
+
+    since = args.since or f"{args.season}-01-01"
+    run_report(since=since)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/tests/test_backtest_precision_report.py
+++ b/pipeline/tests/test_backtest_precision_report.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the 2025 season backtest precision report (issue #245).
+No BigQuery required — all DB calls are mocked.
+"""
+
+import pandas as pd
+import pytest
+
+from scripts.backtest_precision_report import compute_precision_metrics
+
+
+# ---------------------------------------------------------------------------
+# compute_precision_metrics
+# ---------------------------------------------------------------------------
+
+
+def _make_pred_df(rows: list[dict]) -> pd.DataFrame:
+    """Build a prediction_count DataFrame like the one returned by fetch_prediction_counts."""
+    return pd.DataFrame(
+        rows,
+        columns=["claim_category", "status", "prediction_count", "pundit_count"],
+    )
+
+
+def _make_res_df(rows: list[dict]) -> pd.DataFrame:
+    """Build a resolution summary DataFrame like the one returned by fetch_resolution_summary."""
+    return pd.DataFrame(
+        rows,
+        columns=["claim_category", "resolution_status", "resolver", "count"],
+    )
+
+
+def test_no_data_returns_zeros():
+    metrics = compute_precision_metrics(pd.DataFrame(), pd.DataFrame())
+    assert metrics["total_predictions"] == 0
+    assert metrics["testable"] == 0
+    assert metrics["resolved"] == 0
+    assert metrics["precision_pct"] == 0.0
+    assert metrics["accuracy_pct"] is None
+
+
+def test_all_pending_no_resolutions():
+    pred_df = _make_pred_df(
+        [
+            ("draft_pick", "PENDING", 10, 3),
+            ("game_outcome", "PENDING", 5, 2),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, pd.DataFrame())
+    assert metrics["total_predictions"] == 15
+    assert metrics["testable"] == 15
+    assert metrics["resolved"] == 0
+    assert metrics["precision_pct"] == 0.0
+    assert metrics["accuracy_pct"] is None
+
+
+def test_voided_excluded_from_testable():
+    pred_df = _make_pred_df(
+        [
+            ("draft_pick", "PENDING", 8, 2),
+            ("draft_pick", "VOIDED", 2, 1),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, pd.DataFrame())
+    assert metrics["total_predictions"] == 10
+    assert metrics["testable"] == 8  # VOIDED excluded
+
+
+def test_precision_and_accuracy():
+    pred_df = _make_pred_df(
+        [
+            ("draft_pick", "PENDING", 100, 5),
+        ]
+    )
+    res_df = _make_res_df(
+        [
+            ("draft_pick", "CORRECT", "auto", 60),
+            ("draft_pick", "INCORRECT", "auto", 40),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, res_df)
+    assert metrics["total_predictions"] == 100
+    assert metrics["testable"] == 100
+    assert metrics["resolved"] == 100
+    assert metrics["precision_pct"] == 100.0
+    assert metrics["accuracy_pct"] == 60.0
+
+
+def test_partial_resolution():
+    pred_df = _make_pred_df(
+        [
+            ("game_outcome", "PENDING", 200, 8),
+            ("game_outcome", "VOIDED", 20, 3),
+        ]
+    )
+    res_df = _make_res_df(
+        [
+            ("game_outcome", "CORRECT", "auto", 50),
+            ("game_outcome", "INCORRECT", "auto", 30),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, res_df)
+    assert metrics["total_predictions"] == 220
+    assert metrics["testable"] == 200  # 220 - 20 voided
+    assert metrics["resolved"] == 80  # 50 + 30
+    assert metrics["precision_pct"] == 40.0  # 80/200
+    assert metrics["accuracy_pct"] == 62.5  # 50/80
+
+
+def test_mixed_categories():
+    pred_df = _make_pred_df(
+        [
+            ("draft_pick", "PENDING", 50, 5),
+            ("game_outcome", "PENDING", 30, 4),
+            ("player_performance", "VOIDED", 10, 2),
+        ]
+    )
+    res_df = _make_res_df(
+        [
+            ("draft_pick", "CORRECT", "auto", 20),
+            ("draft_pick", "INCORRECT", "auto", 10),
+            ("game_outcome", "CORRECT", "auto", 15),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, res_df)
+    assert metrics["total_predictions"] == 90
+    assert metrics["testable"] == 80  # 90 - 10 voided
+    assert metrics["resolved"] == 45  # 20+10+15
+    assert metrics["precision_pct"] == 56.2  # 45/80 * 100 rounded
+    assert metrics["accuracy_pct"] == 77.8  # 35/45 * 100 rounded
+
+
+def test_zero_testable_no_division_error():
+    pred_df = _make_pred_df(
+        [
+            ("draft_pick", "VOIDED", 10, 2),
+        ]
+    )
+    res_df = _make_res_df(
+        [
+            ("draft_pick", "CORRECT", "auto", 5),
+        ]
+    )
+    metrics = compute_precision_metrics(pred_df, res_df)
+    assert metrics["testable"] == 0
+    assert metrics["precision_pct"] == 0.0
+
+
+def test_accuracy_none_when_no_resolutions():
+    pred_df = _make_pred_df([("draft_pick", "PENDING", 10, 2)])
+    metrics = compute_precision_metrics(pred_df, pd.DataFrame())
+    assert metrics["accuracy_pct"] is None
+
+
+def test_accuracy_none_when_only_voided_resolutions():
+    pred_df = _make_pred_df([("draft_pick", "PENDING", 10, 2)])
+    res_df = _make_res_df([("draft_pick", "VOID", "auto", 5)])
+    metrics = compute_precision_metrics(pred_df, res_df)
+    # VOID resolution_status not CORRECT or INCORRECT → resolved = 0
+    assert metrics["resolved"] == 0
+    assert metrics["accuracy_pct"] is None


### PR DESCRIPTION
## Summary

- **`pipeline/config/backtest_2025_seed_urls.yaml`** — 17 DuckDuckGo search queries covering 2025 NFL preseason picks, win totals, playoff predictions, Super Bowl, MVP, draft, and individual pundit season previews. Works with `python -m src.url_ingestor --config config/backtest_2025_seed_urls.yaml --search`.
- **`pipeline/scripts/backtest_precision_report.py`** — BigQuery precision/recall report for the 2025 season backtest. Measures extraction quality and resolution accuracy with headline metrics + per-pundit accuracy table. Accepts `--season` and `--since` flags.
- **`pipeline/tests/test_backtest_precision_report.py`** — 9 unit tests for `compute_precision_metrics`; no BigQuery required.

Closes #245

## How to run the full backtest

```bash
# 1. Crawl 2025 season prediction articles
python -m src.url_ingestor --config config/backtest_2025_seed_urls.yaml --search

# 2. Extract predictions (all outcomes known; 2025 season complete)
python -m src.assertion_extractor --limit 500

# 3. Resolve against known outcomes
python -m src.resolve_daily

# 4. Measure precision
python pipeline/scripts/backtest_precision_report.py --season 2025
```

## Notes

- `url_ingestor` was added in PR #238; this PR is standalone on `main` and does not require #238.
- The seed config queries all include words like "prediction" / "picks" to pass the existing title keyword filter in `url_ingestor.discover_articles`.

## Test plan

- [x] 9 unit tests pass: `pytest pipeline/tests/test_backtest_precision_report.py`
- [x] Full suite: 529 passed, 24 skipped
- [x] Ruff lint + format check clean
- [ ] End-to-end run (requires Ollama + BQ billing — operational step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)