### PR TITLE
fix(extract): extract draft_year field for draft pick predictions (#274)

### DIFF
--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -532,7 +532,7 @@ def run_extraction(
                         raw_assertion_text=str(row.get("raw_text", ""))[:2000],
                         extracted_claim=pred["extracted_claim"],
                         claim_category=pred["claim_category"],
-                        season_year=pred.get("season_year"),
+                        season_year=pred.get("draft_year") or pred.get("season_year"),
                         target_player_id=None,
                         target_player_name=player_name,
                         target_team=pred.get("target_team"),

--- a/pipeline/src/llm_provider.py
+++ b/pipeline/src/llm_provider.py
@@ -36,6 +36,7 @@ Return a JSON array of objects. Each object must have:
 - "claim_category": string — one of: player_performance, game_outcome, trade, draft_pick, injury, contract (REQUIRED)
 - "stance": string — directional sentiment: "bullish" (positive outcome predicted), "bearish" (negative outcome predicted), or "neutral" (no clear directional bias) (REQUIRED)
 - "season_year": integer or null — season year the prediction applies to (CRITICAL for draft_pick: must be the draft year, e.g. 2025, 2026)
+- "draft_year": integer or null — for draft pick predictions, set to the year of the draft (e.g. 2026). Otherwise null.
 - "target_player": string or null — player name if about a specific player
 - "target_team": string or null — team abbreviation (e.g. "KC", "CHI")
 - "confidence_note": string — how explicit/confident the prediction is (REQUIRED)
@@ -142,6 +143,11 @@ class GeminiProvider(LLMProvider):
                         description="Directional sentiment: bullish=positive outcome predicted, bearish=negative, neutral=no clear bias",
                     ),
                     "season_year": types.Schema(type=types.Type.INTEGER, nullable=True),
+                    "draft_year": types.Schema(
+                        type=types.Type.INTEGER,
+                        nullable=True,
+                        description="For draft pick predictions, the year of the draft (e.g. 2026). Otherwise null.",
+                    ),
                     "target_player": types.Schema(
                         type=types.Type.STRING, nullable=True
                     ),


### PR DESCRIPTION
## Summary

- Adds `draft_year` to `PREDICTION_SCHEMA_DESCRIPTION` in `llm_provider.py` — LLM now returns this field for draft pick predictions
- Maps `draft_year → season_year` in `assertion_extractor.py` PunditPrediction construction
- Fixes draft_pick resolution passes that were skipping all 57 predictions with "no draft year in claim or metadata"

Closes #274

## Test plan
- [x] ruff passes
- [x] Existing tests unaffected (field is additive, no existing test asserts on draft_year)

🤖 Generated with [Claude Code](https://claude.com/claude-code)