### PR TITLE
fix(ci): add STRIPE_SECRET_KEY placeholder to unblock billing route builds (#286)

### DIFF
--- a/.github/workflows/frontend_preflight.yml
+++ b/.github/workflows/frontend_preflight.yml
@@ -37,4 +37,9 @@ jobs:
         working-directory: ./web
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          # Stripe SDK initialises at module load time in billing API routes.
+          # A non-empty placeholder is required so `next build` can import those
+          # modules without throwing "Neither apiKey nor config.authenticator
+          # provided". The real key is only needed at request time, not build time.
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY || 'sk_test_placeholder_for_ci_build' }}
         run: npm run build


### PR DESCRIPTION
## Summary

- Adds `STRIPE_SECRET_KEY` fallback env var to the `Static Build Schema Validation` step in `frontend_preflight.yml`
- Stripe SDK initialises at module load time in the billing API routes added by PRs #281 and #283; without a non-empty key, `next build` fails with *"Neither apiKey nor config.authenticator provided"*
- `preflight-build` is a **required check** in `auto_approve.yml`, so both billing PRs are blocked until this lands

Closes #286

## Why a workflow-level fix

The billing routes are introduced on branches that don't yet exist on `main`, so a separate PR that patches the route files themselves would conflict with #283/#281. Providing a placeholder at build time is the minimal non-conflicting fix. The real secret is only needed at request time.

## Test plan
- [x] Python lint passes (`make lint`)
- [ ] After merge: re-run `preflight-build` on PR #283 — expect pass
- [ ] After merge: re-run `preflight-build` on PR #281 — expect pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)