### PR TITLE
feat(billing): Stripe webhook handler + subscription state mirror (#147)

### DIFF
--- a/pipeline/migrations/013_create_stripe_events.sql
+++ b/pipeline/migrations/013_create_stripe_events.sql
@@ -1,0 +1,20 @@
+-- Migration 013: Create monetization.stripe_events audit table (Issue #147)
+--
+-- Immutable audit log of every Stripe webhook event processed by
+-- POST /api/webhooks/stripe. Used for idempotency checks, billing
+-- dispute resolution, and monitoring subscription state transitions.
+--
+-- Partitioned by processed_at date for cost-efficient time-range scans.
+-- Clustered by event_type for per-type queries.
+
+CREATE TABLE IF NOT EXISTS `cap-alpha-protocol.monetization.stripe_events` (
+    event_id          STRING    NOT NULL,   -- Stripe event ID (evt_xxx) — globally unique
+    event_type        STRING    NOT NULL,   -- e.g. checkout.session.completed
+    user_id           STRING,              -- Clerk user ID, null if not yet resolved
+    stripe_customer_id STRING,             -- Stripe customer ID (cus_xxx)
+    livemode          BOOL      NOT NULL,  -- false = test mode
+    payload           JSON,               -- Serialized event.data.object
+    processed_at      TIMESTAMP NOT NULL   -- When our handler processed the event
+)
+PARTITION BY DATE(processed_at)
+CLUSTER BY event_type, stripe_customer_id;

--- a/pipeline/migrations/013_create_stripe_events.sql
+++ b/pipeline/migrations/013_create_stripe_events.sql
@@ -7,7 +7,7 @@
 -- Partitioned by processed_at date for cost-efficient time-range scans.
 -- Clustered by event_type for per-type queries.
 
-CREATE TABLE IF NOT EXISTS `cap-alpha-protocol.monetization.stripe_events` (
+CREATE TABLE IF NOT EXISTS `{project_id}.monetization.stripe_events` (
     event_id          STRING    NOT NULL,   -- Stripe event ID (evt_xxx) — globally unique
     event_type        STRING    NOT NULL,   -- e.g. checkout.session.completed
     user_id           STRING,              -- Clerk user ID, null if not yet resolved

--- a/web/app/api/webhooks/stripe/route.ts
+++ b/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,324 @@
+/**
+ * POST /api/webhooks/stripe
+ *
+ * Receives Stripe webhook events, verifies the signature, and keeps
+ * subscription state in sync across:
+ *   - Postgres users table (stripe_* columns)
+ *   - Clerk publicMetadata.tier (for fast tier reads by the rate limiter)
+ *   - BigQuery monetization.stripe_events (immutable audit log)
+ *
+ * Idempotent: events already logged to BQ are silently skipped.
+ *
+ * Required env vars:
+ *   STRIPE_WEBHOOK_SECRET — from Stripe Dashboard → Webhooks → endpoint secret
+ *   STRIPE_SECRET_KEY     — Stripe API key (also used by lib/stripe.ts)
+ */
+
+import { clerkClient } from "@clerk/nextjs/server";
+import { BigQuery } from "@google-cloud/bigquery";
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import type Stripe from "stripe";
+
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { stripe, tierFromPriceId } from "@/lib/stripe";
+import type { Tier } from "@/lib/api-keys/tiers";
+
+const PROJECT_ID = process.env.GCP_PROJECT_ID || "cap-alpha-protocol";
+
+// ---------------------------------------------------------------------------
+// BigQuery audit log (fire-and-forget)
+// ---------------------------------------------------------------------------
+
+async function logStripeEvent(
+    event: Stripe.Event,
+    clerkUserId: string | null
+): Promise<void> {
+    try {
+        const bq = new BigQuery({
+            projectId: PROJECT_ID,
+            credentials:
+                process.env.GCP_CLIENT_EMAIL && process.env.GCP_PRIVATE_KEY
+                    ? {
+                          client_email: process.env.GCP_CLIENT_EMAIL,
+                          private_key: process.env.GCP_PRIVATE_KEY.replace(
+                              /\\n/g,
+                              "\n"
+                          ),
+                      }
+                    : undefined,
+        });
+
+        const table = bq
+            .dataset("monetization")
+            .table("stripe_events");
+
+        await table.insert([
+            {
+                event_id: event.id,
+                event_type: event.type,
+                user_id: clerkUserId,
+                stripe_customer_id:
+                    typeof (event.data.object as any).customer === "string"
+                        ? (event.data.object as any).customer
+                        : null,
+                livemode: event.livemode,
+                payload: JSON.stringify(event.data.object),
+                processed_at: new Date().toISOString(),
+            },
+        ]);
+    } catch (err) {
+        // Non-fatal — event handling continues even if audit log fails
+        console.error("[Stripe Webhook] BQ audit log failed:", err);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tier sync helpers
+// ---------------------------------------------------------------------------
+
+async function setUserTier(clerkUserId: string, tier: Tier): Promise<void> {
+    await clerkClient.users.updateUserMetadata(clerkUserId, {
+        publicMetadata: { tier },
+    });
+}
+
+async function getClerkUserIdByStripeCustomer(
+    customerId: string
+): Promise<string | null> {
+    const rows = await db
+        .select({ clerkId: users.clerkId })
+        .from(users)
+        .where(eq(users.stripeCustomerId, customerId))
+        .limit(1);
+    return rows[0]?.clerkId ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+async function handleCheckoutCompleted(
+    session: Stripe.Checkout.Session
+): Promise<string | null> {
+    // client_reference_id is set to the Clerk user ID during checkout
+    const clerkUserId = session.client_reference_id;
+    if (!clerkUserId) {
+        console.warn("[Stripe Webhook] checkout.session.completed: no client_reference_id");
+        return null;
+    }
+
+    const customerId =
+        typeof session.customer === "string" ? session.customer : null;
+    const subscriptionId =
+        typeof session.subscription === "string" ? session.subscription : null;
+
+    // Fetch the subscription to get price details
+    let priceId: string | null = null;
+    let currentPeriodEnd: Date | null = null;
+
+    if (subscriptionId) {
+        const sub = await stripe.subscriptions.retrieve(subscriptionId);
+        priceId = sub.items.data[0]?.price?.id ?? null;
+        currentPeriodEnd = new Date(sub.current_period_end * 1000);
+    }
+
+    await db
+        .update(users)
+        .set({
+            stripeCustomerId: customerId,
+            stripeSubscriptionId: subscriptionId,
+            stripeSubscriptionStatus: "active",
+            stripePriceId: priceId,
+            stripeCurrentPeriodEnd: currentPeriodEnd,
+            isPro: true,
+        })
+        .where(eq(users.clerkId, clerkUserId));
+
+    const tier = tierFromPriceId(priceId);
+    await setUserTier(clerkUserId, tier);
+
+    console.log(`[Stripe Webhook] checkout completed: ${clerkUserId} → ${tier}`);
+    return clerkUserId;
+}
+
+async function handleSubscriptionUpdated(
+    sub: Stripe.Subscription
+): Promise<string | null> {
+    const customerId =
+        typeof sub.customer === "string" ? sub.customer : null;
+    if (!customerId) return null;
+
+    const clerkUserId = await getClerkUserIdByStripeCustomer(customerId);
+    if (!clerkUserId) {
+        console.warn(`[Stripe Webhook] subscription.updated: no user for customer ${customerId}`);
+        return null;
+    }
+
+    const priceId = sub.items.data[0]?.price?.id ?? null;
+    const currentPeriodEnd = new Date(sub.current_period_end * 1000);
+    const status = sub.status;
+
+    await db
+        .update(users)
+        .set({
+            stripeSubscriptionStatus: status,
+            stripePriceId: priceId,
+            stripeCurrentPeriodEnd: currentPeriodEnd,
+            isPro: status === "active" || status === "trialing",
+        })
+        .where(eq(users.clerkId, clerkUserId));
+
+    const tier = tierFromPriceId(priceId);
+    await setUserTier(clerkUserId, tier);
+
+    console.log(`[Stripe Webhook] subscription updated: ${clerkUserId} → ${tier} (${status})`);
+    return clerkUserId;
+}
+
+async function handleSubscriptionDeleted(
+    sub: Stripe.Subscription
+): Promise<string | null> {
+    const customerId =
+        typeof sub.customer === "string" ? sub.customer : null;
+    if (!customerId) return null;
+
+    const clerkUserId = await getClerkUserIdByStripeCustomer(customerId);
+    if (!clerkUserId) {
+        console.warn(`[Stripe Webhook] subscription.deleted: no user for customer ${customerId}`);
+        return null;
+    }
+
+    await db
+        .update(users)
+        .set({
+            stripeSubscriptionStatus: "canceled",
+            stripePriceId: null,
+            stripeCurrentPeriodEnd: null,
+            isPro: false,
+        })
+        .where(eq(users.clerkId, clerkUserId));
+
+    await setUserTier(clerkUserId, "free");
+
+    console.log(`[Stripe Webhook] subscription canceled: ${clerkUserId} → free`);
+    return clerkUserId;
+}
+
+async function handleInvoicePaymentFailed(
+    invoice: Stripe.Invoice
+): Promise<string | null> {
+    const customerId =
+        typeof invoice.customer === "string" ? invoice.customer : null;
+    if (!customerId) return null;
+
+    const clerkUserId = await getClerkUserIdByStripeCustomer(customerId);
+    if (!clerkUserId) return null;
+
+    // Mark past_due but do NOT downgrade — Stripe Smart Retries handles recovery.
+    // We only downgrade on subscription.deleted.
+    await db
+        .update(users)
+        .set({ stripeSubscriptionStatus: "past_due" })
+        .where(eq(users.clerkId, clerkUserId));
+
+    console.log(`[Stripe Webhook] invoice payment failed: ${clerkUserId} → past_due`);
+    return clerkUserId;
+}
+
+async function handleInvoicePaymentSucceeded(
+    invoice: Stripe.Invoice
+): Promise<string | null> {
+    const customerId =
+        typeof invoice.customer === "string" ? invoice.customer : null;
+    if (!customerId) return null;
+
+    const clerkUserId = await getClerkUserIdByStripeCustomer(customerId);
+    if (!clerkUserId) return null;
+
+    // Clear any past_due flag by restoring active status
+    await db
+        .update(users)
+        .set({ stripeSubscriptionStatus: "active", isPro: true })
+        .where(eq(users.clerkId, clerkUserId));
+
+    console.log(`[Stripe Webhook] invoice payment succeeded: ${clerkUserId} → active`);
+    return clerkUserId;
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(req: Request): Promise<Response> {
+    const WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!WEBHOOK_SECRET) {
+        console.error("[Stripe Webhook] STRIPE_WEBHOOK_SECRET not set");
+        return new Response("Webhook secret not configured", { status: 500 });
+    }
+
+    const body = await req.text();
+    const sig = headers().get("stripe-signature");
+
+    if (!sig) {
+        return new Response("Missing stripe-signature header", { status: 400 });
+    }
+
+    let event: Stripe.Event;
+    try {
+        event = stripe.webhooks.constructEvent(body, sig, WEBHOOK_SECRET);
+    } catch (err) {
+        console.error("[Stripe Webhook] Signature verification failed:", err);
+        return new Response("Webhook signature verification failed", { status: 400 });
+    }
+
+    let clerkUserId: string | null = null;
+
+    try {
+        switch (event.type) {
+            case "checkout.session.completed":
+                clerkUserId = await handleCheckoutCompleted(
+                    event.data.object as Stripe.Checkout.Session
+                );
+                break;
+
+            case "customer.subscription.updated":
+                clerkUserId = await handleSubscriptionUpdated(
+                    event.data.object as Stripe.Subscription
+                );
+                break;
+
+            case "customer.subscription.deleted":
+                clerkUserId = await handleSubscriptionDeleted(
+                    event.data.object as Stripe.Subscription
+                );
+                break;
+
+            case "invoice.payment_failed":
+                clerkUserId = await handleInvoicePaymentFailed(
+                    event.data.object as Stripe.Invoice
+                );
+                break;
+
+            case "invoice.payment_succeeded":
+                clerkUserId = await handleInvoicePaymentSucceeded(
+                    event.data.object as Stripe.Invoice
+                );
+                break;
+
+            default:
+                // Unhandled event type — acknowledge receipt and move on
+                break;
+        }
+    } catch (err) {
+        console.error(`[Stripe Webhook] Error handling ${event.type}:`, err);
+        // Return 500 so Stripe retries the event
+        return new Response("Internal error processing webhook", { status: 500 });
+    }
+
+    // Fire-and-forget audit log (non-blocking)
+    logStripeEvent(event, clerkUserId).catch(() => {});
+
+    return new Response(null, { status: 200 });
+}

--- a/web/app/api/webhooks/stripe/route.ts
+++ b/web/app/api/webhooks/stripe/route.ts
@@ -136,7 +136,7 @@ async function handleCheckoutCompleted(
     // Fetch the subscription to get price details
     const sub = await stripe.subscriptions.retrieve(subscriptionId);
     const priceId = sub.items.data[0]?.price?.id ?? null;
-    const currentPeriodEnd = new Date(sub.current_period_end * 1000);
+    const currentPeriodEnd = new Date((sub.items.data[0]?.current_period_end ?? 0) * 1000);
 
     await db
         .update(users)
@@ -171,7 +171,7 @@ async function handleSubscriptionUpdated(
     }
 
     const priceId = sub.items.data[0]?.price?.id ?? null;
-    const currentPeriodEnd = new Date(sub.current_period_end * 1000);
+    const currentPeriodEnd = new Date((sub.items.data[0]?.current_period_end ?? 0) * 1000);
     const status = sub.status;
 
     await db

--- a/web/app/api/webhooks/stripe/route.ts
+++ b/web/app/api/webhooks/stripe/route.ts
@@ -5,9 +5,11 @@
  * subscription state in sync across:
  *   - Postgres users table (stripe_* columns)
  *   - Clerk publicMetadata.tier (for fast tier reads by the rate limiter)
- *   - BigQuery monetization.stripe_events (immutable audit log)
+ *   - BigQuery monetization.stripe_events (best-effort audit log)
  *
- * Idempotent: events already logged to BQ are silently skipped.
+ * Idempotency: Postgres updates are safe to replay (UPDATE WHERE clerkId).
+ * BigQuery audit inserts are best-effort; duplicate deliveries may produce
+ * duplicate rows (event_id uniqueness is not enforced at insert time).
  *
  * Required env vars:
  *   STRIPE_WEBHOOK_SECRET — from Stripe Dashboard → Webhooks → endpoint secret
@@ -17,7 +19,6 @@
 import { clerkClient } from "@clerk/nextjs/server";
 import { BigQuery } from "@google-cloud/bigquery";
 import { eq } from "drizzle-orm";
-import { headers } from "next/headers";
 import type Stripe from "stripe";
 
 import { db } from "@/db";
@@ -28,7 +29,7 @@ import type { Tier } from "@/lib/api-keys/tiers";
 const PROJECT_ID = process.env.GCP_PROJECT_ID || "cap-alpha-protocol";
 
 // ---------------------------------------------------------------------------
-// BigQuery audit log (fire-and-forget)
+// BigQuery audit log (best-effort, errors are swallowed)
 // ---------------------------------------------------------------------------
 
 async function logStripeEvent(
@@ -64,7 +65,9 @@ async function logStripeEvent(
                         ? (event.data.object as any).customer
                         : null,
                 livemode: event.livemode,
-                payload: JSON.stringify(event.data.object),
+                // Pass the object directly so BQ receives the correct JSON type
+                // (the schema column is JSON, not STRING).
+                payload: event.data.object,
                 processed_at: new Date().toISOString(),
             },
         ]);
@@ -102,6 +105,15 @@ async function getClerkUserIdByStripeCustomer(
 async function handleCheckoutCompleted(
     session: Stripe.Checkout.Session
 ): Promise<string | null> {
+    // Only handle subscription checkouts — payment-mode sessions do not create
+    // recurring subscriptions and should not modify tier state.
+    if (session.mode !== "subscription") {
+        console.log(
+            `[Stripe Webhook] checkout.session.completed: skipping non-subscription session (mode=${session.mode})`
+        );
+        return null;
+    }
+
     // client_reference_id is set to the Clerk user ID during checkout
     const clerkUserId = session.client_reference_id;
     if (!clerkUserId) {
@@ -114,15 +126,17 @@ async function handleCheckoutCompleted(
     const subscriptionId =
         typeof session.subscription === "string" ? session.subscription : null;
 
-    // Fetch the subscription to get price details
-    let priceId: string | null = null;
-    let currentPeriodEnd: Date | null = null;
-
-    if (subscriptionId) {
-        const sub = await stripe.subscriptions.retrieve(subscriptionId);
-        priceId = sub.items.data[0]?.price?.id ?? null;
-        currentPeriodEnd = new Date(sub.current_period_end * 1000);
+    if (!subscriptionId) {
+        console.warn(
+            `[Stripe Webhook] checkout.session.completed: session.subscription is null for ${clerkUserId}`
+        );
+        return null;
     }
+
+    // Fetch the subscription to get price details
+    const sub = await stripe.subscriptions.retrieve(subscriptionId);
+    const priceId = sub.items.data[0]?.price?.id ?? null;
+    const currentPeriodEnd = new Date(sub.current_period_end * 1000);
 
     await db
         .update(users)
@@ -259,7 +273,10 @@ export async function POST(req: Request): Promise<Response> {
     }
 
     const body = await req.text();
-    const sig = headers().get("stripe-signature");
+    // Read signature from the Request object directly — avoids a Next.js
+    // dynamic function import (`headers()`) and makes the handler easier to
+    // unit-test without a Next.js request context.
+    const sig = req.headers.get("stripe-signature");
 
     if (!sig) {
         return new Response("Missing stripe-signature header", { status: 400 });
@@ -317,8 +334,9 @@ export async function POST(req: Request): Promise<Response> {
         return new Response("Internal error processing webhook", { status: 500 });
     }
 
-    // Fire-and-forget audit log (non-blocking)
-    logStripeEvent(event, clerkUserId).catch(() => {});
+    // Await audit log so it is not dropped when the serverless response returns.
+    // logStripeEvent swallows its own errors, so this won't fail the response.
+    await logStripeEvent(event, clerkUserId);
 
     return new Response(null, { status: 200 });
 }

--- a/web/lib/api-keys/tiers.ts
+++ b/web/lib/api-keys/tiers.ts
@@ -5,6 +5,8 @@
  * Per-tier key caps are enforced on key creation.
  */
 
+import { clerkClient } from "@clerk/nextjs/server";
+
 export type Tier = "free" | "pro" | "api_starter" | "api_growth" | "enterprise";
 
 interface TierConfig {
@@ -20,13 +22,22 @@ const TIER_CONFIGS: Record<Tier, TierConfig> = {
 };
 
 /**
- * Resolve a user's tier from their subscription state.
+ * Resolve a user's tier from Clerk publicMetadata.
  *
- * TODO(#146/#147): Wire this to Stripe subscription state via Clerk metadata.
- * For now, returns 'free' as the default tier for all users.
+ * The Stripe webhook handler (POST /api/webhooks/stripe) sets
+ * publicMetadata.tier on every subscription state change, so this
+ * read is O(1) without touching the database on every API request.
  */
-export async function getUserTier(_userId: string): Promise<Tier> {
-    // Stub: always returns 'free' until Stripe integration in #146/#147
+export async function getUserTier(userId: string): Promise<Tier> {
+    try {
+        const user = await clerkClient.users.getUser(userId);
+        const tier = user.publicMetadata?.tier as Tier | undefined;
+        if (tier && tier in TIER_CONFIGS) {
+            return tier;
+        }
+    } catch (err) {
+        console.error(`[getUserTier] Clerk lookup failed for ${userId}:`, err);
+    }
     return "free";
 }
 

--- a/web/lib/stripe.ts
+++ b/web/lib/stripe.ts
@@ -1,0 +1,36 @@
+/**
+ * Stripe client singleton and tier mapping.
+ *
+ * Tier is derived from the Stripe price ID on each subscription event.
+ * Price IDs are configured via environment variables so they work in both
+ * test mode and live mode without code changes.
+ */
+import Stripe from "stripe";
+
+import type { Tier } from "./api-keys/tiers";
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: "2024-12-18.acacia",
+});
+
+// Map Stripe price IDs → internal tier names.
+// Each env var holds the price ID from the Stripe Dashboard.
+// Example: STRIPE_PRICE_PRO=price_1OzXXXXXXXXXXXXX
+function buildPriceMap(): Record<string, Tier> {
+    const map: Record<string, Tier> = {};
+    const entries: [string | undefined, Tier][] = [
+        [process.env.STRIPE_PRICE_PRO, "pro"],
+        [process.env.STRIPE_PRICE_API_STARTER, "api_starter"],
+        [process.env.STRIPE_PRICE_ENTERPRISE, "enterprise"],
+    ];
+    for (const [priceId, tier] of entries) {
+        if (priceId) map[priceId] = tier;
+    }
+    return map;
+}
+
+export function tierFromPriceId(priceId: string | null | undefined): Tier {
+    if (!priceId) return "free";
+    const map = buildPriceMap();
+    return map[priceId] ?? "pro"; // unknown paid price → default to pro
+}

--- a/web/lib/stripe.ts
+++ b/web/lib/stripe.ts
@@ -22,7 +22,7 @@ export function getStripe(): Stripe {
                 "[Stripe] STRIPE_SECRET_KEY is not set. Configure it in your environment."
             );
         }
-        _stripe = new Stripe(key, { apiVersion: "2024-12-18.acacia" });
+        _stripe = new Stripe(key, { apiVersion: "2026-04-22.dahlia" });
     }
     return _stripe;
 }

--- a/web/lib/stripe.ts
+++ b/web/lib/stripe.ts
@@ -9,9 +9,36 @@ import Stripe from "stripe";
 
 import type { Tier } from "./api-keys/tiers";
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-    apiVersion: "2024-12-18.acacia",
-});
+// Lazily-initialized Stripe client so that environments without billing
+// configured (e.g., local dev without STRIPE_SECRET_KEY) do not fail at
+// module import time before the webhook handler can return a controlled error.
+let _stripe: Stripe | null = null;
+
+export function getStripe(): Stripe {
+    if (!_stripe) {
+        const key = process.env.STRIPE_SECRET_KEY;
+        if (!key) {
+            throw new Error(
+                "[Stripe] STRIPE_SECRET_KEY is not set. Configure it in your environment."
+            );
+        }
+        _stripe = new Stripe(key, { apiVersion: "2024-12-18.acacia" });
+    }
+    return _stripe;
+}
+
+/** Convenience re-export for call sites that already validate env at startup. */
+export const stripe = {
+    subscriptions: {
+        retrieve: (...args: Parameters<Stripe["subscriptions"]["retrieve"]>) =>
+            getStripe().subscriptions.retrieve(...args),
+    },
+    webhooks: {
+        constructEvent: (
+            ...args: Parameters<Stripe["webhooks"]["constructEvent"]>
+        ) => getStripe().webhooks.constructEvent(...args),
+    },
+} as unknown as Stripe;
 
 // Map Stripe price IDs → internal tier names.
 // Each env var holds the price ID from the Stripe Dashboard.
@@ -32,5 +59,13 @@ function buildPriceMap(): Record<string, Tier> {
 export function tierFromPriceId(priceId: string | null | undefined): Tier {
     if (!priceId) return "free";
     const map = buildPriceMap();
-    return map[priceId] ?? "pro"; // unknown paid price → default to pro
+    const tier = map[priceId];
+    if (tier) return tier;
+    // Unknown price ID — default to least-privileged tier and log so the
+    // mapping can be fixed via env vars (never silently grant paid access).
+    console.warn(
+        `[Stripe] Unknown priceId "${priceId}" — defaulting to "free". ` +
+            "Add the price ID to STRIPE_PRICE_PRO / STRIPE_PRICE_API_STARTER / STRIPE_PRICE_ENTERPRISE."
+    );
+    return "free";
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,8 +25,11 @@
                 "@radix-ui/react-slot": "^1.2.4",
                 "@radix-ui/react-tabs": "^1.1.13",
                 "@radix-ui/react-tooltip": "^1.2.8",
+                "@sentry/nextjs": "^8.55.1",
                 "@tanstack/react-query": "^5.90.20",
                 "@tanstack/react-table": "^8.21.3",
+                "@upstash/ratelimit": "^2.0.8",
+                "@upstash/redis": "^1.37.0",
                 "@vercel/postgres": "^0.10.0",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
@@ -39,7 +42,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "recharts": "^3.7.0",
-                "stripe": "^17.7.0",
+                "stripe": "^22.1.0",
                 "svix": "^1.85.0",
                 "tailwind-merge": "^2.6.1",
                 "tailwindcss-animate": "^1.0.7",
@@ -86,7 +89,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -97,12 +99,257 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-validator-option": "^7.27.1",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "license": "ISC"
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1760,6 +2007,16 @@
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1767,6 +2024,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -2070,6 +2338,628 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/context-async-hooks": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.2",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-amqplib": {
+            "version": "0.46.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+            "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-connect": {
+            "version": "0.43.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
+            "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/connect": "3.4.36"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-dataloader": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
+            "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-express": {
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
+            "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fastify": {
+            "version": "0.44.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.1.tgz",
+            "integrity": "sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fs": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+            "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-generic-pool": {
+            "version": "0.43.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
+            "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-graphql": {
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
+            "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-hapi": {
+            "version": "0.45.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
+            "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http": {
+            "version": "0.57.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
+            "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/instrumentation": "0.57.1",
+                "@opentelemetry/semantic-conventions": "1.28.0",
+                "forwarded-parse": "2.1.2",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+            "version": "0.57.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
+            "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.57.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
+            "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.57.1",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-ioredis": {
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
+            "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/redis-common": "^0.36.2",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-kafkajs": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
+            "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-knex": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
+            "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-koa": {
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
+            "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
+            "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongodb": {
+            "version": "0.51.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
+            "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mongoose": {
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
+            "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql": {
+            "version": "0.45.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
+            "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/mysql": "2.15.26"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-mysql2": {
+            "version": "0.45.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
+            "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@opentelemetry/sql-common": "^0.40.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-nestjs-core": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.0.tgz",
+            "integrity": "sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg": {
+            "version": "0.50.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
+            "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.26.0",
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "1.27.0",
+                "@opentelemetry/sql-common": "^0.40.1",
+                "@types/pg": "8.6.1",
+                "@types/pg-pool": "2.0.6"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+            "version": "8.6.1",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+            "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-redis-4": {
+            "version": "0.46.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
+            "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/redis-common": "^0.36.2",
+                "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-tedious": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
+            "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.57.0",
+                "@opentelemetry/semantic-conventions": "^1.27.0",
+                "@types/tedious": "^4.0.14"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-undici": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
+            "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.8.0",
+                "@opentelemetry/instrumentation": "^0.57.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.7.0"
+            }
+        },
+        "node_modules/@opentelemetry/redis-common": {
+            "version": "0.36.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+            "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "1.30.1",
+                "@opentelemetry/resources": "1.30.1",
+                "@opentelemetry/semantic-conventions": "1.28.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@opentelemetry/sql-common": {
+            "version": "0.40.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+            "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.1.0"
             }
         },
         "node_modules/@oxc-project/types": {
@@ -2465,6 +3355,49 @@
             },
             "engines": {
                 "node": ">=16"
+            }
+        },
+        "node_modules/@prisma/instrumentation": {
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
+            "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.8",
+                "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
+                "@opentelemetry/sdk-trace-base": "^1.22"
+            }
+        },
+        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+            "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.53.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+            "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.53.0",
+                "@types/shimmer": "^1.2.0",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -4401,11 +5334,36 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "28.0.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
+            "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "fdir": "^6.2.0",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/pluginutils": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
             "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -4437,6 +5395,513 @@
             "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@sentry-internal/browser-utils": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.2.tgz",
+            "integrity": "sha512-GnKod+gL/Y+1FUM/RGV8q6le1CoyiGbT40MitEK7eVwWe+bfTRq1gN7ioupyHFMUg1RlQkDQ4/sENmio/uow5A==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry-internal/feedback": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.2.tgz",
+            "integrity": "sha512-XQy//NWbL0mLLM5w8wNDWMNpXz39VUyW2397dUrH8++kR63WhUVAvTOtL0o0GMVadSAzl1b08oHP9zSUNFQwcg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry-internal/replay": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.2.tgz",
+            "integrity": "sha512-+W43Z697EVe/OgpGW07B773sa8xO1UbpnW0Cr+E+3FMDb6ZbXlaBUoagPTUkkQPdwBe35SDh6r8y2M3EOPGbxg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/browser-utils": "8.55.2",
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry-internal/replay-canvas": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.2.tgz",
+            "integrity": "sha512-P/jGiuR7dRLG9IzD/463fLgiibyYceauav/9prRG0ZxJm1AtuO02OKball2Fs3bbzdzwHCTlcsUuL2ivDF4b5A==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/replay": "8.55.2",
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry/babel-plugin-component-annotate": {
+            "version": "2.22.7",
+            "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.22.7.tgz",
+            "integrity": "sha512-aa7XKgZMVl6l04NY+3X7BP7yvQ/s8scn8KzQfTLrGRarziTlMGrsCOBQtCNWXOPEbtxAIHpZ9dsrAn5EJSivOQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sentry/browser": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.2.tgz",
+            "integrity": "sha512-xHuPIEKhx9zw5quWvv4YgZprnwoVMCfxIhmOIf6KJ9iizyUHeUDcKpLS59xERroqwX4RpvK+l/27AZu4zfZlzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/browser-utils": "8.55.2",
+                "@sentry-internal/feedback": "8.55.2",
+                "@sentry-internal/replay": "8.55.2",
+                "@sentry-internal/replay-canvas": "8.55.2",
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core": {
+            "version": "2.22.7",
+            "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.22.7.tgz",
+            "integrity": "sha512-ouQh5sqcB8vsJ8yTTe0rf+iaUkwmeUlGNFi35IkCFUQlWJ22qS6OfvNjOqFI19e6eGUXks0c/2ieFC4+9wJ+1g==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.18.5",
+                "@sentry/babel-plugin-component-annotate": "2.22.7",
+                "@sentry/cli": "2.39.1",
+                "dotenv": "^16.3.1",
+                "find-up": "^5.0.0",
+                "glob": "^9.3.2",
+                "magic-string": "0.30.8",
+                "unplugin": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^8.0.2",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
+            "version": "0.30.8",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+            "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+            "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/cli": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.39.1.tgz",
+            "integrity": "sha512-JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "https-proxy-agent": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "progress": "^2.0.3",
+                "proxy-from-env": "^1.1.0",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "sentry-cli": "bin/sentry-cli"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "optionalDependencies": {
+                "@sentry/cli-darwin": "2.39.1",
+                "@sentry/cli-linux-arm": "2.39.1",
+                "@sentry/cli-linux-arm64": "2.39.1",
+                "@sentry/cli-linux-i686": "2.39.1",
+                "@sentry/cli-linux-x64": "2.39.1",
+                "@sentry/cli-win32-i686": "2.39.1",
+                "@sentry/cli-win32-x64": "2.39.1"
+            }
+        },
+        "node_modules/@sentry/cli-darwin": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.39.1.tgz",
+            "integrity": "sha512-kiNGNSAkg46LNGatfNH5tfsmI/kCAaPA62KQuFZloZiemTNzhy9/6NJP8HZ/GxGs8GDMxic6wNrV9CkVEgFLJQ==",
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-arm": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.39.1.tgz",
+            "integrity": "sha512-DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-arm64": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.39.1.tgz",
+            "integrity": "sha512-5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-i686": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.39.1.tgz",
+            "integrity": "sha512-pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==",
+            "cpu": [
+                "x86",
+                "ia32"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-linux-x64": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.39.1.tgz",
+            "integrity": "sha512-IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "linux",
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-win32-i686": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.39.1.tgz",
+            "integrity": "sha512-NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==",
+            "cpu": [
+                "x86",
+                "ia32"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/cli-win32-x64": {
+            "version": "2.39.1",
+            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.39.1.tgz",
+            "integrity": "sha512-xv0R2CMf/X1Fte3cMWie1NXuHmUyQPDBfCyIt6k6RPFPxAYUgcqgMPznYwVMwWEA1W43PaOkSn3d8ZylsDaETw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@sentry/core": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.2.tgz",
+            "integrity": "sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry/nextjs": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-8.55.2.tgz",
+            "integrity": "sha512-yZnRh4QKiy3IyZKprVQE29Zxu/SKSTBQRQM9x+9LYwIzT+3cSfC1h6t96QiKnKFaah9ct48ghJRk9IHibw/NKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/semantic-conventions": "^1.28.0",
+                "@rollup/plugin-commonjs": "28.0.1",
+                "@sentry-internal/browser-utils": "8.55.2",
+                "@sentry/core": "8.55.2",
+                "@sentry/node": "8.55.2",
+                "@sentry/opentelemetry": "8.55.2",
+                "@sentry/react": "8.55.2",
+                "@sentry/vercel-edge": "8.55.2",
+                "@sentry/webpack-plugin": "2.22.7",
+                "chalk": "3.0.0",
+                "resolve": "1.22.8",
+                "rollup": "3.29.5",
+                "stacktrace-parser": "^0.1.10"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "peerDependencies": {
+                "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"
+            }
+        },
+        "node_modules/@sentry/nextjs/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@sentry/nextjs/node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@sentry/node": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.2.tgz",
+            "integrity": "sha512-x3Whryb4TytiIhH9ABLVuASfBvwA50v6PpJYvq0Y9dUMi9Eb0cfuqvRCB3e+oVntZHQpnXor2U/gRBIdG2jp4w==",
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/context-async-hooks": "^1.30.1",
+                "@opentelemetry/core": "^1.30.1",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/instrumentation-amqplib": "^0.46.0",
+                "@opentelemetry/instrumentation-connect": "0.43.0",
+                "@opentelemetry/instrumentation-dataloader": "0.16.0",
+                "@opentelemetry/instrumentation-express": "0.47.0",
+                "@opentelemetry/instrumentation-fastify": "0.44.1",
+                "@opentelemetry/instrumentation-fs": "0.19.0",
+                "@opentelemetry/instrumentation-generic-pool": "0.43.0",
+                "@opentelemetry/instrumentation-graphql": "0.47.0",
+                "@opentelemetry/instrumentation-hapi": "0.45.1",
+                "@opentelemetry/instrumentation-http": "0.57.1",
+                "@opentelemetry/instrumentation-ioredis": "0.47.0",
+                "@opentelemetry/instrumentation-kafkajs": "0.7.0",
+                "@opentelemetry/instrumentation-knex": "0.44.0",
+                "@opentelemetry/instrumentation-koa": "0.47.0",
+                "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
+                "@opentelemetry/instrumentation-mongodb": "0.51.0",
+                "@opentelemetry/instrumentation-mongoose": "0.46.0",
+                "@opentelemetry/instrumentation-mysql": "0.45.0",
+                "@opentelemetry/instrumentation-mysql2": "0.45.0",
+                "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
+                "@opentelemetry/instrumentation-pg": "0.50.0",
+                "@opentelemetry/instrumentation-redis-4": "0.46.0",
+                "@opentelemetry/instrumentation-tedious": "0.18.0",
+                "@opentelemetry/instrumentation-undici": "0.10.0",
+                "@opentelemetry/resources": "^1.30.1",
+                "@opentelemetry/sdk-trace-base": "^1.30.1",
+                "@opentelemetry/semantic-conventions": "^1.28.0",
+                "@prisma/instrumentation": "5.22.0",
+                "@sentry/core": "8.55.2",
+                "@sentry/opentelemetry": "8.55.2",
+                "import-in-the-middle": "^1.11.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry/opentelemetry": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.2.tgz",
+            "integrity": "sha512-pbhXi4cS1W4l392yEfIx3UD28OYAl9JkYOmh/Cpm6cPTtRMPxi3hWeujGbcXV9T/RkWYjqd+JdUDJjqsWSww9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/context-async-hooks": "^1.30.1",
+                "@opentelemetry/core": "^1.30.1",
+                "@opentelemetry/instrumentation": "^0.57.1",
+                "@opentelemetry/sdk-trace-base": "^1.30.1",
+                "@opentelemetry/semantic-conventions": "^1.28.0"
+            }
+        },
+        "node_modules/@sentry/react": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.2.tgz",
+            "integrity": "sha512-1TPfKZYkJal2Dyt2W0tf1roOZmu7sqr6/dTqjdsuu2WgGTilMEreK26YqB8ROOYdMjkVJpNCcIKXQHyMp2eCwA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/browser": "8.55.2",
+                "@sentry/core": "8.55.2",
+                "hoist-non-react-statics": "^3.3.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || 17.x || 18.x || 19.x"
+            }
+        },
+        "node_modules/@sentry/vercel-edge": {
+            "version": "8.55.2",
+            "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-8.55.2.tgz",
+            "integrity": "sha512-obrDDBeIFIhWOARAuXg7nRQS1fYQHvscNTBRHzMT0fRU0nPtZssN4cUZYtMVZst3jFfakfe9BSyhEBRmrbWQ/w==",
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@sentry/core": "8.55.2"
+            },
+            "engines": {
+                "node": ">=14.18"
+            }
+        },
+        "node_modules/@sentry/webpack-plugin": {
+            "version": "2.22.7",
+            "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-2.22.7.tgz",
+            "integrity": "sha512-j5h5LZHWDlm/FQCCmEghQ9FzYXwfZdlOf3FE/X6rK6lrtx0JCAkq+uhMSasoyP4XYKL4P4vRS6WFSos4jxf/UA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/bundler-plugin-core": "2.22.7",
+                "unplugin": "1.0.1",
+                "uuid": "^9.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "webpack": ">=4.40.0"
+            }
+        },
+        "node_modules/@sentry/webpack-plugin/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.48",
@@ -4616,6 +6081,15 @@
                 "assertion-error": "^2.0.1"
             }
         },
+        "node_modules/@types/connect": {
+            "version": "3.4.36",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+            "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/d3-array": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -4686,11 +6160,32 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -4735,7 +6230,6 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json5": {
@@ -4744,6 +6238,15 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/mysql": {
+            "version": "2.15.26",
+            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+            "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/node": {
             "version": "20.19.37",
@@ -4763,6 +6266,15 @@
                 "@types/node": "*",
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
+            }
+        },
+        "node_modules/@types/pg-pool": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/pg": "*"
             }
         },
         "node_modules/@types/prop-types": {
@@ -4829,12 +6341,27 @@
                 "node": ">= 0.12"
             }
         },
+        "node_modules/@types/shimmer": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+            "license": "MIT"
+        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tedious": {
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -5274,6 +6801,39 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@upstash/core-analytics": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+            "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@upstash/redis": "^1.28.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@upstash/ratelimit": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+            "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@upstash/core-analytics": "^0.0.10"
+            },
+            "peerDependencies": {
+                "@upstash/redis": "^1.34.3"
+            }
+        },
+        "node_modules/@upstash/redis": {
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+            "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+            "license": "MIT",
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
         },
         "node_modules/@vercel/backends": {
             "version": "0.0.46",
@@ -8900,6 +10460,181 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@webassemblyjs/ast": "1.14.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+            "license": "BSD-3-Clause",
+            "peer": true
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+            "license": "Apache-2.0",
+            "peer": true
+        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -8910,7 +10645,6 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -8923,10 +10657,22 @@
             "version": "1.9.5",
             "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
             "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -9006,6 +10752,48 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -9019,7 +10807,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -9479,7 +11266,6 @@
             "version": "2.10.8",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
             "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -9568,7 +11354,6 @@
             "version": "4.28.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -9618,7 +11403,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/bufferutil": {
@@ -9773,6 +11557,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -9896,6 +11681,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/chrome-trace-event": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+            "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
         "node_modules/ci-info": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -9916,7 +11711,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
             "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/class-variance-authority": {
@@ -9982,7 +11776,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -9995,7 +11788,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/color-support": {
@@ -10027,6 +11819,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -10074,7 +11872,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -10794,7 +12591,6 @@
             "version": "1.5.321",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
             "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -10821,6 +12617,20 @@
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.21.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
+            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/env-paths": {
@@ -11075,7 +12885,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -11554,7 +13363,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -11567,7 +13375,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -11577,7 +13384,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/esutils": {
@@ -11605,6 +13411,16 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.8.x"
+            }
         },
         "node_modules/events-intercept": {
             "version": "2.0.0",
@@ -11686,7 +13502,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -11736,6 +13551,23 @@
             "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
             "license": "Unlicense"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -11809,7 +13641,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
@@ -11893,6 +13724,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/forwarded-parse": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+            "license": "MIT"
         },
         "node_modules/fraction.js": {
             "version": "5.3.4",
@@ -12137,6 +13974,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/get-intrinsic": {
@@ -12450,7 +14296,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12529,6 +14374,21 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
         },
         "node_modules/html-entities": {
             "version": "2.6.0",
@@ -12663,6 +14523,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-in-the-middle": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^1.2.2",
+                "module-details-from-path": "^1.0.3"
             }
         },
         "node_modules/imurmurhash": {
@@ -13069,6 +14941,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -13372,6 +15253,37 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
+        "node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
         "node_modules/jiti": {
             "version": "1.21.7",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -13417,6 +15329,18 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/json-bigint": {
@@ -13846,11 +15770,24 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
@@ -13922,7 +15859,6 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -14023,7 +15959,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/merge2": {
@@ -14142,7 +16077,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -14310,6 +16244,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "license": "MIT"
+        },
         "node_modules/mri": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14386,6 +16326,13 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/netmask": {
             "version": "2.0.2",
@@ -14705,7 +16652,6 @@
             "version": "2.0.36",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
             "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/nopt": {
@@ -14780,6 +16726,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -15025,7 +16972,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -15041,7 +16987,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
@@ -15189,7 +17134,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -15224,7 +17168,6 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
@@ -15241,7 +17184,6 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
@@ -15667,6 +17609,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -15789,7 +17740,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/pump": {
@@ -15811,21 +17761,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.15.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -16141,10 +18076,23 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-in-the-middle": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3",
+                "resolve": "^1.22.8"
+            },
+            "engines": {
+                "node": ">=8.6.0"
             }
         },
         "node_modules/reselect": {
@@ -16305,6 +18253,22 @@
                 "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.1"
             }
         },
+        "node_modules/rollup": {
+            "version": "3.29.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+            "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+            "license": "MIT",
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=14.18.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -16419,6 +18383,63 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "node_modules/schema-utils": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.9.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.1.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/schema-utils/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/schema-utils/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
+            }
+        },
+        "node_modules/schema-utils/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -16522,10 +18543,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/shimmer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/side-channel": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -16545,6 +18573,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -16561,6 +18590,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -16579,6 +18609,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -16715,7 +18746,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -16734,7 +18764,6 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -16817,6 +18846,27 @@
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/stacktrace-parser": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+            "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.7.1"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/stacktrace-parser/node_modules/type-fest": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+            "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/standardwebhooks": {
             "version": "1.0.0",
@@ -17182,16 +19232,20 @@
             }
         },
         "node_modules/stripe": {
-            "version": "17.7.0",
-            "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
-            "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+            "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
             "license": "MIT",
-            "dependencies": {
-                "@types/node": ">=8.1.0",
-                "qs": "^6.11.0"
-            },
             "engines": {
-                "node": ">=12.*"
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@types/node": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/stubs": {
@@ -17249,7 +19303,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -17349,6 +19402,20 @@
                 "tailwindcss": ">=3.0.0 || insiders"
             }
         },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
         "node_modules/tar": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -17404,6 +19471,66 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
+        },
+        "node_modules/terser": {
+            "version": "5.46.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+            "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser-webpack-plugin": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.25",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^4.3.0",
+                "terser": "^5.31.1"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -18316,6 +20443,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+            "license": "MIT"
+        },
         "node_modules/undici": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
@@ -18376,6 +20509,18 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/unplugin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
+            "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.8.1",
+                "chokidar": "^3.5.3",
+                "webpack-sources": "^3.2.3",
+                "webpack-virtual-modules": "^0.5.0"
+            }
+        },
         "node_modules/unrs-resolver": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -18415,7 +20560,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
             "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -20159,6 +22303,20 @@
                 }
             }
         },
+        "node_modules/watchpack": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/web-vitals": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
@@ -20171,6 +22329,110 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/webpack": {
+            "version": "5.106.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+            "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.16.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.20.0",
+                "es-module-lexer": "^2.0.0",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.11",
+                "loader-runner": "^4.3.1",
+                "mime-db": "^1.54.0",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.17",
+                "watchpack": "^2.5.1",
+                "webpack-sources": "^3.3.4"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-sources": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
+            "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+            "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+            "license": "MIT"
+        },
+        "node_modules/webpack/node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/webpack/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/webpack/node_modules/estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -20563,7 +22825,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,11 +25,8 @@
                 "@radix-ui/react-slot": "^1.2.4",
                 "@radix-ui/react-tabs": "^1.1.13",
                 "@radix-ui/react-tooltip": "^1.2.8",
-                "@sentry/nextjs": "^8.55.1",
                 "@tanstack/react-query": "^5.90.20",
                 "@tanstack/react-table": "^8.21.3",
-                "@upstash/ratelimit": "^2.0.8",
-                "@upstash/redis": "^1.37.0",
                 "@vercel/postgres": "^0.10.0",
                 "class-variance-authority": "^0.7.0",
                 "clsx": "^2.1.1",
@@ -42,7 +39,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "recharts": "^3.7.0",
-                "stripe": "^22.1.0",
+                "stripe": "^17.7.0",
                 "svix": "^1.85.0",
                 "tailwind-merge": "^2.6.1",
                 "tailwindcss-animate": "^1.0.7",
@@ -89,6 +86,7 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -99,257 +97,12 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/core/node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "license": "ISC"
-        },
-        "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2007,16 +1760,6 @@
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
-        "node_modules/@jridgewell/remapping": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2024,17 +1767,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@jridgewell/source-map": {
-            "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -2338,628 +2070,6 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/api": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
-            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/core": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-            "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/semantic-conventions": "1.28.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-amqplib": {
-            "version": "0.46.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
-            "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-connect": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
-            "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/connect": "3.4.36"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-dataloader": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
-            "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-express": {
-            "version": "0.47.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
-            "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-fastify": {
-            "version": "0.44.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.1.tgz",
-            "integrity": "sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-fs": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
-            "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-generic-pool": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
-            "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-graphql": {
-            "version": "0.47.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
-            "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-hapi": {
-            "version": "0.45.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
-            "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http": {
-            "version": "0.57.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
-            "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/instrumentation": "0.57.1",
-                "@opentelemetry/semantic-conventions": "1.28.0",
-                "forwarded-parse": "2.1.2",
-                "semver": "^7.5.2"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
-            "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
-            "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.57.1",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-ioredis": {
-            "version": "0.47.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
-            "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/redis-common": "^0.36.2",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-kafkajs": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
-            "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-knex": {
-            "version": "0.44.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
-            "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-koa": {
-            "version": "0.47.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
-            "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-            "version": "0.44.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
-            "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongodb": {
-            "version": "0.51.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
-            "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongoose": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
-            "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql": {
-            "version": "0.45.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
-            "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/mysql": "2.15.26"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql2": {
-            "version": "0.45.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
-            "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@opentelemetry/sql-common": "^0.40.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-            "version": "0.44.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.0.tgz",
-            "integrity": "sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-pg": {
-            "version": "0.50.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
-            "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.26.0",
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "1.27.0",
-                "@opentelemetry/sql-common": "^0.40.1",
-                "@types/pg": "8.6.1",
-                "@types/pg-pool": "2.0.6"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-            "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-            "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "pg-protocol": "*",
-                "pg-types": "^2.2.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-redis-4": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
-            "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/redis-common": "^0.36.2",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-tedious": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
-            "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/tedious": "^4.0.14"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-undici": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
-            "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.7.0"
-            }
-        },
-        "node_modules/@opentelemetry/redis-common": {
-            "version": "0.36.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
-            "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/resources": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/sql-common": {
-            "version": "0.40.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
-            "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.1.0"
             }
         },
         "node_modules/@oxc-project/types": {
@@ -3355,49 +2465,6 @@
             },
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/@prisma/instrumentation": {
-            "version": "5.22.0",
-            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
-            "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.8",
-                "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
-                "@opentelemetry/sdk-trace-base": "^1.22"
-            }
-        },
-        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
-            "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
-            "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.53.0",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
             }
         },
         "node_modules/@radix-ui/number": {
@@ -5334,36 +4401,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@rollup/plugin-commonjs": {
-            "version": "28.0.1",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
-            "integrity": "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==",
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/pluginutils": "^5.0.1",
-                "commondir": "^1.0.1",
-                "estree-walker": "^2.0.2",
-                "fdir": "^6.2.0",
-                "is-reference": "1.2.1",
-                "magic-string": "^0.30.3",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0 || 14 >= 14.17"
-            },
-            "peerDependencies": {
-                "rollup": "^2.68.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@rollup/pluginutils": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
             "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -5395,513 +4437,6 @@
             "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@sentry-internal/browser-utils": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.1.tgz",
-            "integrity": "sha512-SipXiwVhJrxzy3/4kf+YIFmpYlLKtGSRD+er7SBCcuSBtv31Fee8IXMDvk+bq24gRXxyjOLUmT//GGXjy2LL6w==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry-internal/feedback": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.1.tgz",
-            "integrity": "sha512-9iFHaT/ijtzB0ffZhXMnt2rPNIXO/dDiCL1G1Bc55rQMPXgawR9AIaAWciyqQjYcbL1DDOhWbzdVqB+kVs5gXw==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry-internal/replay": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.1.tgz",
-            "integrity": "sha512-XaX6r8pXeX47rfiQrSQUwkgxHsDkOKzIT++zfTwrmveVlYSqAhp3x+AKhxAXGmKG62wlmAKQz54GJKcG4cgyKQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry-internal/browser-utils": "8.55.1",
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry-internal/replay-canvas": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.1.tgz",
-            "integrity": "sha512-2sKRu96Qe70y6TiYdYbwkhg4um2prgzH/ZJRItuoSEAjPjoFYYlP+1qjE2CcBw4RPS8/PimV7SFheSaeZs2GCw==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry-internal/replay": "8.55.1",
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry/babel-plugin-component-annotate": {
-            "version": "2.22.7",
-            "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.22.7.tgz",
-            "integrity": "sha512-aa7XKgZMVl6l04NY+3X7BP7yvQ/s8scn8KzQfTLrGRarziTlMGrsCOBQtCNWXOPEbtxAIHpZ9dsrAn5EJSivOQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@sentry/browser": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.1.tgz",
-            "integrity": "sha512-OEn2eg8h3Mr7BmBGQ28BqbWehYA/NklZ0pAZB1FypPPl+kMd85AbaRdGTnaSjgmpc8bKbBO64edq4Y14sbCs5w==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry-internal/browser-utils": "8.55.1",
-                "@sentry-internal/feedback": "8.55.1",
-                "@sentry-internal/replay": "8.55.1",
-                "@sentry-internal/replay-canvas": "8.55.1",
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core": {
-            "version": "2.22.7",
-            "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.22.7.tgz",
-            "integrity": "sha512-ouQh5sqcB8vsJ8yTTe0rf+iaUkwmeUlGNFi35IkCFUQlWJ22qS6OfvNjOqFI19e6eGUXks0c/2ieFC4+9wJ+1g==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/core": "^7.18.5",
-                "@sentry/babel-plugin-component-annotate": "2.22.7",
-                "@sentry/cli": "2.39.1",
-                "dotenv": "^16.3.1",
-                "find-up": "^5.0.0",
-                "glob": "^9.3.2",
-                "magic-string": "0.30.8",
-                "unplugin": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
-            "version": "9.3.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
-            "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "minimatch": "^8.0.2",
-                "minipass": "^4.2.4",
-                "path-scurry": "^1.6.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/magic-string": {
-            "version": "0.30.8",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-            "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
-            "version": "8.0.7",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
-            "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@sentry/cli": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.39.1.tgz",
-            "integrity": "sha512-JIb3e9vh0+OmQ0KxmexMXg9oZsR/G7HMwxt5BUIKAXZ9m17Xll4ETXTRnRUBT3sf7EpNGAmlQk1xEmVN9pYZYQ==",
-            "hasInstallScript": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.6.7",
-                "progress": "^2.0.3",
-                "proxy-from-env": "^1.1.0",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "sentry-cli": "bin/sentry-cli"
-            },
-            "engines": {
-                "node": ">= 10"
-            },
-            "optionalDependencies": {
-                "@sentry/cli-darwin": "2.39.1",
-                "@sentry/cli-linux-arm": "2.39.1",
-                "@sentry/cli-linux-arm64": "2.39.1",
-                "@sentry/cli-linux-i686": "2.39.1",
-                "@sentry/cli-linux-x64": "2.39.1",
-                "@sentry/cli-win32-i686": "2.39.1",
-                "@sentry/cli-win32-x64": "2.39.1"
-            }
-        },
-        "node_modules/@sentry/cli-darwin": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.39.1.tgz",
-            "integrity": "sha512-kiNGNSAkg46LNGatfNH5tfsmI/kCAaPA62KQuFZloZiemTNzhy9/6NJP8HZ/GxGs8GDMxic6wNrV9CkVEgFLJQ==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-arm": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.39.1.tgz",
-            "integrity": "sha512-DkENbxyRxUrfLnJLXTA4s5UL/GoctU5Cm4ER1eB7XN7p9WsamFJd/yf2KpltkjEyiTuplv0yAbdjl1KX3vKmEQ==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-arm64": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.39.1.tgz",
-            "integrity": "sha512-5VbVJDatolDrWOgaffsEM7znjs0cR8bHt9Bq0mStM3tBolgAeSDHE89NgHggfZR+DJ2VWOy4vgCwkObrUD6NQw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-i686": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.39.1.tgz",
-            "integrity": "sha512-pXWVoKXCRrY7N8vc9H7mETiV9ZCz+zSnX65JQCzZxgYrayQPJTc+NPRnZTdYdk5RlAupXaFicBI2GwOCRqVRkg==",
-            "cpu": [
-                "x86",
-                "ia32"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-linux-x64": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.39.1.tgz",
-            "integrity": "sha512-IwayNZy+it7FWG4M9LayyUmG1a/8kT9+/IEm67sT5+7dkMIMcpmHDqL8rWcPojOXuTKaOBBjkVdNMBTXy0mXlA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "linux",
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-win32-i686": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.39.1.tgz",
-            "integrity": "sha512-NglnNoqHSmE+Dz/wHeIVRnV2bLMx7tIn3IQ8vXGO5HWA2f8zYJGktbkLq1Lg23PaQmeZLPGlja3gBQfZYSG10Q==",
-            "cpu": [
-                "x86",
-                "ia32"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/cli-win32-x64": {
-            "version": "2.39.1",
-            "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.39.1.tgz",
-            "integrity": "sha512-xv0R2CMf/X1Fte3cMWie1NXuHmUyQPDBfCyIt6k6RPFPxAYUgcqgMPznYwVMwWEA1W43PaOkSn3d8ZylsDaETw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@sentry/core": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.1.tgz",
-            "integrity": "sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry/nextjs": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-8.55.1.tgz",
-            "integrity": "sha512-AiOqnXO9CCHnctIzOJCCOS4Ykk5VEXDmNdUf/TaH72KJJ0lFXUMXxCGv0ZijLrHTAoKdwUlDucZhmDXavKmkqQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/semantic-conventions": "^1.28.0",
-                "@rollup/plugin-commonjs": "28.0.1",
-                "@sentry-internal/browser-utils": "8.55.1",
-                "@sentry/core": "8.55.1",
-                "@sentry/node": "8.55.1",
-                "@sentry/opentelemetry": "8.55.1",
-                "@sentry/react": "8.55.1",
-                "@sentry/vercel-edge": "8.55.1",
-                "@sentry/webpack-plugin": "2.22.7",
-                "chalk": "3.0.0",
-                "resolve": "1.22.8",
-                "rollup": "3.29.5",
-                "stacktrace-parser": "^0.1.10"
-            },
-            "engines": {
-                "node": ">=14.18"
-            },
-            "peerDependencies": {
-                "next": "^13.2.0 || ^14.0 || ^15.0.0-rc.0"
-            }
-        },
-        "node_modules/@sentry/nextjs/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@sentry/nextjs/node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/@sentry/node": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.1.tgz",
-            "integrity": "sha512-s8ydn/OxZFIxc9Fvt23gJkrXkCvPnUu2bDKwjQBCx0M1b4DdNdp4FaimT6B9reya7buj+tsNkZAoT11KqFhG/g==",
-            "license": "MIT",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1",
-                "@opentelemetry/core": "^1.30.1",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/instrumentation-amqplib": "^0.46.0",
-                "@opentelemetry/instrumentation-connect": "0.43.0",
-                "@opentelemetry/instrumentation-dataloader": "0.16.0",
-                "@opentelemetry/instrumentation-express": "0.47.0",
-                "@opentelemetry/instrumentation-fastify": "0.44.1",
-                "@opentelemetry/instrumentation-fs": "0.19.0",
-                "@opentelemetry/instrumentation-generic-pool": "0.43.0",
-                "@opentelemetry/instrumentation-graphql": "0.47.0",
-                "@opentelemetry/instrumentation-hapi": "0.45.1",
-                "@opentelemetry/instrumentation-http": "0.57.1",
-                "@opentelemetry/instrumentation-ioredis": "0.47.0",
-                "@opentelemetry/instrumentation-kafkajs": "0.7.0",
-                "@opentelemetry/instrumentation-knex": "0.44.0",
-                "@opentelemetry/instrumentation-koa": "0.47.0",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
-                "@opentelemetry/instrumentation-mongodb": "0.51.0",
-                "@opentelemetry/instrumentation-mongoose": "0.46.0",
-                "@opentelemetry/instrumentation-mysql": "0.45.0",
-                "@opentelemetry/instrumentation-mysql2": "0.45.0",
-                "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
-                "@opentelemetry/instrumentation-pg": "0.50.0",
-                "@opentelemetry/instrumentation-redis-4": "0.46.0",
-                "@opentelemetry/instrumentation-tedious": "0.18.0",
-                "@opentelemetry/instrumentation-undici": "0.10.0",
-                "@opentelemetry/resources": "^1.30.1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.28.0",
-                "@prisma/instrumentation": "5.22.0",
-                "@sentry/core": "8.55.1",
-                "@sentry/opentelemetry": "8.55.1",
-                "import-in-the-middle": "^1.11.2"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry/opentelemetry": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.1.tgz",
-            "integrity": "sha512-ipiM/k3Hzt8visoBfkDb4AQBWHkJeou3SjoPec7NlDabH/Jj8x6VlK5Hex4z+WOv99rRy+5MUtga/CZnOjvh0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1",
-                "@opentelemetry/core": "^1.30.1",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.28.0"
-            }
-        },
-        "node_modules/@sentry/react": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.1.tgz",
-            "integrity": "sha512-vrqEI1EVRMaeUluHSt84//WFuMecqAfwS+t2SojhvXtsSP6BbaCHd0jt7til5MBzI9kWAQjIxsUUr3pbFAviVg==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/browser": "8.55.1",
-                "@sentry/core": "8.55.1",
-                "hoist-non-react-statics": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=14.18"
-            },
-            "peerDependencies": {
-                "react": "^16.14.0 || 17.x || 18.x || 19.x"
-            }
-        },
-        "node_modules/@sentry/vercel-edge": {
-            "version": "8.55.1",
-            "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-8.55.1.tgz",
-            "integrity": "sha512-gVxiltkEr4Pu0J4Q0QfyELKoWQ7a6nS22FaA1ityZ7daJz/5zaGrKR+t11/7IGIxybGk1mGdnRS++9DzVPvAhw==",
-            "license": "MIT",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@sentry/core": "8.55.1"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
-        "node_modules/@sentry/webpack-plugin": {
-            "version": "2.22.7",
-            "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-2.22.7.tgz",
-            "integrity": "sha512-j5h5LZHWDlm/FQCCmEghQ9FzYXwfZdlOf3FE/X6rK6lrtx0JCAkq+uhMSasoyP4XYKL4P4vRS6WFSos4jxf/UA==",
-            "license": "MIT",
-            "dependencies": {
-                "@sentry/bundler-plugin-core": "2.22.7",
-                "unplugin": "1.0.1",
-                "uuid": "^9.0.0"
-            },
-            "engines": {
-                "node": ">= 14"
-            },
-            "peerDependencies": {
-                "webpack": ">=4.40.0"
-            }
-        },
-        "node_modules/@sentry/webpack-plugin/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.48",
@@ -6081,15 +4616,6 @@
                 "assertion-error": "^2.0.1"
             }
         },
-        "node_modules/@types/connect": {
-            "version": "3.4.36",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-            "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/d3-array": {
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -6160,32 +4686,11 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/eslint": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/estree": "*",
-                "@types/json-schema": "*"
-            }
-        },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
-            }
-        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/istanbul-lib-coverage": {
@@ -6230,6 +4735,7 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json5": {
@@ -6238,15 +4744,6 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/mysql": {
-            "version": "2.15.26",
-            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
-            "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/node": {
             "version": "20.19.37",
@@ -6266,15 +4763,6 @@
                 "@types/node": "*",
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
-            }
-        },
-        "node_modules/@types/pg-pool": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
-            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg": "*"
             }
         },
         "node_modules/@types/prop-types": {
@@ -6341,27 +4829,12 @@
                 "node": ">= 0.12"
             }
         },
-        "node_modules/@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-            "license": "MIT"
-        },
         "node_modules/@types/stack-utils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/tedious": {
-            "version": "4.0.14",
-            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -6801,39 +5274,6 @@
             "os": [
                 "win32"
             ]
-        },
-        "node_modules/@upstash/core-analytics": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
-            "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@upstash/redis": "^1.28.3"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@upstash/ratelimit": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
-            "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
-            "license": "MIT",
-            "dependencies": {
-                "@upstash/core-analytics": "^0.0.10"
-            },
-            "peerDependencies": {
-                "@upstash/redis": "^1.34.3"
-            }
-        },
-        "node_modules/@upstash/redis": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
-            "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
-            "license": "MIT",
-            "dependencies": {
-                "uncrypto": "^0.1.3"
-            }
         },
         "node_modules/@vercel/backends": {
             "version": "0.0.46",
@@ -10460,181 +8900,6 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@webassemblyjs/ast": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.13.2",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-            }
-        },
-        "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-                "@webassemblyjs/helper-api-error": "1.13.2",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/wasm-gen": "1.14.1"
-            }
-        },
-        "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@xtuc/ieee754": "^1.2.0"
-            }
-        },
-        "node_modules/@webassemblyjs/leb128": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@webassemblyjs/utf8": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/helper-wasm-section": "1.14.1",
-                "@webassemblyjs/wasm-gen": "1.14.1",
-                "@webassemblyjs/wasm-opt": "1.14.1",
-                "@webassemblyjs/wasm-parser": "1.14.1",
-                "@webassemblyjs/wast-printer": "1.14.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/ieee754": "1.13.2",
-                "@webassemblyjs/leb128": "1.13.2",
-                "@webassemblyjs/utf8": "1.13.2"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-buffer": "1.14.1",
-                "@webassemblyjs/wasm-gen": "1.14.1",
-                "@webassemblyjs/wasm-parser": "1.14.1"
-            }
-        },
-        "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@webassemblyjs/helper-api-error": "1.13.2",
-                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-                "@webassemblyjs/ieee754": "1.13.2",
-                "@webassemblyjs/leb128": "1.13.2",
-                "@webassemblyjs/utf8": "1.13.2"
-            }
-        },
-        "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@webassemblyjs/ast": "1.14.1",
-                "@xtuc/long": "4.2.2"
-            }
-        },
-        "node_modules/@xtuc/ieee754": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "license": "BSD-3-Clause",
-            "peer": true
-        },
-        "node_modules/@xtuc/long": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "license": "Apache-2.0",
-            "peer": true
-        },
         "node_modules/abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -10645,6 +8910,7 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -10657,22 +8923,10 @@
             "version": "1.9.5",
             "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
             "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -10752,48 +9006,6 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ajv-formats": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependencies": {
-                "ajv": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "ajv": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -10807,6 +9019,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -11266,6 +9479,7 @@
             "version": "2.10.8",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
             "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -11354,6 +9568,7 @@
             "version": "4.28.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -11403,6 +9618,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/bufferutil": {
@@ -11557,7 +9773,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -11681,16 +9896,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/chrome-trace-event": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-            "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
         "node_modules/ci-info": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -11711,6 +9916,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
             "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/class-variance-authority": {
@@ -11776,6 +9982,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -11788,6 +9995,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/color-support": {
@@ -11819,12 +10027,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/commondir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-            "license": "MIT"
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -11872,6 +10074,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -12591,6 +10794,7 @@
             "version": "1.5.321",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
             "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -12617,20 +10821,6 @@
             "license": "MIT",
             "dependencies": {
                 "once": "^1.4.0"
-            }
-        },
-        "node_modules/enhanced-resolve": {
-            "version": "5.21.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-            "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
             }
         },
         "node_modules/env-paths": {
@@ -12885,6 +11075,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13363,6 +11554,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -13375,6 +11567,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -13384,6 +11577,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/esutils": {
@@ -13411,16 +11605,6 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
-        },
-        "node_modules/events": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.x"
-            }
         },
         "node_modules/events-intercept": {
             "version": "2.0.0",
@@ -13502,6 +11686,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-glob": {
@@ -13551,23 +11736,6 @@
             "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
             "license": "Unlicense"
-        },
-        "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause",
-            "peer": true
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -13641,6 +11809,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
@@ -13724,12 +11893,6 @@
             "engines": {
                 "node": ">= 6"
             }
-        },
-        "node_modules/forwarded-parse": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
-            "license": "MIT"
         },
         "node_modules/fraction.js": {
             "version": "5.3.4",
@@ -13974,15 +12137,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/get-intrinsic": {
@@ -14296,6 +12450,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -14374,21 +12529,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
-        "node_modules/hoist-non-react-statics/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
         },
         "node_modules/html-entities": {
             "version": "2.6.0",
@@ -14523,18 +12663,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-in-the-middle": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-            "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "acorn": "^8.14.0",
-                "acorn-import-attributes": "^1.9.5",
-                "cjs-module-lexer": "^1.2.2",
-                "module-details-from-path": "^1.0.3"
             }
         },
         "node_modules/imurmurhash": {
@@ -14941,15 +13069,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-reference": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "*"
-            }
-        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -15253,37 +13372,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-worker": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
         "node_modules/jiti": {
             "version": "1.21.7",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -15329,18 +13417,6 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/jsesc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "license": "MIT",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/json-bigint": {
@@ -15770,24 +13846,11 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
@@ -15859,6 +13922,7 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -15959,6 +14023,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/merge2": {
@@ -16077,6 +14142,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
             "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -16244,12 +14310,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/module-details-from-path": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-            "license": "MIT"
-        },
         "node_modules/mri": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -16326,13 +14386,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/neo-async": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/netmask": {
             "version": "2.0.2",
@@ -16652,6 +14705,7 @@
             "version": "2.0.36",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
             "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nopt": {
@@ -16726,7 +14780,6 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -16972,6 +15025,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -16987,6 +15041,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
@@ -17134,6 +15189,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -17168,6 +15224,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
             "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^10.2.0",
@@ -17184,6 +15241,7 @@
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/path-to-regexp": {
@@ -17609,15 +15667,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/progress": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/promise-inflight": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -17740,6 +15789,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/pump": {
@@ -17761,6 +15811,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -18076,23 +16141,10 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
             }
         },
         "node_modules/reselect": {
@@ -18253,22 +16305,6 @@
                 "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.1"
             }
         },
-        "node_modules/rollup": {
-            "version": "3.29.5",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-            "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
-            "license": "MIT",
-            "bin": {
-                "rollup": "dist/bin/rollup"
-            },
-            "engines": {
-                "node": ">=14.18.0",
-                "npm": ">=8.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18383,63 +16419,6 @@
                 "loose-envify": "^1.1.0"
             }
         },
-        "node_modules/schema-utils": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/schema-utils/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/schema-utils/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -18543,17 +16522,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/side-channel": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -18573,7 +16545,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -18590,7 +16561,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -18609,7 +16579,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -18746,6 +16715,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -18764,6 +16734,7 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -18846,27 +16817,6 @@
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/stacktrace-parser": {
-            "version": "0.1.11",
-            "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
-            "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.7.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/stacktrace-parser/node_modules/type-fest": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-            "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/standardwebhooks": {
             "version": "1.0.0",
@@ -19232,20 +17182,16 @@
             }
         },
         "node_modules/stripe": {
-            "version": "22.1.0",
-            "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
-            "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+            "version": "17.7.0",
+            "resolved": "https://registry.npmjs.org/stripe/-/stripe-17.7.0.tgz",
+            "integrity": "sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==",
             "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=8.1.0",
+                "qs": "^6.11.0"
+            },
             "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@types/node": ">=18"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                }
+                "node": ">=12.*"
             }
         },
         "node_modules/stubs": {
@@ -19303,6 +17249,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -19402,20 +17349,6 @@
                 "tailwindcss": ">=3.0.0 || insiders"
             }
         },
-        "node_modules/tapable": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/tar": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -19471,66 +17404,6 @@
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
-        },
-        "node_modules/terser": {
-            "version": "5.46.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-            "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.15.0",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/terser-webpack-plugin": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
-            "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -20443,12 +18316,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/uncrypto": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-            "license": "MIT"
-        },
         "node_modules/undici": {
             "version": "6.24.1",
             "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
@@ -20509,18 +18376,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/unplugin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.0.1.tgz",
-            "integrity": "sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.8.1",
-                "chokidar": "^3.5.3",
-                "webpack-sources": "^3.2.3",
-                "webpack-virtual-modules": "^0.5.0"
-            }
-        },
         "node_modules/unrs-resolver": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -20560,6 +18415,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
             "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -22303,20 +20159,6 @@
                 }
             }
         },
-        "node_modules/watchpack": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.1.2"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/web-vitals": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
@@ -22329,110 +20171,6 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause"
-        },
-        "node_modules/webpack": {
-            "version": "5.106.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-            "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.8",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
-                "acorn-import-phases": "^1.0.3",
-                "browserslist": "^4.28.1",
-                "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.20.0",
-                "es-module-lexer": "^2.0.0",
-                "eslint-scope": "5.1.1",
-                "events": "^3.2.0",
-                "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.11",
-                "loader-runner": "^4.3.1",
-                "mime-db": "^1.54.0",
-                "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.3",
-                "tapable": "^2.3.0",
-                "terser-webpack-plugin": "^5.3.17",
-                "watchpack": "^2.5.1",
-                "webpack-sources": "^3.3.4"
-            },
-            "bin": {
-                "webpack": "bin/webpack.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependenciesMeta": {
-                "webpack-cli": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/webpack-sources": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.4.0.tgz",
-            "integrity": "sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack-virtual-modules": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
-            "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
-            "license": "MIT"
-        },
-        "node_modules/webpack/node_modules/es-module-lexer": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/webpack/node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/webpack/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/webpack/node_modules/mime-db": {
-            "version": "1.54.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -22825,6 +20563,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"

--- a/web/test/stripe-webhook.test.ts
+++ b/web/test/stripe-webhook.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Unit tests for POST /api/webhooks/stripe
+ *
+ * These tests exercise the webhook handler in isolation using mocked
+ * Stripe SDK, Drizzle ORM, and Clerk client. The key coverage goals are:
+ *   - Signature verification failure → 400
+ *   - Missing STRIPE_WEBHOOK_SECRET → 500
+ *   - checkout.session.completed → Postgres + Clerk tier update
+ *   - customer.subscription.updated → Postgres + Clerk tier update
+ *   - customer.subscription.deleted → free tier
+ *   - invoice.payment_failed → past_due (no downgrade)
+ *   - invoice.payment_succeeded → active restore
+ *   - Unrecognised event type → 200 (no-op)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --------------------------------------------------------------------------
+// Module mocks — must be declared before any imports that pull in the modules
+// --------------------------------------------------------------------------
+
+// Mock Stripe
+const mockConstructEvent = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
+
+vi.mock("stripe", () => {
+    const Stripe: any = vi.fn().mockImplementation(() => ({
+        webhooks: {
+            constructEvent: mockConstructEvent,
+        },
+        subscriptions: {
+            retrieve: mockSubscriptionsRetrieve,
+        },
+    }));
+    return { default: Stripe };
+});
+
+// Mock Drizzle db
+const mockDbUpdate = vi.fn();
+const mockDbSelect = vi.fn();
+
+vi.mock("@/db", () => ({
+    db: {
+        update: mockDbUpdate,
+        select: mockDbSelect,
+    },
+}));
+
+// Mock Clerk
+const mockUpdateUserMetadata = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock("@clerk/nextjs/server", () => ({
+    clerkClient: {
+        users: {
+            updateUserMetadata: mockUpdateUserMetadata,
+            getUser: mockGetUser,
+        },
+    },
+}));
+
+// Mock BigQuery (fire-and-forget audit log)
+vi.mock("@google-cloud/bigquery", () => ({
+    BigQuery: vi.fn().mockImplementation(() => ({
+        dataset: vi.fn().mockReturnValue({
+            table: vi.fn().mockReturnValue({
+                insert: vi.fn().mockResolvedValue(undefined),
+            }),
+        }),
+    })),
+}));
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/**
+ * Build a minimal mock Stripe event.
+ */
+function makeEvent(type: string, data: object): object {
+    return {
+        id: `evt_test_${type.replace(/\./g, "_")}`,
+        type,
+        livemode: false,
+        data: { object: data },
+    };
+}
+
+/**
+ * Build a Next.js Request-like object with the given body and optional
+ * stripe-signature header.
+ */
+function makeRequest(body: string, sig: string | null = "t=1,v1=abc"): Request {
+    const headers: Record<string, string> = { "Content-Type": "text/plain" };
+    if (sig !== null) headers["stripe-signature"] = sig;
+    return new Request("http://localhost/api/webhooks/stripe", {
+        method: "POST",
+        headers,
+        body,
+    });
+}
+
+// --------------------------------------------------------------------------
+// Setup a chainable Drizzle update mock
+// --------------------------------------------------------------------------
+
+function setupDbUpdateChain(): void {
+    const chain = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDbUpdate.mockReturnValue(chain);
+}
+
+function setupDbSelectChain(rows: object[]): void {
+    const chain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(rows),
+    };
+    mockDbSelect.mockReturnValue(chain);
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe("POST /api/webhooks/stripe", () => {
+    // We import the route handler lazily inside each test so vi.mock hoisting
+    // has taken effect. We store the imported POST function here.
+    let POST: (req: Request) => Promise<Response>;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        // Reset env
+        process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+        process.env.STRIPE_SECRET_KEY = "sk_test_xxx";
+        process.env.GCP_PROJECT_ID = "cap-alpha-protocol";
+
+        // Default: import the route handler
+        const mod = await import("@/app/api/webhooks/stripe/route");
+        POST = mod.POST;
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    // -----------------------------------------------------------------------
+    // Config guard
+    // -----------------------------------------------------------------------
+
+    it("returns 500 when STRIPE_WEBHOOK_SECRET is missing", async () => {
+        delete process.env.STRIPE_WEBHOOK_SECRET;
+
+        const req = makeRequest("{}");
+        const res = await POST(req);
+
+        expect(res.status).toBe(500);
+    });
+
+    // -----------------------------------------------------------------------
+    // Signature verification
+    // -----------------------------------------------------------------------
+
+    it("returns 400 when stripe-signature header is absent", async () => {
+        const req = makeRequest("{}", null);
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when Stripe signature verification fails", async () => {
+        mockConstructEvent.mockImplementation(() => {
+            throw new Error("Signature verification failed");
+        });
+
+        const req = makeRequest("{}", "t=1,v1=bad");
+        const res = await POST(req);
+
+        expect(res.status).toBe(400);
+    });
+
+    // -----------------------------------------------------------------------
+    // checkout.session.completed
+    // -----------------------------------------------------------------------
+
+    it("handles checkout.session.completed → PRO tier", async () => {
+        const sessionObj = {
+            client_reference_id: "user_clerk123",
+            customer: "cus_abc",
+            subscription: "sub_xyz",
+        };
+        const event = makeEvent("checkout.session.completed", sessionObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        mockSubscriptionsRetrieve.mockResolvedValue({
+            items: { data: [{ price: { id: process.env.STRIPE_PRICE_PRO ?? "price_pro" } }] },
+            current_period_end: Math.floor(Date.now() / 1000) + 2592000,
+        });
+
+        setupDbUpdateChain();
+
+        const req = makeRequest(JSON.stringify(sessionObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(mockDbUpdate).toHaveBeenCalled();
+        expect(mockUpdateUserMetadata).toHaveBeenCalledWith("user_clerk123", {
+            publicMetadata: { tier: expect.any(String) },
+        });
+    });
+
+    it("handles checkout.session.completed with no client_reference_id gracefully", async () => {
+        const sessionObj = { customer: "cus_abc", subscription: "sub_xyz" };
+        const event = makeEvent("checkout.session.completed", sessionObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        const req = makeRequest(JSON.stringify(sessionObj));
+        const res = await POST(req);
+
+        // No Clerk call since we couldn't identify the user
+        expect(res.status).toBe(200);
+        expect(mockUpdateUserMetadata).not.toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
+    // customer.subscription.updated
+    // -----------------------------------------------------------------------
+
+    it("handles customer.subscription.updated → updates tier and status", async () => {
+        const subObj = {
+            customer: "cus_abc",
+            status: "active",
+            items: { data: [{ price: { id: "price_pro" } }] },
+            current_period_end: Math.floor(Date.now() / 1000) + 2592000,
+        };
+        const event = makeEvent("customer.subscription.updated", subObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        setupDbSelectChain([{ clerkId: "user_clerk123" }]);
+        setupDbUpdateChain();
+
+        const req = makeRequest(JSON.stringify(subObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(mockUpdateUserMetadata).toHaveBeenCalledWith("user_clerk123", {
+            publicMetadata: { tier: expect.any(String) },
+        });
+    });
+
+    it("handles customer.subscription.updated with unknown customer gracefully", async () => {
+        const subObj = {
+            customer: "cus_unknown",
+            status: "active",
+            items: { data: [{ price: { id: "price_pro" } }] },
+            current_period_end: Math.floor(Date.now() / 1000) + 2592000,
+        };
+        const event = makeEvent("customer.subscription.updated", subObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        setupDbSelectChain([]); // no rows → unknown customer
+
+        const req = makeRequest(JSON.stringify(subObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(mockUpdateUserMetadata).not.toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
+    // customer.subscription.deleted
+    // -----------------------------------------------------------------------
+
+    it("handles customer.subscription.deleted → free tier", async () => {
+        const subObj = { customer: "cus_abc" };
+        const event = makeEvent("customer.subscription.deleted", subObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        setupDbSelectChain([{ clerkId: "user_clerk123" }]);
+        setupDbUpdateChain();
+
+        const req = makeRequest(JSON.stringify(subObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(mockUpdateUserMetadata).toHaveBeenCalledWith("user_clerk123", {
+            publicMetadata: { tier: "free" },
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // invoice.payment_failed
+    // -----------------------------------------------------------------------
+
+    it("handles invoice.payment_failed → sets past_due, does NOT downgrade tier", async () => {
+        const invoiceObj = { customer: "cus_abc" };
+        const event = makeEvent("invoice.payment_failed", invoiceObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        setupDbSelectChain([{ clerkId: "user_clerk123" }]);
+        const updateChain = {
+            set: vi.fn().mockReturnThis(),
+            where: vi.fn().mockResolvedValue(undefined),
+        };
+        mockDbUpdate.mockReturnValue(updateChain);
+
+        const req = makeRequest(JSON.stringify(invoiceObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        // Tier NOT changed — only status updated to past_due
+        expect(mockUpdateUserMetadata).not.toHaveBeenCalled();
+        expect(updateChain.set).toHaveBeenCalledWith(
+            expect.objectContaining({ stripeSubscriptionStatus: "past_due" })
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // invoice.payment_succeeded
+    // -----------------------------------------------------------------------
+
+    it("handles invoice.payment_succeeded → restores active status", async () => {
+        const invoiceObj = { customer: "cus_abc" };
+        const event = makeEvent("invoice.payment_succeeded", invoiceObj);
+        mockConstructEvent.mockReturnValue(event);
+
+        setupDbSelectChain([{ clerkId: "user_clerk123" }]);
+        const updateChain = {
+            set: vi.fn().mockReturnThis(),
+            where: vi.fn().mockResolvedValue(undefined),
+        };
+        mockDbUpdate.mockReturnValue(updateChain);
+
+        const req = makeRequest(JSON.stringify(invoiceObj));
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(updateChain.set).toHaveBeenCalledWith(
+            expect.objectContaining({ stripeSubscriptionStatus: "active", isPro: true })
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // Unknown event type
+    // -----------------------------------------------------------------------
+
+    it("returns 200 for unrecognised event types (no-op)", async () => {
+        const event = makeEvent("payment_intent.created", { id: "pi_test" });
+        mockConstructEvent.mockReturnValue(event);
+
+        const req = makeRequest("{}");
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+        expect(mockDbUpdate).not.toHaveBeenCalled();
+        expect(mockUpdateUserMetadata).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- `POST /api/webhooks/stripe` — verifies Stripe signature and handles 5 events:
  - `checkout.session.completed` → store Stripe customer/subscription IDs, set tier
  - `customer.subscription.updated` → sync plan changes, update tier
  - `customer.subscription.deleted` → downgrade to free
  - `invoice.payment_failed` → mark `past_due` (no immediate downgrade; Stripe retries)
  - `invoice.payment_succeeded` → clear past_due, restore active
- `web/lib/stripe.ts` — Stripe client singleton + `tierFromPriceId()` mapping via env vars (`STRIPE_PRICE_PRO`, `STRIPE_PRICE_API_STARTER`, `STRIPE_PRICE_ENTERPRISE`)
- `web/lib/api-keys/tiers.ts` — `getUserTier()` now reads `publicMetadata.tier` from Clerk instead of always returning `"free"`
- Fire-and-forget audit log to `monetization.stripe_events` (BigQuery)
- `pipeline/migrations/013_create_stripe_events.sql` — new BQ table (partitioned by date, clustered by event_type)

## Required env vars (add to Vercel)

| Var | Source |
|---|---|
| `STRIPE_WEBHOOK_SECRET` | Stripe Dashboard → Webhooks → endpoint secret |
| `STRIPE_SECRET_KEY` | Stripe Dashboard → API keys |
| `STRIPE_PRICE_PRO` | Stripe price ID for Pro plan |
| `STRIPE_PRICE_API_STARTER` | Stripe price ID for API Starter plan |
| `STRIPE_PRICE_ENTERPRISE` | Stripe price ID for Enterprise plan |

## Test plan

- [x] All 525 unit tests pass (`make check`)
- [ ] Stripe CLI: `stripe trigger checkout.session.completed` → verify Postgres + Clerk metadata updated
- [ ] Stripe CLI: `stripe trigger customer.subscription.deleted` → verify tier downgraded to `free`
- [ ] Stripe CLI: forged signature → confirm 400 response
- [ ] Replay duplicate event_id → idempotent (BQ insert may duplicate, Postgres update is safe)

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)