### PR TITLE
fix(web): graceful degradation when Clerk env vars missing

### DIFF
--- a/web/components/auth-interstitial.tsx
+++ b/web/components/auth-interstitial.tsx
@@ -1,11 +1,26 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth, SignIn } from "@clerk/nextjs";
+
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+// Dynamically import Clerk components only if configured
+let useAuth: any = null;
+let SignIn: any = null;
+
+if (hasClerkConfig) {
+    const clerk = require("@clerk/nextjs");
+    useAuth = clerk.useAuth;
+    SignIn = clerk.SignIn;
+}
 
 export function AuthInterstitial() {
-    const { isLoaded, isSignedIn } = useAuth();
+    const clerkAuth = hasClerkConfig && useAuth ? useAuth() : { isLoaded: true, isSignedIn: false };
+    const { isLoaded, isSignedIn } = clerkAuth;
     const [showSignIn, setShowSignIn] = useState(false);
+
+    // Don't show interstitial if Clerk is not configured
+    if (!hasClerkConfig) return null;
 
     useEffect(() => {
         if (!isLoaded) return;

--- a/web/components/navbar.tsx
+++ b/web/components/navbar.tsx
@@ -2,14 +2,28 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { UserButton, useUser, SignInButton } from "@clerk/nextjs";
 import { GlobalSearch } from "./global-search";
 import { useState, useEffect } from "react";
 import { useTeam } from "./team-context";
 
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+// Dynamically import Clerk components only if configured
+let UserButton: any = null;
+let SignInButton: any = null;
+let useUser: any = null;
+
+if (hasClerkConfig) {
+    const clerk = require("@clerk/nextjs");
+    UserButton = clerk.UserButton;
+    SignInButton = clerk.SignInButton;
+    useUser = clerk.useUser;
+}
+
 export function Navbar() {
     const pathname = usePathname();
-    const { isSignedIn, isLoaded } = useUser();
+    const clerkUser = hasClerkConfig && useUser ? useUser() : { isSignedIn: false, isLoaded: true };
+    const { isSignedIn, isLoaded } = clerkUser;
     const { activeTeam, setTeamSelectorOpen } = useTeam();
     const [isScrolled, setIsScrolled] = useState(false);
 
@@ -83,9 +97,9 @@ export function Navbar() {
 
                 <div className="flex items-center gap-4">
                     <GlobalSearch />
-                    
-                    {/* Auth */}
-                    {isLoaded && (
+
+                    {/* Auth - only show if Clerk is configured */}
+                    {hasClerkConfig && isLoaded && (
                         isSignedIn ? (
                             <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: "w-9 h-9 border border-emerald-500/50" } }} />
                         ) : (

--- a/web/components/persona-switcher.tsx
+++ b/web/components/persona-switcher.tsx
@@ -4,12 +4,24 @@ import React from "react";
 import { usePersona, Persona } from "./persona-context";
 import { Activity, CircleDollarSign, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useAuth, SignInButton } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
+
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+// Dynamically import Clerk components only if configured
+let useAuth: any = null;
+let SignInButton: any = null;
+
+if (hasClerkConfig) {
+    const clerk = require("@clerk/nextjs");
+    useAuth = clerk.useAuth;
+    SignInButton = clerk.SignInButton;
+}
 
 export default function PersonaSwitcher() {
     const { persona, setPersona } = usePersona();
-    const { isSignedIn } = useAuth();
+    const clerkAuth = hasClerkConfig && useAuth ? useAuth() : { isSignedIn: false };
+    const { isSignedIn } = clerkAuth;
     const router = useRouter();
 
     const options: { id: Persona; label: string; icon: React.ReactNode; isPro: boolean; path: string }[] = [
@@ -47,11 +59,15 @@ export default function PersonaSwitcher() {
                 );
 
                 if (option.isPro && !isSignedIn) {
-                    return (
-                        <SignInButton key={option.id} mode="modal" fallbackRedirectUrl={option.path}>
-                            {ButtonContent}
-                        </SignInButton>
-                    );
+                    // Only wrap with SignInButton if Clerk is configured
+                    if (hasClerkConfig && SignInButton) {
+                        return (
+                            <SignInButton key={option.id} mode="modal" fallbackRedirectUrl={option.path}>
+                                {ButtonContent}
+                            </SignInButton>
+                        );
+                    }
+                    return ButtonContent;
                 }
 
                 return ButtonContent;

--- a/web/components/providers.tsx
+++ b/web/components/providers.tsx
@@ -6,7 +6,20 @@ import { PersonaProvider } from "@/components/persona-context";
 import { TeamProvider } from "@/components/team-context";
 import { ReactNode } from "react";
 
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
 export function Providers({ children }: { children: ReactNode }) {
+    // Skip ClerkProvider if Clerk is not configured
+    if (!hasClerkConfig) {
+        return (
+            <TeamProvider>
+                <PersonaProvider>
+                    {children}
+                </PersonaProvider>
+            </TeamProvider>
+        );
+    }
+
     return (
         <ClerkProvider
             appearance={{

--- a/web/components/save-scenario-button.tsx
+++ b/web/components/save-scenario-button.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { useState } from "react";
-import { useUser, SignInButton } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import { Save, Loader2 } from "lucide-react";
 import {
@@ -17,6 +16,18 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+// Dynamically import Clerk components only if configured
+let useUser: any = null;
+let SignInButton: any = null;
+
+if (hasClerkConfig) {
+    const clerk = require("@clerk/nextjs");
+    useUser = clerk.useUser;
+    SignInButton = clerk.SignInButton;
+}
+
 interface SaveScenarioButtonProps {
     rosterState: any; // The current state of the roster (post-cuts)
     // @ts-ignore
@@ -25,7 +36,8 @@ interface SaveScenarioButtonProps {
 
 export function SaveScenarioButton({ rosterState, defaultName = "My Roster Scenario" }: SaveScenarioButtonProps) {
     // @ts-ignore
-    const { isSignedIn, user } = useUser();
+    const clerkUser = hasClerkConfig && useUser ? useUser() : { isSignedIn: false, user: null };
+    const { isSignedIn, user } = clerkUser;
     const [isOpen, setIsOpen] = useState(false);
     const [name, setName] = useState(defaultName);
     const [isLoading, setIsLoading] = useState(false);
@@ -57,13 +69,23 @@ export function SaveScenarioButton({ rosterState, defaultName = "My Roster Scena
     };
 
     if (!isSignedIn) {
+        // Only show SignInButton if Clerk is configured
+        if (hasClerkConfig && SignInButton) {
+            return (
+                <SignInButton mode="modal">
+                    <Button variant="outline" className="gap-2">
+                        <Save className="h-4 w-4" />
+                        Sign in to Save
+                    </Button>
+                </SignInButton>
+            );
+        }
+        // If Clerk not configured, just show disabled button
         return (
-            <SignInButton mode="modal">
-                <Button variant="outline" className="gap-2">
-                    <Save className="h-4 w-4" />
-                    Sign in to Save
-                </Button>
-            </SignInButton>
+            <Button variant="outline" className="gap-2" disabled>
+                <Save className="h-4 w-4" />
+                Save (Auth Required)
+            </Button>
         );
     }
 

--- a/web/components/team-context.tsx
+++ b/web/components/team-context.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from "react";
-import { useUser } from "@clerk/nextjs";
 import { updateUserTeam } from "@/app/actions/user";
 
 interface TeamContextType {
@@ -14,8 +13,13 @@ interface TeamContextType {
 
 const TeamContext = createContext<TeamContextType | undefined>(undefined);
 
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
 export function TeamProvider({ children }: { children: ReactNode }) {
-    const { user, isLoaded } = useUser();
+    // Only use useUser if Clerk is configured
+    const clerkUser = hasClerkConfig ? require("@clerk/nextjs").useUser() : { user: null, isLoaded: true };
+    const { user, isLoaded } = clerkUser;
+
     const [activeTeam, setActiveTeamState] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isTeamSelectorOpen, setTeamSelectorOpen] = useState(false);

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,5 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 const isProtectedRoute = createRouteMatcher([
     "/scenarios(.*)",
@@ -11,25 +11,37 @@ const isProtectedRoute = createRouteMatcher([
     "/api/api-keys(.*)"
 ]);
 
-export default clerkMiddleware((auth, req) => {
-    if (isProtectedRoute(req)) {
-        auth().protect();
-    }
-    
+// Fallback middleware when Clerk is not configured
+function passthroughMiddleware(req: NextRequest) {
     const requestHeaders = new Headers(req.headers);
-    requestHeaders.set('x-forwarded-proto', 'https'); // Often needed for local headless testing behind proxies
-    
-    const response = NextResponse.next({
+    requestHeaders.set('x-forwarded-proto', 'https');
+
+    return NextResponse.next({
         request: {
             headers: requestHeaders,
         },
     });
+}
 
-    // We can also set CSP here if next.config.js headers are not enough:
-    // response.headers.set('Content-Security-Policy', "worker-src 'self' blob:;");
-    
-    return response;
-});
+// Use Clerk if keys are available, otherwise passthrough
+const hasClerkConfig = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY && !!process.env.CLERK_SECRET_KEY;
+
+export default hasClerkConfig
+    ? clerkMiddleware((auth, req) => {
+        if (isProtectedRoute(req)) {
+            auth().protect();
+        }
+
+        const requestHeaders = new Headers(req.headers);
+        requestHeaders.set('x-forwarded-proto', 'https');
+
+        return NextResponse.next({
+            request: {
+                headers: requestHeaders,
+            },
+        });
+    })
+    : passthroughMiddleware;
 
 export const config = {
     matcher: ["/((?!.*\\..*|_next).*)", "/", "/(api|trpc)(.*)"],


### PR DESCRIPTION
Fixes the MIDDLEWARE_INVOCATION_FAILED 500 error when Clerk environment variables are not configured in Vercel.

## Problem
The Vercel deployment was failing with a 500 error because Clerk middleware was crashing when `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` weren't set in the environment.

## Solution
Make all Clerk integration gracefully degrade when env vars are missing:
- Middleware falls back to passthrough when Clerk config unavailable
- Providers conditionally wrap with ClerkProvider
- Auth components only render when Clerk is configured
- App works in guest mode without crashing

This allows deployments to Vercel to succeed even before setting up Clerk credentials in the dashboard. Once Clerk env vars are added, auth features will automatically enable.

## Changes
- middleware.ts: conditional Clerk middleware
- providers.tsx: conditional ClerkProvider wrapper
- team-context.tsx: conditional useUser hook
- navbar.tsx, auth-interstitial.tsx, persona-switcher.tsx, save-scenario-button.tsx: graceful Clerk handling

## Testing
- App loads without errors when Clerk env vars missing
- Protected routes still accessible in guest mode
- No auth features available until Clerk is configured