### PR TITLE
feat(api): Upstash rate limiting + API key auth middleware (#144)

### DIFF
--- a/web/lib/__tests__/api-key-auth.test.ts
+++ b/web/lib/__tests__/api-key-auth.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for authenticateApiRequest.
+ *
+ * All external dependencies (BigQuery, Upstash, Clerk) are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.hoisted ensures these are available inside vi.mock() factories,
+// which are hoisted above regular imports by vitest.
+const { mockVerifyKey, mockGetUserTier, mockCheckRateLimit, mockBuildRateLimitHeaders } =
+    vi.hoisted(() => ({
+        mockVerifyKey: vi.fn(),
+        mockGetUserTier: vi.fn(),
+        mockCheckRateLimit: vi.fn(),
+        mockBuildRateLimitHeaders: vi.fn(),
+    }));
+
+vi.mock("@/lib/api-keys/repository", () => ({
+    verifyKey: mockVerifyKey,
+}));
+
+vi.mock("@/lib/api-keys/tiers", () => ({
+    getUserTier: mockGetUserTier,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+    checkRateLimit: mockCheckRateLimit,
+    buildRateLimitHeaders: mockBuildRateLimitHeaders,
+}));
+
+import { authenticateApiRequest } from "../api-key-auth";
+
+// Helpers for building mock Request objects
+function makeRequest(authHeader?: string): Request {
+    const headers: Record<string, string> = {};
+    if (authHeader !== undefined) headers["Authorization"] = authHeader;
+    return new Request("https://api.cap-alpha.co/v1/pundits", { headers });
+}
+
+const ACTIVE_KEY = {
+    keyId: "capk_live_abc123",
+    userId: "user_xyz",
+    status: "active",
+};
+
+const DEFAULT_RATE_LIMIT = {
+    success: true,
+    limit: 100,
+    remaining: 99,
+    reset: Math.floor(Date.now() / 1000) + 60,
+};
+
+const DEFAULT_HEADERS = {
+    "X-RateLimit-Limit": "100",
+    "X-RateLimit-Remaining": "99",
+    "X-RateLimit-Reset": String(DEFAULT_RATE_LIMIT.reset),
+};
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetUserTier.mockResolvedValue("free");
+    mockCheckRateLimit.mockResolvedValue(DEFAULT_RATE_LIMIT);
+    mockBuildRateLimitHeaders.mockReturnValue(DEFAULT_HEADERS);
+});
+
+// ── Missing / malformed Authorization header ──────────────────────────────────
+
+describe("authenticateApiRequest — missing/invalid auth header", () => {
+    it("returns 401 when Authorization header is absent", async () => {
+        const auth = await authenticateApiRequest(makeRequest());
+        expect(auth.ok).toBe(false);
+        if (!auth.ok) {
+            expect(auth.response.status).toBe(401);
+        }
+    });
+
+    it("returns 401 when Authorization header lacks 'Bearer ' prefix", async () => {
+        const auth = await authenticateApiRequest(
+            makeRequest("Token capk_live_abc123")
+        );
+        expect(auth.ok).toBe(false);
+        if (!auth.ok) expect(auth.response.status).toBe(401);
+    });
+
+    it("returns 401 for an empty Bearer value", async () => {
+        const auth = await authenticateApiRequest(makeRequest("Bearer "));
+        // verifyKey returns null for invalid key
+        mockVerifyKey.mockResolvedValueOnce(null);
+        // (header is technically valid format, so verifyKey is called)
+    });
+
+    it("does not call verifyKey when header is absent", async () => {
+        await authenticateApiRequest(makeRequest());
+        expect(mockVerifyKey).not.toHaveBeenCalled();
+    });
+});
+
+// ── Invalid / revoked keys ────────────────────────────────────────────────────
+
+describe("authenticateApiRequest — invalid or revoked key", () => {
+    it("returns 401 when verifyKey returns null", async () => {
+        mockVerifyKey.mockResolvedValueOnce(null);
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_bad")
+        );
+        expect(auth.ok).toBe(false);
+        if (!auth.ok) expect(auth.response.status).toBe(401);
+    });
+
+    it("returns 401 when key status is 'revoked'", async () => {
+        mockVerifyKey.mockResolvedValueOnce({
+            ...ACTIVE_KEY,
+            status: "revoked",
+        });
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_abc123")
+        );
+        expect(auth.ok).toBe(false);
+        if (!auth.ok) expect(auth.response.status).toBe(401);
+    });
+
+    it("does not check rate limit for invalid keys", async () => {
+        mockVerifyKey.mockResolvedValueOnce(null);
+        await authenticateApiRequest(makeRequest("Bearer capk_live_bad"));
+        expect(mockCheckRateLimit).not.toHaveBeenCalled();
+    });
+});
+
+// ── Rate limit exceeded ───────────────────────────────────────────────────────
+
+describe("authenticateApiRequest — rate limit exceeded", () => {
+    it("returns 429 when rate limit is exceeded", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+        mockCheckRateLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: Math.floor(Date.now() / 1000) + 30,
+            retryAfter: 30,
+        });
+        mockBuildRateLimitHeaders.mockReturnValueOnce({
+            "X-RateLimit-Limit": "100",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 30),
+            "Retry-After": "30",
+        });
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_abc123")
+        );
+        expect(auth.ok).toBe(false);
+        if (!auth.ok) expect(auth.response.status).toBe(429);
+    });
+
+    it("includes retryAfter in the 429 response body", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+        mockCheckRateLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: Math.floor(Date.now() / 1000) + 30,
+            retryAfter: 30,
+        });
+        mockBuildRateLimitHeaders.mockReturnValueOnce({
+            "Retry-After": "30",
+        });
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_abc123")
+        );
+        if (!auth.ok) {
+            const body = await auth.response.json();
+            expect(body.error).toMatch(/rate limit/i);
+            expect(body.retryAfter).toBe(30);
+        }
+    });
+});
+
+// ── Successful authentication ─────────────────────────────────────────────────
+
+describe("authenticateApiRequest — success", () => {
+    it("returns ok=true with keyId, userId, and tier", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_abc123")
+        );
+        expect(auth.ok).toBe(true);
+        if (auth.ok) {
+            expect(auth.keyId).toBe("capk_live_abc123");
+            expect(auth.userId).toBe("user_xyz");
+            expect(auth.tier).toBe("free");
+        }
+    });
+
+    it("returns rateLimitHeaders for the caller to forward", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+
+        const auth = await authenticateApiRequest(
+            makeRequest("Bearer capk_live_abc123")
+        );
+        if (auth.ok) {
+            expect(auth.rateLimitHeaders).toMatchObject({
+                "X-RateLimit-Limit": expect.any(String),
+                "X-RateLimit-Remaining": expect.any(String),
+                "X-RateLimit-Reset": expect.any(String),
+            });
+        }
+    });
+
+    it("uses the user's tier when checking rate limit", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+        mockGetUserTier.mockResolvedValueOnce("pro");
+
+        await authenticateApiRequest(makeRequest("Bearer capk_live_abc123"));
+
+        expect(mockCheckRateLimit).toHaveBeenCalledWith(
+            ACTIVE_KEY.keyId,
+            "pro"
+        );
+    });
+
+    it("passes the keyId (not userId) as the rate limit identifier", async () => {
+        mockVerifyKey.mockResolvedValueOnce(ACTIVE_KEY);
+
+        await authenticateApiRequest(makeRequest("Bearer capk_live_abc123"));
+
+        const [callKeyId] = mockCheckRateLimit.mock.calls[0];
+        expect(callKeyId).toBe(ACTIVE_KEY.keyId);
+        expect(callKeyId).not.toBe(ACTIVE_KEY.userId);
+    });
+});

--- a/web/lib/__tests__/rate-limit.test.ts
+++ b/web/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for the rate limiting utility.
+ *
+ * @upstash/ratelimit and @upstash/redis are mocked. Two test groups:
+ *   1. Fail-open  — no UPSTASH env vars → all requests succeed, limit from tier config.
+ *   2. With Upstash — env vars set → Ratelimit.limit() is called, results propagated.
+ *
+ * The fail-open group runs FIRST (before env vars are set) to avoid the
+ * module-level Redis singleton being populated prematurely.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+
+// Mock Upstash before any import of rate-limit.ts
+const mockLimit = vi.fn();
+
+vi.mock("@upstash/ratelimit", () => ({
+    Ratelimit: class MockRatelimit {
+        limit = mockLimit;
+        constructor(_opts: unknown) {}
+        static slidingWindow(_count: number, _window: string) {
+            return { type: "slidingWindow", _count, _window };
+        }
+    },
+}));
+
+vi.mock("@upstash/redis", () => ({
+    Redis: class MockRedis {
+        constructor(_opts: unknown) {}
+    },
+}));
+
+import {
+    checkRateLimit,
+    buildRateLimitHeaders,
+    TIER_RATE_LIMITS,
+} from "../rate-limit";
+
+// ── Tier limit constants ──────────────────────────────────────────────────────
+
+describe("TIER_RATE_LIMITS", () => {
+    it("defines all tiers with positive per-minute limits", () => {
+        const tiers = [
+            "free",
+            "pro",
+            "api_starter",
+            "api_growth",
+            "enterprise",
+        ] as const;
+        for (const tier of tiers) {
+            expect(TIER_RATE_LIMITS[tier]).toBeGreaterThan(0);
+        }
+    });
+
+    it("enforces ascending order: free < pro < api_starter < api_growth < enterprise", () => {
+        expect(TIER_RATE_LIMITS.free).toBeLessThan(TIER_RATE_LIMITS.pro);
+        expect(TIER_RATE_LIMITS.pro).toBeLessThan(TIER_RATE_LIMITS.api_starter);
+        expect(TIER_RATE_LIMITS.api_starter).toBeLessThan(
+            TIER_RATE_LIMITS.api_growth
+        );
+        expect(TIER_RATE_LIMITS.api_growth).toBeLessThan(
+            TIER_RATE_LIMITS.enterprise
+        );
+    });
+
+    it("free tier allows 100 req/min", () => {
+        expect(TIER_RATE_LIMITS.free).toBe(100);
+    });
+
+    it("pro tier allows 1000 req/min", () => {
+        expect(TIER_RATE_LIMITS.pro).toBe(1_000);
+    });
+
+    it("api_starter tier allows 10,000 req/min", () => {
+        expect(TIER_RATE_LIMITS.api_starter).toBe(10_000);
+    });
+
+    it("api_growth tier allows 100,000 req/min", () => {
+        expect(TIER_RATE_LIMITS.api_growth).toBe(100_000);
+    });
+});
+
+// ── Fail-open (no Upstash configured) ────────────────────────────────────────
+// These must run before env vars are set so _redis singleton stays null.
+
+describe("checkRateLimit — fail-open when UPSTASH env vars are absent", () => {
+    it("returns success=true for free tier", async () => {
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.success).toBe(true);
+    });
+
+    it("reports limit equal to tier's per-minute cap", async () => {
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.limit).toBe(TIER_RATE_LIMITS.free);
+        expect(result.remaining).toBe(TIER_RATE_LIMITS.free);
+    });
+
+    it("reports limit equal to pro tier cap", async () => {
+        const result = await checkRateLimit("capk_live_pro", "pro");
+        expect(result.limit).toBe(TIER_RATE_LIMITS.pro);
+    });
+
+    it("returns a reset timestamp ~60 s in the future", async () => {
+        const before = Math.floor(Date.now() / 1000);
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.reset).toBeGreaterThanOrEqual(before + 59);
+        expect(result.reset).toBeLessThanOrEqual(before + 61);
+    });
+
+    it("does not set retryAfter when allowing", async () => {
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.retryAfter).toBeUndefined();
+    });
+
+    it("never calls Ratelimit.limit() when Upstash is absent", async () => {
+        await checkRateLimit("capk_live_abc", "free");
+        expect(mockLimit).not.toHaveBeenCalled();
+    });
+});
+
+// ── With Upstash configured ───────────────────────────────────────────────────
+
+describe("checkRateLimit — with Upstash", () => {
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    beforeAll(() => {
+        process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io";
+        process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+        mockLimit.mockReset();
+    });
+
+    afterAll(() => {
+        process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+        process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    });
+
+    it("returns success=true and remaining count when under the limit", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) + 60) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: true,
+            limit: 100,
+            remaining: 75,
+            reset: resetMs,
+        });
+
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(75);
+        expect(result.retryAfter).toBeUndefined();
+    });
+
+    it("returns success=false with retryAfter when the limit is exceeded", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) + 30) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: resetMs,
+        });
+
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.success).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.retryAfter).toBeGreaterThan(0);
+        expect(result.retryAfter).toBeLessThanOrEqual(30);
+    });
+
+    it("sets retryAfter=0 when reset is in the past (clock skew)", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) - 5) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: resetMs,
+        });
+
+        const result = await checkRateLimit("capk_live_abc", "free");
+        expect(result.retryAfter).toBe(0);
+    });
+
+    it("forwards the keyId to Ratelimit.limit()", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) + 60) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: true,
+            limit: 1000,
+            remaining: 999,
+            reset: resetMs,
+        });
+
+        await checkRateLimit("capk_live_mykey", "pro");
+        expect(mockLimit).toHaveBeenCalledWith("capk_live_mykey");
+    });
+});
+
+// ── buildRateLimitHeaders ─────────────────────────────────────────────────────
+
+describe("buildRateLimitHeaders", () => {
+    it("includes X-RateLimit-Limit, Remaining, and Reset on success", () => {
+        const headers = buildRateLimitHeaders({
+            success: true,
+            limit: 100,
+            remaining: 50,
+            reset: 1_700_000_000,
+        }) as Record<string, string>;
+
+        expect(headers["X-RateLimit-Limit"]).toBe("100");
+        expect(headers["X-RateLimit-Remaining"]).toBe("50");
+        expect(headers["X-RateLimit-Reset"]).toBe("1700000000");
+        expect(headers["Retry-After"]).toBeUndefined();
+    });
+
+    it("includes Retry-After when retryAfter is set", () => {
+        const headers = buildRateLimitHeaders({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: 1_700_000_030,
+            retryAfter: 30,
+        }) as Record<string, string>;
+
+        expect(headers["Retry-After"]).toBe("30");
+    });
+
+    it("Retry-After is 0 when retryAfter=0", () => {
+        const headers = buildRateLimitHeaders({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: 1_700_000_000,
+            retryAfter: 0,
+        }) as Record<string, string>;
+
+        expect(headers["Retry-After"]).toBe("0");
+    });
+
+    it("all header values are strings", () => {
+        const headers = buildRateLimitHeaders({
+            success: true,
+            limit: 1000,
+            remaining: 999,
+            reset: 1_700_000_000,
+        }) as Record<string, string>;
+
+        for (const val of Object.values(headers)) {
+            expect(typeof val).toBe("string");
+        }
+    });
+});

--- a/web/lib/api-key-auth.ts
+++ b/web/lib/api-key-auth.ts
@@ -1,0 +1,106 @@
+/**
+ * API key authentication + rate limiting for public API routes.
+ *
+ * Usage in a Next.js API route handler:
+ *
+ *   import { authenticateApiRequest } from "@/lib/api-key-auth";
+ *
+ *   export async function GET(req: Request) {
+ *     const auth = await authenticateApiRequest(req);
+ *     if (!auth.ok) return auth.response;
+ *     // auth.userId, auth.keyId, auth.tier, auth.rateLimitHeaders are available
+ *     const data = await fetchData(auth.userId);
+ *     return NextResponse.json(data, { headers: auth.rateLimitHeaders });
+ *   }
+ */
+import { NextResponse } from "next/server";
+import { verifyKey } from "@/lib/api-keys/repository";
+import { getUserTier } from "@/lib/api-keys/tiers";
+import { checkRateLimit, buildRateLimitHeaders } from "@/lib/rate-limit";
+import type { Tier } from "@/lib/api-keys/tiers";
+
+export interface AuthSuccess {
+    ok: true;
+    keyId: string;
+    userId: string;
+    tier: Tier;
+    /** Include these headers on the successful response. */
+    rateLimitHeaders: HeadersInit;
+}
+
+export interface AuthFailure {
+    ok: false;
+    /** Return this response directly to the client. */
+    response: NextResponse;
+}
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+/**
+ * Authenticate an API request using a Bearer token.
+ *
+ * Steps:
+ *   1. Extract `Authorization: Bearer <key>` from the request.
+ *   2. Verify the key against BigQuery.
+ *   3. Look up the user's subscription tier.
+ *   4. Check the sliding-window rate limit via Upstash.
+ *   5. Return the authenticated context or an appropriate error response.
+ */
+export async function authenticateApiRequest(
+    req: Request
+): Promise<AuthResult> {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                {
+                    error: "Missing or invalid Authorization header.",
+                    hint: "Use: Authorization: Bearer <api-key>",
+                },
+                { status: 401 }
+            ),
+        };
+    }
+
+    const plaintextKey = authHeader.slice(7); // strip "Bearer "
+
+    const keyData = await verifyKey(plaintextKey);
+    if (!keyData || keyData.status !== "active") {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                { error: "Invalid or revoked API key." },
+                { status: 401 }
+            ),
+        };
+    }
+
+    const tier = await getUserTier(keyData.userId);
+    const rateLimitResult = await checkRateLimit(keyData.keyId, tier);
+    const rateLimitHeaders = buildRateLimitHeaders(rateLimitResult);
+
+    if (!rateLimitResult.success) {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                {
+                    error: "Rate limit exceeded.",
+                    limit: rateLimitResult.limit,
+                    remaining: 0,
+                    reset: rateLimitResult.reset,
+                    retryAfter: rateLimitResult.retryAfter,
+                },
+                { status: 429, headers: rateLimitHeaders }
+            ),
+        };
+    }
+
+    return {
+        ok: true,
+        keyId: keyData.keyId,
+        userId: keyData.userId,
+        tier,
+        rateLimitHeaders,
+    };
+}

--- a/web/lib/api-keys/tiers.ts
+++ b/web/lib/api-keys/tiers.ts
@@ -5,7 +5,7 @@
  * Per-tier key caps are enforced on key creation.
  */
 
-export type Tier = "free" | "pro" | "api_starter" | "enterprise";
+export type Tier = "free" | "pro" | "api_starter" | "api_growth" | "enterprise";
 
 interface TierConfig {
     maxKeys: number;
@@ -15,6 +15,7 @@ const TIER_CONFIGS: Record<Tier, TierConfig> = {
     free: { maxKeys: 1 },
     pro: { maxKeys: 3 },
     api_starter: { maxKeys: 10 },
+    api_growth: { maxKeys: 20 },
     enterprise: { maxKeys: 25 },
 };
 

--- a/web/lib/rate-limit.ts
+++ b/web/lib/rate-limit.ts
@@ -1,0 +1,126 @@
+/**
+ * Rate limiting infrastructure using Upstash Redis.
+ *
+ * Implements tiered sliding-window rate limits (per minute).
+ * Gracefully degrades (fail-open) when UPSTASH_REDIS_REST_URL is not
+ * configured, so the API remains available before Upstash is provisioned.
+ *
+ * Issue: #144
+ */
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import type { Tier } from "@/lib/api-keys/tiers";
+
+export interface RateLimitResult {
+    success: boolean;
+    limit: number;
+    remaining: number;
+    /** Unix timestamp (seconds) when the current window resets */
+    reset: number;
+    /** Seconds to wait before retrying — only set when success=false */
+    retryAfter?: number;
+}
+
+/** Per-minute request limits by tier */
+export const TIER_RATE_LIMITS: Record<Tier, number> = {
+    free: 100,
+    pro: 1_000,
+    api_starter: 10_000,
+    api_growth: 100_000,
+    enterprise: 1_000_000, // effectively unlimited
+};
+
+// Module-level cache — only populated when UPSTASH env vars are present.
+// Re-checked on every call when env vars are absent (fail-open path).
+let _redis: Redis | null = null;
+const _limiters = new Map<Tier, Ratelimit>();
+
+function getRedis(): Redis | null {
+    if (_redis !== null) return _redis;
+
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    if (!url || !token) {
+        // Env vars absent — do NOT cache null so we re-check on each call.
+        return null;
+    }
+
+    _redis = new Redis({ url, token });
+    return _redis;
+}
+
+function getLimiter(tier: Tier): Ratelimit | null {
+    const redis = getRedis();
+    if (!redis) return null;
+
+    if (_limiters.has(tier)) return _limiters.get(tier)!;
+
+    const limiter = new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(TIER_RATE_LIMITS[tier], "60 s"),
+        prefix: `rl:${tier}`,
+        analytics: true,
+    });
+
+    _limiters.set(tier, limiter);
+    return limiter;
+}
+
+/**
+ * Check the rate limit for an API key.
+ *
+ * @param keyId - The API key ID used as the per-key rate limit identifier.
+ * @param tier  - The user's subscription tier.
+ * @returns Result with success flag and values for rate limit response headers.
+ */
+export async function checkRateLimit(
+    keyId: string,
+    tier: Tier
+): Promise<RateLimitResult> {
+    const limiter = getLimiter(tier);
+    const limit = TIER_RATE_LIMITS[tier];
+
+    // Fail-open: allow all requests if Upstash is not configured.
+    if (!limiter) {
+        return {
+            success: true,
+            limit,
+            remaining: limit,
+            reset: Math.floor(Date.now() / 1000) + 60,
+        };
+    }
+
+    const result = await limiter.limit(keyId);
+    const resetSeconds = Math.floor(result.reset / 1000);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    return {
+        success: result.success,
+        limit: result.limit,
+        remaining: result.remaining,
+        reset: resetSeconds,
+        ...(result.success
+            ? {}
+            : { retryAfter: Math.max(0, resetSeconds - nowSeconds) }),
+    };
+}
+
+/**
+ * Build rate limit response headers from a RateLimitResult.
+ *
+ * Include these on every API response so clients can self-throttle.
+ */
+export function buildRateLimitHeaders(result: RateLimitResult): HeadersInit {
+    const headers: Record<string, string> = {
+        "X-RateLimit-Limit": String(result.limit),
+        "X-RateLimit-Remaining": String(result.remaining),
+        "X-RateLimit-Reset": String(result.reset),
+    };
+
+    if (result.retryAfter !== undefined) {
+        headers["Retry-After"] = String(result.retryAfter);
+    }
+
+    return headers;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,6 +27,8 @@
                 "@radix-ui/react-tooltip": "^1.2.8",
                 "@tanstack/react-query": "^5.90.20",
                 "@tanstack/react-table": "^8.21.3",
+                "@upstash/ratelimit": "^2.0.8",
+                "@upstash/redis": "^1.37.0",
                 "@vercel/postgres": "^0.10.0",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
@@ -5273,6 +5275,39 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@upstash/core-analytics": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+            "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@upstash/redis": "^1.28.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@upstash/ratelimit": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+            "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@upstash/core-analytics": "^0.0.10"
+            },
+            "peerDependencies": {
+                "@upstash/redis": "^1.34.3"
+            }
+        },
+        "node_modules/@upstash/redis": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+            "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+            "license": "MIT",
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
         },
         "node_modules/@vercel/backends": {
             "version": "0.0.46",
@@ -18292,6 +18327,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "6.24.1",

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,8 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-table": "^8.21.3",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.37.0",
         "@vercel/postgres": "^0.10.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary

- **`web/lib/rate-limit.ts`** — tiered sliding-window rate limiter using `@upstash/ratelimit`. Limits per tier (req/min): free=100, pro=1k, api_starter=10k, api_growth=100k, enterprise=1M. Gracefully fail-opens (allow-all) when `UPSTASH_REDIS_REST_URL` is absent so the API stays available before Upstash is provisioned. `buildRateLimitHeaders()` returns `X-RateLimit-Limit/Remaining/Reset` + `Retry-After`.
- **`web/lib/api-key-auth.ts`** — `authenticateApiRequest(req)` helper for any paid API route. Extracts `Authorization: Bearer <key>`, verifies via BigQuery, resolves user tier, checks rate limit, returns 401/429 or an `AuthSuccess` with `rateLimitHeaders` to forward.
- **`web/lib/api-keys/tiers.ts`** — adds `api_growth` tier (20 max keys, 100k req/min) per issue spec.
- **`@upstash/ratelimit` + `@upstash/redis`** added to `web/package.json`.
- **33 unit tests** — all mocked, no live Upstash or BQ required. Covers: tier ordering, fail-open behavior, Upstash success/throttle paths, header construction, auth 401/429/success flows.

Closes #144

## Test plan

- [x] `npx vitest run lib/__tests__/rate-limit.test.ts lib/__tests__/api-key-auth.test.ts` — 33 tests pass
- [x] Existing `lib/api-keys/__tests__/` suite — 44 tests pass (no regression)
- [x] `tsc --noEmit` — no type errors
- [ ] Load test (200 req/60s free-tier key) — requires `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` in Vercel (see issue #144 provisioning steps)

## Integration

To use in an API route:

```typescript
import { authenticateApiRequest } from "@/lib/api-key-auth";

export async function GET(req: Request) {
  const auth = await authenticateApiRequest(req);
  if (!auth.ok) return auth.response; // 401 or 429 already built
  const data = await fetchData(auth.userId);
  return NextResponse.json(data, { headers: auth.rateLimitHeaders });
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)