### PR TITLE
chore(dx): rewrite /go command — parallel subagents + duplicate PR check

### DIFF
--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -1,24 +1,205 @@
-  ---
-  description: Autonomous Sprint Task Execution Engine
-  ---
+---
+description: Safely claim and complete one issue using a shared orientation cache
+---
 
-  # /go Workflow Instructions
-  // turbo-all
+# Multi-Agent Work Protocol (Minimal)
 
-  When the user triggers the `/go` slash command, you must operate in full autonomous mode to execute the remaining sprint backlog. Follow this strict operational loop:
+You are one of multiple agents working in parallel.
 
-  1. **Locate the Next Task**: Open and read the official Nexus sprint document at `docs/sprints/MASTER_SPRINT_PLAN.md`. Find the very next task that is NOT marked as `[x]`, `[-]` (Deferred), `[b]` (Blocked), or `[/]` (In Progress). To prevent collisions in multi-agent runs, favor tasks in different
-  technical domains or files than what other agents are actively working on.
-  2. **Mark In-Progress & Claim**: Update `MASTER_SPRINT_PLAN.md` and mark the task as `[/]` (In Progress). You MUST append a claim tag (e.g. `(Claimed by Agent)`) to explicitly lock the task.
-  3. **Execute Task**:
-      - Leverage the `// turbo-all` directive globally. Do not ask for user permission to run standard bash commands, tests, or scripts.
-      - If the task requires architectural design, draft it in `implementation_plan.md` first.
-      - Write the code, run the necessary scripts, or configure the necessary infrastructure autonomously.
-  4. **Validation & Resolution**:
-      - You MUST run validation tests autonomously. If tests fail or commands error out, fix them autonomously by reading the terminal output. Do not notify the user until everything passes or you have failed 5 times in a row.
-  5. **Handle Blockers**: If you encounter a hard blocker (e.g., missing third-party API keys, impossible OS constraints):
-      - Mark the task as `[b]` (Blocked) in `MASTER_SPRINT_PLAN.md`.
-      - Document the explicit blocker and move to the NEXT unblocked task in step 1 without alerting the user.
-  6. **Mark Completed**: Once you have explicitly proven the task is done, mark the task as `[x]` (Completed) in `MASTER_SPRINT_PLAN.md`.
-  7. **The Infinite Loop**: Immediately return to Step 1 and find the *next* task. Continue this loop until there are absolute zero actionable sprint tasks remaining in the `MASTER_SPRINT_PLAN.md` backlog. Do not stop to wait for praise. MOVE!
+Your goal:
+- Complete exactly one unblocked issue
+- Avoid duplicate work
+- Follow repository conventions via a shared cache
 
+If you cannot reliably perform any required step, EXIT safely.
+
+## Autonomy
+
+Run autonomously. Do NOT prompt the user for permission on:
+- Read-only / exploratory commands (git log, git status, cat, ls, grep, gh issue/pr queries)
+- Running tests (pytest)
+- Creating branches, committing, pushing feature branches
+- Opening/commenting on issues and PRs
+- Any command whose purpose is understanding the current state of the codebase or infrastructure
+
+Only pause for user input on items listed in CLAUDE.md "When to ask the user" (reward changes, schema changes, universe changes, billing, scope ambiguity).
+
+---
+
+# Core Flow
+
+1. LOAD_ORIENTATION
+2. PROCESS_FEEDBACK
+3. SELECT_ISSUE
+4. CLAIM
+5. VERIFY
+6. WORK
+7. COMPLETE
+
+---
+
+# STATE 1: LOAD_ORIENTATION
+
+IF `.claude/agent-orientation.md` exists:
+  READ it and follow it strictly
+
+ELSE:
+  You are the bootstrap agent:
+    - Discover repo conventions
+    - Define how to perform required operations (issues, comments, PRs, etc.)
+    - Write `.claude/agent-orientation.md`
+    - Open a PR: "bootstrap agent orientation cache"
+  EXIT
+
+---
+
+# STATE 2: PROCESS_FEEDBACK
+
+Check for:
+- Issues labeled `agent-feedback`
+- Comments mentioning "agent"
+- Recently failed/closed PRs
+
+IF feedback affects conventions:
+  Update orientation cache (use lock)
+  IF substantial change:
+    EXIT
+
+---
+
+# STATE 3: SELECT_ISSUE
+
+List open issues
+
+Exclude:
+- do-not-touch labels
+- agent-feedback
+- blocked / dependency issues
+- issues with active claim (<2h)
+
+Prefer:
+- clear scope
+- small surface area
+- ready-to-work labels
+
+IF none:
+  EXIT
+
+---
+
+# STATE 4: CLAIM
+
+Check issue comments for active claim:
+- contains "🤖" or "claim" or "working"
+- within last 2 hours
+- not released
+
+IF exists:
+  return to SELECT_ISSUE
+
+POST comment (with identity footer per agent-orientation.md):
+  "🤖 intending to work on this at <UTC timestamp>
+
+  — 🤖 `go`"
+
+WAIT ~2 minutes
+
+---
+
+# STATE 5: VERIFY
+
+Re-read comments
+
+Extract all claims
+Sort by timestamp in comment body
+
+IF your claim is earliest:
+  proceed
+
+ELSE:
+  POST "🤖 yielding to earlier claim"
+  return to SELECT_ISSUE
+
+---
+
+# CHECKPOINT (MANDATORY)
+
+Before work:
+
+[ ] Claim posted
+[ ] Wait completed
+[ ] No earlier claim
+[ ] You are earliest
+
+IF any false:
+  STOP
+
+---
+
+# STATE 6: WORK
+
+- Create branch per repo convention (or fallback: agent/issue-<id>)
+- Implement solution
+- Follow all conventions from cache
+- Run all required checks
+
+DO NOT:
+- modify restricted paths
+- disable checks
+- perform destructive git actions
+
+---
+
+# STATE 7: COMPLETE
+
+Choose ONE:
+
+## DONE
+- Open PR (use repo conventions)
+- Include closing keyword (e.g., Closes #id)
+- Comment with PR link
+
+## BLOCKED
+- Comment:
+  - what failed
+  - what you tried
+  - what is needed
+- Mark blocked if label exists
+- POST "🤖 releasing issue"
+
+## INVALID
+- Explain and close issue
+- POST "🤖 releasing issue"
+
+---
+
+# CACHE LOCK (for updates only)
+
+Before editing `.claude/agent-orientation.md`:
+
+- Check for open "agent-orientation cache lock"
+- If recent (<30 min): do not proceed
+- If stale: take over
+- If none: create lock
+
+After update:
+- Close lock with PR reference
+
+---
+
+# HARD RULES
+
+- One issue per run
+- Never override documented conventions
+- Never ignore active claims
+- Never force-push shared branches
+- Never modify default branch directly
+- When unsure: EXIT or file `agent-feedback`
+
+---
+
+# SUCCESS =
+
+- One issue claimed without conflict
+- Valid PR OR clear blocked report
+- Clean repository state

--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -182,6 +182,27 @@ DO NOT:
 Choose ONE:
 
 ## DONE
+
+### Pre-PR duplicate check (MANDATORY — run before gh pr create)
+
+```bash
+# 1. Exact branch match
+gh pr list --head <branch> --json number,url,state
+
+# 2. Same closing issue
+gh pr list --state open --search "Closes #N" --json number,title,url
+
+# 3. Similar title (same type+scope prefix)
+gh pr list --state open --search "<type(scope)>" --json number,title,url
+```
+
+Resolve as follows:
+- **Existing open PR on this branch** → push to it; do NOT create a new PR. Update the PR body if the scope changed.
+- **Open PR closing the same issue** → post a comment linking to it; do NOT create a new PR; EXIT.
+- **Merged/closed PR closing the same issue** → verify the issue is actually closed; if so, EXIT with "already done".
+- **No duplicate found** → proceed to create the PR.
+
+### Create PR
 - Push branch, open PR with `Closes #N` in body
 - Use `gh pr merge <number> --rebase --auto` to queue
 - Comment on issue N:

--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -1,15 +1,15 @@
 ---
-description: Safely claim and complete one issue using a shared orientation cache
+description: Safely claim and complete issues using a shared orientation cache — spawns parallel subagents
 ---
 
-# Multi-Agent Work Protocol (Minimal)
+# /go — Parallel Agent Orchestrator
 
-You are one of multiple agents working in parallel.
+You are invoked either as an **ORCHESTRATOR** (default, no issue pre-assigned) or as a
+**WORKER** (orchestrator passed you `ISSUE=<n>`).
 
-Your goal:
-- Complete exactly one unblocked issue
-- Avoid duplicate work
-- Follow repository conventions via a shared cache
+Detect your mode from the invocation context:
+- `ISSUE=<n>` present in this prompt → **WORKER MODE** — skip to STATE 4
+- No issue assigned → **ORCHESTRATOR MODE** — run states 1–3, then spawn workers
 
 If you cannot reliably perform any required step, EXIT safely.
 
@@ -22,19 +22,12 @@ Run autonomously. Do NOT prompt the user for permission on:
 - Opening/commenting on issues and PRs
 - Any command whose purpose is understanding the current state of the codebase or infrastructure
 
-Only pause for user input on items listed in CLAUDE.md "When to ask the user" (reward changes, schema changes, universe changes, billing, scope ambiguity).
+Only pause for user input on items listed in CLAUDE.md "When to ask the user" (reward changes,
+schema changes, universe changes, billing, scope ambiguity).
 
 ---
 
-# Core Flow
-
-1. LOAD_ORIENTATION
-2. PROCESS_FEEDBACK
-3. SELECT_ISSUE
-4. CLAIM
-5. VERIFY
-6. WORK
-7. COMPLETE
+# ORCHESTRATOR MODE (states 1–3 + spawn)
 
 ---
 
@@ -67,86 +60,120 @@ IF feedback affects conventions:
 
 ---
 
-# STATE 3: SELECT_ISSUE
+# STATE 3: SELECT_ISSUES + SPAWN WORKERS
 
-List open issues
+## 3a. Build shortlist
 
-Exclude:
-- do-not-touch labels
-- agent-feedback
-- blocked / dependency issues
-- issues with active claim (<2h)
+List open issues. For each, check:
+- No `do-not-touch`, `agent-feedback`, `icebox` labels
+- Not an umbrella/meta issue
+- No active claim comment within last 2 hours (contains "🤖" / "claim" / "intending", not "releasing")
 
-Prefer:
-- clear scope
-- small surface area
-- ready-to-work labels
+Rank by priority:
+1. `critical-path` bugs
+2. `backend` / `data` / `infrastructure` features with clear scope
+3. Everything else
 
-IF none:
-  EXIT
+Pick up to **3** candidates (more = diminishing returns, GitHub rate limits).
+
+## 3b. Spawn workers in parallel
+
+For each selected issue N, call the **Agent** tool with:
+- `isolation: "worktree"`
+- Prompt: the full text of this file, prepended with `ISSUE=<N>`
+
+Call all Agent tools simultaneously (parallel, not sequential).
+
+## 3c. Collect and report
+
+Wait for all subagents to finish. Print a summary table:
+
+```
+| Issue | Title (short) | Outcome | PR |
+|-------|--------------|---------|-----|
+| #N    | ...          | DONE / YIELDED / BLOCKED | #M |
+```
+
+## 3d. WORKFLOW REVIEW (mandatory)
+
+After the summary, review this run for friction, inefficiency, or gaps in the protocol.
+Output ONE of:
+
+- A bulleted list of concrete improvement suggestions (file to edit, what to change, why)
+- "No improvements needed this run."
+
+Do not skip this step.
+
+---
+
+# WORKER MODE (states 4–7, triggered with ISSUE=<N>)
+
+The orchestrator has pre-assigned you issue **N**. Your only job is to claim it, implement
+the fix, and open a PR. Do not scan for other issues.
 
 ---
 
 # STATE 4: CLAIM
 
-Check issue comments for active claim:
-- contains "🤖" or "claim" or "working"
+Check issue N's comments for an active claim:
+- contains "🤖" or "claim" or "working" or "intending"
 - within last 2 hours
-- not released
+- not followed by "releasing"
 
-IF exists:
-  return to SELECT_ISSUE
+IF active claim exists:
+  EXIT with "yielding — active claim already on #N"
 
-POST comment (with identity footer per agent-orientation.md):
-  "🤖 intending to work on this at <UTC timestamp>
+POST comment on issue N:
+```
+🤖 intending to work on this at <UTC timestamp>
 
-  — 🤖 `go`"
+— 🤖 `go`
+```
 
-WAIT ~2 minutes
+WAIT ~2 minutes (use sleep or background task; do not skip).
 
 ---
 
 # STATE 5: VERIFY
 
-Re-read comments
+Re-read issue N's comments.
 
-Extract all claims
-Sort by timestamp in comment body
+Extract all claim timestamps from comment bodies (ISO-8601 UTC strings).
+Sort ascending.
 
-IF your claim is earliest:
+IF your timestamp is earliest:
   proceed
 
 ELSE:
   POST "🤖 yielding to earlier claim"
-  return to SELECT_ISSUE
+  EXIT
 
 ---
 
 # CHECKPOINT (MANDATORY)
 
-Before work:
+Before any code changes:
 
-[ ] Claim posted
-[ ] Wait completed
-[ ] No earlier claim
-[ ] You are earliest
+[ ] Claim posted on issue N
+[ ] 2-minute wait completed
+[ ] Re-read comments
+[ ] Your timestamp is earliest
 
-IF any false:
-  STOP
+IF any false: STOP
 
 ---
 
 # STATE 6: WORK
 
-- Create branch per repo convention (or fallback: agent/issue-<id>)
+- Create worktree branch: `worktree-<type>-<N>-<slug>`
 - Implement solution
-- Follow all conventions from cache
-- Run all required checks
+- Follow all conventions from orientation cache and CLAUDE.md
+- Run `make check` (lint + unit tests) before committing
 
 DO NOT:
-- modify restricted paths
-- disable checks
-- perform destructive git actions
+- modify restricted/shared files without claiming them first
+- disable linting or test checks
+- perform destructive git actions (force-push, reset --hard)
 
 ---
 
@@ -155,51 +182,56 @@ DO NOT:
 Choose ONE:
 
 ## DONE
-- Open PR (use repo conventions)
-- Include closing keyword (e.g., Closes #id)
-- Comment with PR link
+- Push branch, open PR with `Closes #N` in body
+- Use `gh pr merge <number> --rebase --auto` to queue
+- Comment on issue N:
+  ```
+  🤖 PR #<M> opened and queued for merge: <url>
+
+  Changes:
+  - <bullet summary>
+
+  — 🤖 `go`
+  ```
 
 ## BLOCKED
-- Comment:
+- Comment on issue N explaining:
   - what failed
   - what you tried
-  - what is needed
-- Mark blocked if label exists
-- POST "🤖 releasing issue"
+  - what is needed to unblock
+- POST "🤖 releasing issue — blocked"
+- EXIT
 
 ## INVALID
-- Explain and close issue
-- POST "🤖 releasing issue"
+- Explain why and close the issue
+- POST "🤖 releasing issue — invalid"
+- EXIT
 
 ---
 
-# CACHE LOCK (for updates only)
+# CACHE LOCK (orientation updates only)
 
 Before editing `.claude/agent-orientation.md`:
 
-- Check for open "agent-orientation cache lock"
+- Check for open "agent-orientation cache lock" issue/comment
 - If recent (<30 min): do not proceed
-- If stale: take over
-- If none: create lock
-
-After update:
-- Close lock with PR reference
+- If stale or none: take the lock, update, release with PR reference
 
 ---
 
 # HARD RULES
 
-- One issue per run
-- Never override documented conventions
+- Orchestrator spawns workers; workers do not spawn more workers
+- Max 3 workers per orchestrator run
 - Never ignore active claims
 - Never force-push shared branches
-- Never modify default branch directly
-- When unsure: EXIT or file `agent-feedback`
+- Never push directly to main
+- When unsure: EXIT and file an `agent-feedback` issue
 
 ---
 
 # SUCCESS =
 
-- One issue claimed without conflict
-- Valid PR OR clear blocked report
+- Each worker: one issue claimed without conflict, valid PR OR clear blocked report
+- Orchestrator: summary table printed, workflow review completed
 - Clean repository state

--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -197,7 +197,8 @@ gh pr list --state open --search "<type(scope)>" --json number,title,url
 ```
 
 Resolve as follows:
-- **Existing open PR on this branch** → push to it; do NOT create a new PR. Update the PR body if the scope changed.
+- **Existing open PR on this branch by you** → push to it; do NOT create a new PR. Update the PR body if the scope changed.
+- **Existing open PR on this branch by a different agent** → do NOT push to it; comment linking to it; EXIT.
 - **Open PR closing the same issue** → post a comment linking to it; do NOT create a new PR; EXIT.
 - **Merged/closed PR closing the same issue** → verify the issue is actually closed; if so, EXIT with "already done".
 - **No duplicate found** → proceed to create the PR.


### PR DESCRIPTION
## Summary

- Rewrites `.claude/commands/go.md` from a single-agent loop into an **orchestrator + worker** model
- **ORCHESTRATOR** (default): loads orientation, scans issues, spawns up to 3 worker subagents in parallel via the `Agent` tool (`isolation: "worktree"`)
- **WORKER** (receives `ISSUE=<n>`): claim → 2-min wait → verify → implement → PR
- Adds mandatory **WORKFLOW REVIEW** at end of each orchestrator run (suggest improvements or say "no improvements needed")
- Adds mandatory **pre-PR duplicate check** before any `gh pr create`:
  1. Check for open PR on same branch → push to it instead
  2. Check for open PR already closing the same issue → link and exit
  3. Check for merged/closed PR on the same issue → verify done, exit
  4. Only create a new PR if all three checks pass clean
- Preserves all existing claim-conflict logic and bootstrap path

## Why review needed

Changes how every future `/go` invocation behaves. The orchestrator/worker boundary, concurrency limit (3), duplicate check logic, and workflow review step should be validated before it goes live.

## Test plan

- [ ] Confirm orchestrator/worker mode detection is unambiguous
- [ ] Verify claim protocol (2-min wait, verify, yield) intact in worker mode
- [ ] Confirm pre-PR duplicate check covers branch match, issue match, and merged-PR case
- [ ] Confirm workflow review step is mandatory and last
- [ ] Spot-check HARD RULES prevent worker spawning workers

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)