### PR TITLE
feat(extract): prompt versioning + LLM provider tracking (#247)

### DIFF
--- a/pipeline/migrations/011_add_extraction_provenance.sql
+++ b/pipeline/migrations/011_add_extraction_provenance.sql
@@ -1,0 +1,18 @@
+-- Migration 011: Add extraction provenance columns to prediction_ledger (Issue #247)
+--
+-- Tracks which prompt version and LLM produced each prediction, enabling:
+--   - Quality comparison across prompt versions (prompt_version)
+--   - Quality comparison across LLM backends (llm_provider + llm_model)
+--   - Rollback analysis if a new prompt degrades extraction quality
+--
+-- All columns are nullable — existing rows will have NULL (treated as "unknown").
+-- No backfill required: NULL = pre-provenance-tracking era.
+--
+-- Run against the project with:
+--   bq query --use_legacy_sql=false --project_id=<PROJECT_ID> \
+--     < pipeline/migrations/011_add_extraction_provenance.sql
+
+ALTER TABLE `${PROJECT_ID}.gold_layer.prediction_ledger`
+ADD COLUMN IF NOT EXISTS prompt_version STRING,
+ADD COLUMN IF NOT EXISTS llm_provider STRING,
+ADD COLUMN IF NOT EXISTS llm_model STRING;

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -18,6 +18,7 @@ Usage (inside Docker):
 """
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -91,6 +92,10 @@ AUTHOR: {author}
 TITLE: {title}
 TEXT:
 {text}"""
+
+# 8-char SHA-256 prefix of the prompt template — changes whenever the prompt changes.
+# Used to track which prompt version produced each prediction.
+PROMPT_VERSION = hashlib.sha256(EXTRACTION_PROMPT.encode("utf-8")).hexdigest()[:8]
 
 
 @dataclass
@@ -390,6 +395,12 @@ def run_extraction(
             config.setdefault("extraction", {})["provider"] = provider_name
         provider = get_provider_with_fallback("extraction", config)
 
+    provider_type = (
+        type(provider).__name__.replace("Provider", "").lower()
+        if provider
+        else "dry-run"
+    )
+
     summary = {
         "total_processed": 0,
         "predictions_extracted": 0,
@@ -521,6 +532,9 @@ def run_extraction(
                         target_team=pred.get("target_team"),
                         stance=stance,
                         sport=str(row.get("sport", sport)),
+                        prompt_version=PROMPT_VERSION,
+                        llm_provider=provider_type,
+                        llm_model=getattr(provider, "model", None),
                     )
                 )
 

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -395,10 +395,15 @@ def run_extraction(
             config.setdefault("extraction", {})["provider"] = provider_name
         provider = get_provider_with_fallback("extraction", config)
 
+    _pname = getattr(provider, "provider_name", None) if provider else None
     provider_type = (
-        type(provider).__name__.replace("Provider", "").lower()
-        if provider
-        else "dry-run"
+        _pname
+        if isinstance(_pname, str)
+        else (
+            type(provider).__name__.replace("Provider", "").lower()
+            if provider
+            else "dry-run"
+        )
     )
 
     summary = {

--- a/pipeline/src/cryptographic_ledger.py
+++ b/pipeline/src/cryptographic_ledger.py
@@ -50,6 +50,9 @@ class PunditPrediction:
     ingestion_timestamp: datetime = field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
+    prompt_version: Optional[str] = None  # SHA-256 prefix of extraction prompt template
+    llm_provider: Optional[str] = None  # e.g. "ollama", "gemini", "openai"
+    llm_model: Optional[str] = None  # e.g. "qwen2.5:32b", "gemini-2.5-flash"
 
 
 def _canonical_payload(prediction: PunditPrediction) -> str:
@@ -141,6 +144,9 @@ def ingest_prediction(
             "target_team": prediction.target_team,
             "stance": prediction.stance,
             "sport": prediction.sport,
+            "prompt_version": prediction.prompt_version,
+            "llm_provider": prediction.llm_provider,
+            "llm_model": prediction.llm_model,
             "resolution_status": "PENDING",
             "resolved_at": None,
             "resolution_notes": None,
@@ -191,9 +197,13 @@ def ingest_batch(
                     "claim_category": prediction.claim_category,
                     "season_year": prediction.season_year,
                     "target_player_id": prediction.target_player_id,
+                    "target_player_name": prediction.target_player_name,
                     "target_team": prediction.target_team,
                     "stance": prediction.stance,
                     "sport": prediction.sport,
+                    "prompt_version": prediction.prompt_version,
+                    "llm_provider": prediction.llm_provider,
+                    "llm_model": prediction.llm_model,
                     "resolution_status": "PENDING",
                     "resolved_at": None,
                     "resolution_notes": None,

--- a/pipeline/src/extraction_quality.py
+++ b/pipeline/src/extraction_quality.py
@@ -1,0 +1,185 @@
+"""
+Extraction Quality Reporter (Issue #247)
+
+CLI for comparing extraction quality across prompt versions and LLM providers/models.
+Queries gold_layer.prediction_ledger to produce per-group statistics.
+
+Usage:
+    python -m src.extraction_quality --compare-versions
+    python -m src.extraction_quality --compare-providers
+    python -m src.extraction_quality --compare-models
+    python -m src.extraction_quality --compare-versions --compare-providers
+"""
+
+import argparse
+import logging
+import os
+from typing import Optional
+
+import pandas as pd
+
+from src.db_manager import DBManager
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+LEDGER_TABLE = "gold_layer.prediction_ledger"
+RESOLUTIONS_TABLE = "gold_layer.prediction_resolutions"
+
+
+def _fetch_provenance_stats(db: DBManager) -> pd.DataFrame:
+    """
+    Fetch per-(prompt_version, llm_provider, llm_model) statistics from BQ.
+
+    Returns a DataFrame with columns:
+        prompt_version, llm_provider, llm_model,
+        total_predictions, resolved, correct, incorrect, pending,
+        precision (correct / resolved, NULL if no resolutions)
+    """
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    query = f"""
+        SELECT
+            COALESCE(l.prompt_version, 'unknown') AS prompt_version,
+            COALESCE(l.llm_provider, 'unknown')   AS llm_provider,
+            COALESCE(l.llm_model,    'unknown')   AS llm_model,
+            COUNT(*)                               AS total_predictions,
+            COUNTIF(r.resolution_status = 'CORRECT')   AS correct,
+            COUNTIF(r.resolution_status = 'INCORRECT') AS incorrect,
+            COUNTIF(r.resolution_status IS NULL
+                    OR r.resolution_status = 'PENDING') AS pending,
+            COUNTIF(r.resolution_status IN ('CORRECT', 'INCORRECT')) AS resolved,
+            SAFE_DIVIDE(
+                COUNTIF(r.resolution_status = 'CORRECT'),
+                NULLIF(COUNTIF(r.resolution_status IN ('CORRECT', 'INCORRECT')), 0)
+            ) AS precision
+        FROM `{project_id}.{LEDGER_TABLE}` l
+        LEFT JOIN `{project_id}.{RESOLUTIONS_TABLE}` r
+            ON l.prediction_hash = r.prediction_hash
+        GROUP BY 1, 2, 3
+        ORDER BY total_predictions DESC
+    """
+    return db.fetch_df(query)
+
+
+def _print_table(df: pd.DataFrame, group_cols: list[str]) -> None:
+    """Print a grouped summary table."""
+    agg = (
+        df.groupby(group_cols, dropna=False)
+        .agg(
+            total_predictions=("total_predictions", "sum"),
+            resolved=("resolved", "sum"),
+            correct=("correct", "sum"),
+            incorrect=("incorrect", "sum"),
+            pending=("pending", "sum"),
+        )
+        .reset_index()
+    )
+    agg["precision"] = agg.apply(
+        lambda r: f"{r['correct'] / r['resolved']:.1%}" if r["resolved"] > 0 else "—",
+        axis=1,
+    )
+
+    header = " | ".join(
+        [f"{c:<20}" for c in group_cols]
+        + ["total", "resolved", "correct", "pending", "precision"]
+    )
+    print("\n" + header)
+    print("-" * len(header))
+    for _, row in agg.iterrows():
+        parts = [f"{str(row[c]):<20}" for c in group_cols]
+        parts += [
+            f"{row['total_predictions']:<7}",
+            f"{row['resolved']:<9}",
+            f"{row['correct']:<8}",
+            f"{row['pending']:<8}",
+            str(row["precision"]),
+        ]
+        print(" | ".join(parts))
+    print()
+
+
+def run_report(
+    compare_versions: bool = False,
+    compare_providers: bool = False,
+    compare_models: bool = False,
+    db: Optional[DBManager] = None,
+) -> None:
+    """
+    Fetch provenance stats and print comparison tables.
+    At least one of compare_* must be True.
+    """
+    if not any([compare_versions, compare_providers, compare_models]):
+        compare_versions = True  # default
+
+    close_db = db is None
+    if db is None:
+        db = DBManager()
+
+    try:
+        df = _fetch_provenance_stats(db)
+
+        if df.empty:
+            print("No predictions found in ledger.")
+            return
+
+        total = df["total_predictions"].sum()
+        resolved = df["resolved"].sum()
+        correct = df["correct"].sum()
+        print(
+            f"\nLedger totals: {total:,} predictions | {resolved:,} resolved | "
+            f"{correct:,} correct"
+        )
+
+        if compare_versions:
+            print("\n=== By Prompt Version ===")
+            _print_table(df, ["prompt_version"])
+
+        if compare_providers:
+            print("\n=== By LLM Provider ===")
+            _print_table(df, ["llm_provider"])
+
+        if compare_models:
+            print("\n=== By LLM Model ===")
+            _print_table(df, ["llm_model"])
+
+        if compare_versions and compare_providers:
+            print("\n=== By Prompt Version × LLM Provider ===")
+            _print_table(df, ["prompt_version", "llm_provider"])
+
+    finally:
+        if close_db:
+            db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare extraction quality across prompt versions and LLM providers."
+    )
+    parser.add_argument(
+        "--compare-versions",
+        action="store_true",
+        help="Break down by prompt_version",
+    )
+    parser.add_argument(
+        "--compare-providers",
+        action="store_true",
+        help="Break down by llm_provider (ollama, gemini, etc.)",
+    )
+    parser.add_argument(
+        "--compare-models",
+        action="store_true",
+        help="Break down by llm_model (qwen2.5:32b, gemini-2.5-flash, etc.)",
+    )
+    args = parser.parse_args()
+
+    run_report(
+        compare_versions=args.compare_versions,
+        compare_providers=args.compare_providers,
+        compare_models=args.compare_models,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/src/llm_provider.py
+++ b/pipeline/src/llm_provider.py
@@ -47,6 +47,8 @@ If no testable predictions exist, return an empty array: []
 class LLMProvider(ABC):
     """Abstract base for LLM extraction backends."""
 
+    provider_name: str = None  # Override in subclasses
+
     def __init__(self, model: str, **kwargs):
         self.model = model
 
@@ -99,6 +101,8 @@ class LLMProvider(ABC):
 
 class GeminiProvider(LLMProvider):
     """Google Gemini API with native schema enforcement."""
+
+    provider_name = "gemini"
 
     def __init__(self, model: str = "gemini-2.5-flash", **kwargs):
         super().__init__(model)
@@ -184,6 +188,8 @@ class GeminiProvider(LLMProvider):
 class ClaudeProvider(LLMProvider):
     """Anthropic Claude API with structured output via system prompt."""
 
+    provider_name = "claude"
+
     def __init__(self, model: str = "claude-sonnet-4-20250514", **kwargs):
         super().__init__(model)
         try:
@@ -221,6 +227,8 @@ class ClaudeProvider(LLMProvider):
 
 class OpenAIProvider(LLMProvider):
     """OpenAI API with JSON mode."""
+
+    provider_name = "openai"
 
     def __init__(self, model: str = "gpt-4o", **kwargs):
         super().__init__(model)
@@ -267,6 +275,8 @@ class OpenAIProvider(LLMProvider):
 
 class OllamaProvider(LLMProvider):
     """Local Ollama models via HTTP API. Zero cost."""
+
+    provider_name = "ollama"
 
     def __init__(
         self,
@@ -400,6 +410,7 @@ class _FallbackProvider(LLMProvider):
         super().__init__(model=primary.model)
         self.primary = primary
         self.fallback = fallback
+        self.provider_name = primary.provider_name
 
     def extract_predictions(self, prompt: str) -> list[dict]:
         try:

--- a/pipeline/src/local_rag_pipeline.py
+++ b/pipeline/src/local_rag_pipeline.py
@@ -38,6 +38,7 @@ from src.cryptographic_ledger import ingest_batch
 from src.db_manager import DBManager
 from src.llm_provider import LLMProvider, get_provider_with_fallback, load_llm_config
 from src.team_batcher import (
+    BATCH_PROMPT_VERSION,
     ArticleRecord,
     annotate_team_mentions,
     batch_articles_by_team,
@@ -75,6 +76,9 @@ def _build_pundit_predictions(
     source_article: ArticleRecord,
     pundit_id: str,
     source_url: str,
+    prompt_version: Optional[str] = None,
+    llm_provider: Optional[str] = None,
+    llm_model: Optional[str] = None,
 ) -> list[PunditPrediction]:
     """Convert raw LLM prediction dicts to PunditPrediction objects."""
     result = []
@@ -104,6 +108,9 @@ def _build_pundit_predictions(
                 target_player_name=player_name,
                 target_team=pred.get("target_team"),
                 sport="NFL",
+                prompt_version=prompt_version,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
             )
         )
     return result
@@ -146,6 +153,11 @@ def run_batched_extraction(
         provider = get_provider_with_fallback("extraction", config)
 
     provider_model = getattr(provider, "model", "dry-run") if provider else "dry-run"
+    provider_type = (
+        type(provider).__name__.replace("Provider", "").lower()
+        if provider
+        else "dry-run"
+    )
     summary = {
         "total_articles": 0,
         "total_batches": 0,
@@ -268,7 +280,13 @@ def run_batched_extraction(
                     )
 
                     preds = _build_pundit_predictions(
-                        [pred], source_art, pundit_id, source_url
+                        [pred],
+                        source_art,
+                        pundit_id,
+                        source_url,
+                        prompt_version=BATCH_PROMPT_VERSION,
+                        llm_provider=provider_type,
+                        llm_model=provider_model,
                     )
                     all_predictions.extend(preds)
 

--- a/pipeline/src/schema_validator.py
+++ b/pipeline/src/schema_validator.py
@@ -86,7 +86,7 @@ CORE_CONTRACTS: list[ColumnContract] = [
             "pundit_name",
             "raw_assertion_text",
         ],
-        description="Gold prediction ledger",
+        description="Gold prediction ledger with prompt versioning + LLM tracking",
     ),
     ColumnContract(
         dataset="gold_layer",

--- a/pipeline/src/team_batcher.py
+++ b/pipeline/src/team_batcher.py
@@ -14,10 +14,21 @@ Usage:
         predictions = provider.extract_predictions(prompt)
 """
 
+import hashlib
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Optional
+
+# Canonical marker for the batched prompt structure.
+# Update this string (not the hash) when the prompt instructions change significantly.
+_BATCH_PROMPT_STRUCTURE = (
+    "batched-extraction-v1|"
+    "fields:extracted_claim,pundit_name,claim_category,season_year,"
+    "target_player_name,target_team,consensus_note|"
+    "categories:player_performance,game_outcome,trade,draft_pick,injury,contract,other"
+)
+BATCH_PROMPT_VERSION = hashlib.sha256(_BATCH_PROMPT_STRUCTURE.encode()).hexdigest()[:8]
 
 # ---------------------------------------------------------------------------
 # Team name / alias → abbreviation mapping (all 32 NFL teams)

--- a/pipeline/tests/test_extraction_provenance.py
+++ b/pipeline/tests/test_extraction_provenance.py
@@ -1,0 +1,352 @@
+"""
+Tests for extraction provenance tracking (Issue #247).
+
+Covers:
+  - PunditPrediction has prompt_version / llm_provider / llm_model fields
+  - PROMPT_VERSION is a stable 8-char hex string
+  - run_extraction populates provenance fields on every PunditPrediction
+  - _build_pundit_predictions (local_rag_pipeline) passes provenance through
+  - ingest_batch includes provenance columns in the row dict
+  - extraction_quality.run_report handles an empty ledger gracefully
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.assertion_extractor import (
+    PROMPT_VERSION,
+    ExtractionResult,
+    run_extraction,
+)
+from src.cryptographic_ledger import PunditPrediction, ingest_batch
+from src.local_rag_pipeline import _build_pundit_predictions
+from src.team_batcher import BATCH_PROMPT_VERSION, ArticleRecord
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.fetch_df.return_value = pd.DataFrame()
+    return db
+
+
+@pytest.fixture
+def mock_provider():
+    provider = MagicMock()
+    provider.model = "test-model-7b"
+    provider.extract_predictions.return_value = []
+    return provider
+
+
+def make_raw_media_df():
+    return pd.DataFrame(
+        [
+            {
+                "content_hash": "abc123",
+                "source_id": "espn_nfl",
+                "title": "Mock Article",
+                "raw_text": "Chiefs will win the Super Bowl this season.",
+                "source_url": "https://espn.com/1",
+                "author": "Adam Schefter",
+                "matched_pundit_id": "adam_schefter",
+                "matched_pundit_name": "Adam Schefter",
+                "published_at": datetime(2026, 9, 1, tzinfo=timezone.utc),
+            }
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# PunditPrediction dataclass fields
+# ---------------------------------------------------------------------------
+
+
+class TestPunditPredictionProvenanceFields:
+    def test_new_fields_default_to_none(self):
+        p = PunditPrediction(
+            pundit_id="test",
+            pundit_name="Test Pundit",
+            source_url="https://example.com",
+            raw_assertion_text="Some prediction",
+        )
+        assert p.prompt_version is None
+        assert p.llm_provider is None
+        assert p.llm_model is None
+
+    def test_fields_accept_values(self):
+        p = PunditPrediction(
+            pundit_id="test",
+            pundit_name="Test Pundit",
+            source_url="https://example.com",
+            raw_assertion_text="Some prediction",
+            prompt_version="a1b2c3d4",
+            llm_provider="ollama",
+            llm_model="qwen2.5:32b",
+        )
+        assert p.prompt_version == "a1b2c3d4"
+        assert p.llm_provider == "ollama"
+        assert p.llm_model == "qwen2.5:32b"
+
+
+# ---------------------------------------------------------------------------
+# PROMPT_VERSION constant
+# ---------------------------------------------------------------------------
+
+
+class TestPromptVersion:
+    def test_is_8_char_hex(self):
+        assert len(PROMPT_VERSION) == 8
+        int(PROMPT_VERSION, 16)  # raises ValueError if not valid hex
+
+    def test_batch_prompt_version_is_8_char_hex(self):
+        assert len(BATCH_PROMPT_VERSION) == 8
+        int(BATCH_PROMPT_VERSION, 16)
+
+    def test_versions_are_different(self):
+        # The single-article and batch prompts should version independently.
+        assert PROMPT_VERSION != BATCH_PROMPT_VERSION
+
+
+# ---------------------------------------------------------------------------
+# run_extraction populates provenance on PunditPredictions
+# ---------------------------------------------------------------------------
+
+
+class TestRunExtractionProvenance:
+    @patch("src.assertion_extractor.ingest_batch")
+    @patch("src.assertion_extractor.extract_assertions")
+    def test_provenance_fields_set_on_predictions(
+        self, mock_extract, mock_ingest, mock_db, mock_provider
+    ):
+        mock_db.fetch_df.return_value = make_raw_media_df()
+        mock_extract.return_value = ExtractionResult(
+            content_hash="abc123",
+            predictions=[
+                {
+                    "extracted_claim": "Chiefs win Super Bowl",
+                    "claim_category": "game_outcome",
+                    "season_year": 2026,
+                    "stance": "bullish",
+                }
+            ],
+        )
+        mock_ingest.return_value = ["hash1"]
+
+        run_extraction(limit=10, db=mock_db, provider=mock_provider)
+
+        assert mock_ingest.called
+        predictions_arg = mock_ingest.call_args[0][0]
+        assert len(predictions_arg) == 1
+        pred = predictions_arg[0]
+
+        assert pred.prompt_version == PROMPT_VERSION
+        assert (
+            pred.llm_provider
+            == type(mock_provider).__name__.replace("Provider", "").lower()
+        )
+        assert pred.llm_model == "test-model-7b"
+
+    @patch("src.assertion_extractor.ingest_batch")
+    @patch("src.assertion_extractor.extract_assertions")
+    def test_provider_type_derived_from_class_name(
+        self, mock_extract, mock_ingest, mock_db
+    ):
+        """Provider type uses the class name with 'Provider' stripped."""
+        from unittest.mock import MagicMock
+
+        class GeminiProvider:
+            model = "gemini-2.5-flash"
+            extract_predictions = MagicMock(return_value=[])
+
+        gemini = GeminiProvider()
+        mock_db.fetch_df.return_value = make_raw_media_df()
+        mock_extract.return_value = ExtractionResult(
+            content_hash="abc123",
+            predictions=[
+                {
+                    "extracted_claim": "Chiefs win Super Bowl",
+                    "claim_category": "game_outcome",
+                    "stance": "bullish",
+                    "season_year": 2026,
+                }
+            ],
+        )
+        mock_ingest.return_value = ["hash1"]
+
+        run_extraction(limit=10, db=mock_db, provider=gemini)
+
+        pred = mock_ingest.call_args[0][0][0]
+        assert pred.llm_provider == "gemini"
+        assert pred.llm_model == "gemini-2.5-flash"
+
+
+# ---------------------------------------------------------------------------
+# _build_pundit_predictions (local_rag_pipeline) passes provenance through
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPunditPredictionsProvenance:
+    def _make_article(self):
+        return ArticleRecord(
+            content_hash="art123",
+            raw_text="The Chiefs will win it all.",
+            title="Mock Article",
+            pundit_name="Pat McAfee",
+            source_name="pat_mcafee_show",
+            published_date="2026-04-01",
+        )
+
+    def test_provenance_passed_to_predictions(self):
+        predictions = [
+            {
+                "extracted_claim": "Chiefs win Super Bowl",
+                "claim_category": "game_outcome",
+            }
+        ]
+        article = self._make_article()
+        result = _build_pundit_predictions(
+            predictions,
+            article,
+            pundit_id="pat_mcafee",
+            source_url="https://mcafee.com/1",
+            prompt_version="b4a3f1c2",
+            llm_provider="ollama",
+            llm_model="qwen2.5:32b",
+        )
+
+        assert len(result) == 1
+        assert result[0].prompt_version == "b4a3f1c2"
+        assert result[0].llm_provider == "ollama"
+        assert result[0].llm_model == "qwen2.5:32b"
+
+    def test_defaults_to_none_when_not_provided(self):
+        predictions = [
+            {
+                "extracted_claim": "Bears make playoffs",
+                "claim_category": "game_outcome",
+            }
+        ]
+        article = self._make_article()
+        result = _build_pundit_predictions(
+            predictions,
+            article,
+            pundit_id="cowherd",
+            source_url="https://cowherd.com/1",
+        )
+
+        assert result[0].prompt_version is None
+        assert result[0].llm_provider is None
+        assert result[0].llm_model is None
+
+
+# ---------------------------------------------------------------------------
+# ingest_batch includes provenance in row dict
+# ---------------------------------------------------------------------------
+
+
+class TestIngestBatchProvenance:
+    @patch("src.cryptographic_ledger._append_to_ledger")
+    @patch("src.cryptographic_ledger.get_latest_chain_hash", return_value="")
+    def test_provenance_columns_in_row(self, mock_chain, mock_append, mock_db):
+        predictions = [
+            PunditPrediction(
+                pundit_id="test",
+                pundit_name="Test",
+                source_url="https://x.com",
+                raw_assertion_text="Some claim",
+                prompt_version="a1b2c3d4",
+                llm_provider="ollama",
+                llm_model="qwen2.5:32b",
+            )
+        ]
+        ingest_batch(predictions, db=mock_db)
+
+        assert mock_append.called
+        df_arg = mock_append.call_args[0][0]
+        assert "prompt_version" in df_arg.columns
+        assert "llm_provider" in df_arg.columns
+        assert "llm_model" in df_arg.columns
+        assert df_arg.iloc[0]["prompt_version"] == "a1b2c3d4"
+        assert df_arg.iloc[0]["llm_provider"] == "ollama"
+        assert df_arg.iloc[0]["llm_model"] == "qwen2.5:32b"
+
+    @patch("src.cryptographic_ledger._append_to_ledger")
+    @patch("src.cryptographic_ledger.get_latest_chain_hash", return_value="")
+    def test_null_provenance_written_as_none(self, mock_chain, mock_append, mock_db):
+        predictions = [
+            PunditPrediction(
+                pundit_id="test",
+                pundit_name="Test",
+                source_url="https://x.com",
+                raw_assertion_text="Some claim",
+            )
+        ]
+        ingest_batch(predictions, db=mock_db)
+
+        df_arg = mock_append.call_args[0][0]
+        assert pd.isna(df_arg.iloc[0]["prompt_version"])
+        assert pd.isna(df_arg.iloc[0]["llm_provider"])
+        assert pd.isna(df_arg.iloc[0]["llm_model"])
+
+
+# ---------------------------------------------------------------------------
+# extraction_quality CLI — unit tests (no BQ)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionQualityReport:
+    def test_run_report_handles_empty_ledger(self, mock_db, capsys):
+        mock_db.fetch_df.return_value = pd.DataFrame()
+
+        from src.extraction_quality import run_report
+
+        run_report(compare_versions=True, db=mock_db)
+        out = capsys.readouterr().out
+        assert "No predictions found" in out
+
+    def test_run_report_prints_version_table(self, mock_db, capsys):
+        mock_db.fetch_df.return_value = pd.DataFrame(
+            [
+                {
+                    "prompt_version": "a1b2c3d4",
+                    "llm_provider": "ollama",
+                    "llm_model": "qwen2.5:32b",
+                    "total_predictions": 50,
+                    "correct": 30,
+                    "incorrect": 10,
+                    "pending": 10,
+                    "resolved": 40,
+                    "precision": 0.75,
+                }
+            ]
+        )
+
+        from src.extraction_quality import run_report
+
+        run_report(compare_versions=True, db=mock_db)
+        out = capsys.readouterr().out
+        assert "prompt_version" in out.lower() or "Prompt Version" in out
+
+    def test_run_report_defaults_to_versions_when_no_flags(self, mock_db, capsys):
+        mock_db.fetch_df.return_value = pd.DataFrame()
+
+        from src.extraction_quality import run_report
+
+        # All flags False → should still run (defaults to versions)
+        run_report(
+            compare_versions=False,
+            compare_providers=False,
+            compare_models=False,
+            db=mock_db,
+        )
+        out = capsys.readouterr().out
+        # Should not raise and should produce some output
+        assert out  # non-empty


### PR DESCRIPTION
## Summary

- **`PunditPrediction`** gets 3 new nullable fields: `prompt_version`, `llm_provider`, `llm_model`
- **`PROMPT_VERSION`** constant auto-computed as 8-char SHA-256 of the extraction prompt template — changes whenever the prompt changes
- **`LLMProvider` subclasses** (Gemini, Claude, OpenAI, Ollama) get `provider_name` class attribute for reliable provider identification
- **`extraction_quality.py`** — new CLI: `python -m src.extraction_quality --compare-versions --compare-providers --compare-models`
- **`011_add_extraction_provenance.sql`** — BigQuery migration to add the 3 columns to `gold_layer.prediction_ledger`
- **14 new unit tests** in `test_extraction_provenance.py` covering all new behaviour

Closes #247

## Test plan
- [x] `make check` passes: 534 passed, 24 skipped
- [x] `make lint` passes: all checks passed
- [x] `TestPunditPredictionProvenanceFields` — dataclass fields default to None, accept values
- [x] `TestPromptVersion` — PROMPT_VERSION is 8-char hex, differs from BATCH_PROMPT_VERSION
- [x] `TestRunExtractionProvenance` — provenance fields populated on every PunditPrediction
- [x] `TestBuildPunditPredictionsProvenance` — local_rag_pipeline passes fields through
- [x] `TestIngestBatchProvenance` — row dicts include provenance columns
- [x] `TestExtractionQualityReport` — report handles empty ledger, prints tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)