### PR TITLE
test(resolve): unit tests for draft pick claim parsing and resolution (#259)

### DIFF
--- a/pipeline/tests/test_resolve_daily.py
+++ b/pipeline/tests/test_resolve_daily.py
@@ -559,6 +559,371 @@ class TestResolvePlayerPerformance:
         assert summary["checked"] == 0
 
 
+# _extract_draft_claim
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDraftClaim:
+    def test_numeric_pick_format(self):
+        result = _extract_draft_claim(
+            "Will Anderson Jr. is the No. 3 overall pick in 2023"
+        )
+        assert result["pick_number"] == 3
+        assert result["draft_year"] == 2023
+
+    def test_hash_pick_format(self):
+        result = _extract_draft_claim("CJ Stroud goes at #2 pick in 2023")
+        assert result["pick_number"] == 2
+
+    def test_ordinal_first_overall(self):
+        result = _extract_draft_claim(
+            "Caleb Williams will be the first overall pick in 2024"
+        )
+        assert result["pick_number"] == 1
+
+    def test_ordinal_third_pick(self):
+        result = _extract_draft_claim("Drake Maye is the third pick in 2024")
+        assert result["pick_number"] == 3
+
+    def test_top_n_extraction(self):
+        result = _extract_draft_claim("Jayden Daniels will be a top-5 pick in 2024")
+        assert result["top_n"] == 5
+
+    def test_top_10_extraction(self):
+        result = _extract_draft_claim("J.J. McCarthy goes in the top-10 picks of 2024")
+        assert result["top_n"] == 10
+
+    def test_round_number_extraction(self):
+        result = _extract_draft_claim("Player X is a Round 2 pick in 2024")
+        assert result["round_number"] == 2
+
+    def test_first_round_text(self):
+        result = _extract_draft_claim("Michael Penix Jr. is a first round pick in 2024")
+        assert result["round_number"] == 1
+
+    def test_year_extraction(self):
+        result = _extract_draft_claim("Top QB prospect in the 2025 NFL draft")
+        assert result["draft_year"] == 2025
+
+    def test_no_year_in_claim(self):
+        result = _extract_draft_claim("Will Anderson Jr. is the #3 overall pick")
+        assert "draft_year" not in result
+        assert result["pick_number"] == 3
+
+    def test_unparseable_returns_empty(self):
+        result = _extract_draft_claim("This player will do well in football")
+        assert result == {}
+
+    def test_pick_and_year_combined(self):
+        result = _extract_draft_claim(
+            "Bryce Young is the No. 1 overall pick in the 2023 NFL Draft"
+        )
+        assert result["pick_number"] == 1
+        assert result["draft_year"] == 2023
+
+
+# ---------------------------------------------------------------------------
+# resolve_draft_picks
+# ---------------------------------------------------------------------------
+
+_DRAFT_DATA_2024 = pd.DataFrame(
+    [
+        {
+            "Name": "Caleb Williams",
+            "name_lower": "caleb williams",
+            "draft_year": 2024,
+            "draft_round": 1,
+            "draft_pick": 1,
+            "draft_team": "CHI",
+            "current_team": "CHI",
+            "undrafted": False,
+        },
+        {
+            "Name": "Jayden Daniels",
+            "name_lower": "jayden daniels",
+            "draft_year": 2024,
+            "draft_round": 1,
+            "draft_pick": 2,
+            "draft_team": "WAS",
+            "current_team": "WAS",
+            "undrafted": False,
+        },
+        {
+            "Name": "Drake Maye",
+            "name_lower": "drake maye",
+            "draft_year": 2024,
+            "draft_round": 1,
+            "draft_pick": 3,
+            "draft_team": "NE",
+            "current_team": "NE",
+            "undrafted": False,
+        },
+        {
+            "Name": "Marvin Harrison Jr.",
+            "name_lower": "marvin harrison jr.",
+            "draft_year": 2024,
+            "draft_round": 1,
+            "draft_pick": 4,
+            "draft_team": "ARI",
+            "current_team": "ARI",
+            "undrafted": False,
+        },
+    ]
+)
+
+
+class TestResolveDraftPicks:
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_correct_pick_number(self, mock_resolve, mock_pending, mock_load, mock_db):
+        """Caleb Williams predicted as #1 pick — correct when he was actually pick #1."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Caleb Williams is the No. 1 overall pick in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "Caleb Williams",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        assert summary["skipped"] == 0
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_incorrect_pick_number(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
+        """Drake Maye predicted as #1 pick — incorrect (actual pick #3)."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Drake Maye is the No. 1 overall pick in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "Drake Maye",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is False
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_correct_top_n_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
+        """Marvin Harrison Jr. predicted as top-5 — correct (actual pick #4)."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Marvin Harrison Jr. will be a top-5 pick in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "Marvin Harrison Jr.",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_correct_round_prediction(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
+        """Drake Maye predicted as first round pick — correct (actual round 1)."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Drake Maye is a first round pick in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "Drake Maye",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skip_no_draft_year_in_claim_or_metadata(
+        self, mock_pending, mock_load, mock_db
+    ):
+        """Skip predictions with no year in claim and no season_year."""
+        rows = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Someone will be the #1 pick",
+                    "season_year": None,
+                    "target_player_id": "Some Player",
+                }
+            ],
+        )
+        mock_pending.return_value = rows
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+        assert summary["resolved"] == 0
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_season_year_used_as_draft_year_fallback(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
+        """season_year is used as draft year when not present in claim text."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Caleb Williams is the No. 1 overall pick",
+                    "season_year": 2024,
+                    "target_player_id": "Caleb Williams",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["resolved"] == 1
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skip_future_draft_year(self, mock_pending, mock_load, mock_db):
+        """Skip predictions for future draft years (data not available yet)."""
+        future_year = pd.Timestamp.now().year + 1
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": f"Top QB will be the #1 pick in {future_year}",
+                    "season_year": future_year,
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024  # Has 2024 data, not future year
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_skip_player_not_found_in_draft_data(
+        self, mock_pending, mock_load, mock_db
+    ):
+        """Skip when the predicted player isn't in the draft data."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "John Nobody is the #5 pick in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "John Nobody",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["skipped"] == 1
+        assert summary["resolved"] == 0
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_return_early_when_no_draft_data(self, mock_pending, mock_load, mock_db):
+        """Return with 0 checked when the draft data table is empty."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [{"claim": "Caleb Williams is the #1 pick in 2024", "season_year": 2024}],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = pd.DataFrame()
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["checked"] == 0
+
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.void_prediction")
+    def test_void_when_claim_has_no_pick_structure(
+        self, mock_void, mock_pending, mock_load, mock_db
+    ):
+        """Void when player is found but claim has no pick number, round, or top-N."""
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Caleb Williams will have an impact in 2024",
+                    "season_year": 2024,
+                    "target_player_id": "Caleb Williams",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = _DRAFT_DATA_2024
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        assert summary["voided"] == 1
+        mock_void.assert_called_once()
+
+    @patch("src.resolve_daily.get_pending_predictions")
+    def test_empty_predictions(self, mock_pending, mock_db):
+        """Return 0 checked when there are no draft_pick predictions."""
+        mock_pending.return_value = pd.DataFrame(
+            columns=[
+                "prediction_hash",
+                "extracted_claim",
+                "claim_category",
+                "season_year",
+            ]
+        )
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+        assert summary["checked"] == 0
+
+
 # ---------------------------------------------------------------------------
 # _resolve_team_claim
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `TestExtractDraftClaim` (12 tests) covering pick number formats (`#N`, `No. N`, ordinals), top-N, round number, year extraction, and unparseable claims
- Adds `TestResolveDraftPicks` (11 tests) covering correct/incorrect pick/top-N/round resolution, skip conditions (no year, future draft, player not found, empty data), void behavior, and empty predictions
- All DB calls mocked — no BigQuery required to run

Closes #259

## Test plan
- [x] `pytest pipeline/tests/test_resolve_daily.py` — 56 passed (33 existing + 23 new)
- [x] `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)