### PR TITLE
feat(billing): API usage metering — fire-and-forget BQ streaming insert (#145)

### DIFF
--- a/web/lib/__tests__/api-metering.test.ts
+++ b/web/lib/__tests__/api-metering.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the API metering module.
+ *
+ * BigQuery is mocked — these tests verify:
+ * - recordApiRequest is fire-and-forget (never throws)
+ * - BQ failures do NOT propagate to the caller
+ * - Row payload is correctly constructed
+ * - IP hashing works and respects METERING_IP_PEPPER
+ * - Fire-and-forget when GCP credentials absent (logs, no throw)
+ */
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+// Set env vars before any imports that read them
+beforeAll(() => {
+    process.env.GCP_PROJECT_ID = "test-project";
+    process.env.METERING_IP_PEPPER = "test-metering-pepper";
+});
+
+// Mock BigQuery — streaming insert path uses dataset().table().insert()
+const mockInsert = vi.fn();
+vi.mock("@google-cloud/bigquery", () => {
+    return {
+        BigQuery: class MockBigQuery {
+            constructor(_opts?: any) {}
+            dataset(_name: string) {
+                return {
+                    table: (_tbl: string) => ({
+                        insert: mockInsert,
+                    }),
+                };
+            }
+        },
+    };
+});
+
+import { recordApiRequest, hashIp } from "../api-metering";
+import type { MeteringEvent } from "../api-metering";
+
+const baseEvent: MeteringEvent = {
+    keyId: "capk_live_abc123",
+    userId: "user_xyz",
+    tier: "pro",
+    endpoint: "/v1/pundits/{id}",
+    endpointPath: "/v1/pundits/adam-schefter",
+    method: "GET",
+    statusCode: 200,
+    latencyMs: 42,
+    bytesOut: 1024,
+    rateLimitHit: false,
+    costClass: "cheap",
+};
+
+beforeEach(() => {
+    mockInsert.mockReset();
+});
+
+// Helper: flush the microtask queue so fire-and-forget promises settle
+function flushPromises(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// ─── recordApiRequest ─────────────────────────────────────────────────────────
+
+describe("recordApiRequest", () => {
+    it("does not throw when BQ insert succeeds", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        expect(() => recordApiRequest(baseEvent)).not.toThrow();
+        await flushPromises();
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT throw when BQ insert fails (fire-and-forget)", async () => {
+        mockInsert.mockRejectedValueOnce(new Error("BQ unavailable"));
+        expect(() => recordApiRequest(baseEvent)).not.toThrow();
+        // After promises settle, still no throw — error is swallowed
+        await flushPromises();
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT throw on network timeout (fire-and-forget)", async () => {
+        mockInsert.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+        expect(() => recordApiRequest(baseEvent)).not.toThrow();
+        await flushPromises();
+    });
+
+    it("calls insert with a single-element array", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent);
+        await flushPromises();
+
+        const [rows] = mockInsert.mock.calls[0];
+        expect(Array.isArray(rows)).toBe(true);
+        expect(rows).toHaveLength(1);
+    });
+
+    it("passes skipInvalidRows: false to catch schema mismatches", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent);
+        await flushPromises();
+
+        const [, options] = mockInsert.mock.calls[0];
+        expect(options).toEqual({ skipInvalidRows: false });
+    });
+});
+
+// ─── Row payload ─────────────────────────────────────────────────────────────
+
+describe("row payload", () => {
+    it("maps all required fields correctly", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent);
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.key_id).toBe("capk_live_abc123");
+        expect(row.user_id).toBe("user_xyz");
+        expect(row.tier).toBe("pro");
+        expect(row.endpoint).toBe("/v1/pundits/{id}");
+        expect(row.endpoint_path).toBe("/v1/pundits/adam-schefter");
+        expect(row.method).toBe("GET");
+        expect(row.status_code).toBe(200);
+        expect(row.latency_ms).toBe(42);
+        expect(row.bytes_out).toBe(1024);
+        expect(row.rate_limit_hit).toBe(false);
+        expect(row.cost_class).toBe("cheap");
+    });
+
+    it("normalises method to uppercase", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest({ ...baseEvent, method: "get" });
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.method).toBe("GET");
+    });
+
+    it("defaults sport to 'nfl' when not provided", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent); // no sport field
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.sport).toBe("nfl");
+    });
+
+    it("respects an explicit sport value", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest({ ...baseEvent, sport: "mlb" });
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.sport).toBe("mlb");
+    });
+
+    it("sets ip_hash when ip is provided", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest({ ...baseEvent, ip: "1.2.3.4" });
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(typeof row.ip_hash).toBe("string");
+        expect(row.ip_hash).toHaveLength(64); // hex SHA-256
+    });
+
+    it("sets ip_hash to null when ip is not provided", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent); // no ip
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.ip_hash).toBeNull();
+    });
+
+    it("sets user_agent to null when not provided", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent); // no userAgent
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.user_agent).toBeNull();
+    });
+
+    it("stores userAgent when provided", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest({ ...baseEvent, userAgent: "curl/7.88" });
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(row.user_agent).toBe("curl/7.88");
+    });
+
+    it("includes a ts field as an ISO string", async () => {
+        mockInsert.mockResolvedValueOnce(undefined);
+        recordApiRequest(baseEvent);
+        await flushPromises();
+
+        const row = mockInsert.mock.calls[0][0][0];
+        expect(typeof row.ts).toBe("string");
+        expect(() => new Date(row.ts)).not.toThrow();
+    });
+});
+
+// ─── hashIp ──────────────────────────────────────────────────────────────────
+
+describe("hashIp", () => {
+    it("returns a 64-char hex string", () => {
+        const hash = hashIp("192.168.1.1");
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("produces a deterministic hash for the same input", () => {
+        expect(hashIp("10.0.0.1")).toBe(hashIp("10.0.0.1"));
+    });
+
+    it("produces different hashes for different IPs", () => {
+        expect(hashIp("10.0.0.1")).not.toBe(hashIp("10.0.0.2"));
+    });
+
+    it("incorporates the pepper (different pepper → different hash)", () => {
+        const pepper1 = process.env.METERING_IP_PEPPER;
+        process.env.METERING_IP_PEPPER = "pepper-A";
+        const hashA = hashIp("1.2.3.4");
+
+        process.env.METERING_IP_PEPPER = "pepper-B";
+        const hashB = hashIp("1.2.3.4");
+
+        // Restore
+        process.env.METERING_IP_PEPPER = pepper1;
+
+        expect(hashA).not.toBe(hashB);
+    });
+
+    it("does not throw when METERING_IP_PEPPER is unset (logs warning)", () => {
+        const saved = process.env.METERING_IP_PEPPER;
+        delete process.env.METERING_IP_PEPPER;
+
+        expect(() => hashIp("1.2.3.4")).not.toThrow();
+
+        process.env.METERING_IP_PEPPER = saved;
+    });
+});

--- a/web/lib/api-metering.sql
+++ b/web/lib/api-metering.sql
@@ -1,0 +1,68 @@
+-- BigQuery schema: monetization.api_requests
+-- Purpose: every paid API request is streamed here for usage analytics,
+--          abuse detection, and pricing research (#148, #122).
+--
+-- Partitioned by day on `ts` and clustered by (key_id, user_id) so that
+-- per-key and per-user queries hit only the relevant partitions.
+--
+-- To apply:
+--   export PROJECT_ID=cap-alpha-protocol
+--   bq query --use_legacy_sql=false --project_id=$PROJECT_ID \
+--     < web/lib/api-metering.sql
+
+CREATE TABLE IF NOT EXISTS `cap-alpha-protocol.monetization.api_requests` (
+    -- When the request was received (partition key)
+    ts TIMESTAMP NOT NULL,
+
+    -- API key that made the request (clustered)
+    key_id STRING NOT NULL,
+
+    -- Clerk user ID that owns the key (clustered)
+    user_id STRING NOT NULL,
+
+    -- Subscription tier at request time (free/pro/agent/api_starter/api_growth/enterprise)
+    tier STRING NOT NULL,
+
+    -- URL path template for grouping — e.g. /v1/pundits/{id}
+    endpoint STRING NOT NULL,
+
+    -- Resolved URL path — e.g. /v1/pundits/adam-schefter (for per-endpoint CTAs)
+    endpoint_path STRING NOT NULL,
+
+    -- HTTP method (GET, POST, etc.)
+    method STRING NOT NULL,
+
+    -- HTTP response status code
+    status_code INT64 NOT NULL,
+
+    -- End-to-end latency in milliseconds
+    latency_ms INT64 NOT NULL,
+
+    -- Response body size in bytes
+    bytes_out INT64 NOT NULL,
+
+    -- Caller's User-Agent header (nullable)
+    user_agent STRING,
+
+    -- SHA-256(METERING_IP_PEPPER || ip) — for abuse detection, never raw IP
+    ip_hash STRING,
+
+    -- Whether this request hit the rate limit
+    rate_limit_hit BOOL NOT NULL DEFAULT FALSE,
+
+    -- Two-axis quota enforcement: "cheap" = KV/lookup, "expensive" = /ask,/backtest,semantic
+    cost_class STRING NOT NULL,
+
+    -- Sport slug (nfl / mlb / …) for future multi-sport filtering
+    sport STRING NOT NULL DEFAULT 'nfl'
+)
+PARTITION BY DATE(ts)
+CLUSTER BY key_id, user_id
+OPTIONS (
+    description = 'Per-request API metering log. Fire-and-forget streaming inserts. '
+                  'Partitioned daily, clustered by key_id + user_id. '
+                  'ip_hash is SHA-256(pepper || ip) — never raw IPs. '
+                  'cost_class distinguishes cheap (quota-A) vs expensive (quota-B) calls. '
+                  'Feeds: usage dashboard (#148), pricing research (#122).',
+    require_partition_filter = FALSE
+);

--- a/web/lib/api-metering.ts
+++ b/web/lib/api-metering.ts
@@ -1,0 +1,127 @@
+/**
+ * API request metering — fire-and-forget event recording to BigQuery.
+ *
+ * Records every paid API request to monetization.api_requests.
+ * The call NEVER blocks the request path: a BQ outage will NOT fail the
+ * API caller. All errors are logged and swallowed.
+ *
+ * Issue: #145
+ */
+import { BigQuery } from "@google-cloud/bigquery";
+import { createHash } from "crypto";
+
+export type CostClass = "cheap" | "expensive";
+
+export interface MeteringEvent {
+    /** Full key ID (capk_live_xxx) */
+    keyId: string;
+    userId: string;
+    tier: string;
+    /**
+     * URL path template — e.g. /v1/pundits/{id}
+     * Use the route pattern, not the resolved path, for grouping.
+     */
+    endpoint: string;
+    /** Resolved URL path — e.g. /v1/pundits/adam-schefter */
+    endpointPath: string;
+    method: string;
+    statusCode: number;
+    latencyMs: number;
+    bytesOut: number;
+    userAgent?: string | null;
+    /** Raw IP address — hashed with METERING_IP_PEPPER before storage */
+    ip?: string | null;
+    rateLimitHit: boolean;
+    /**
+     * "cheap" = KV reads, lookup endpoints (burns quota-A)
+     * "expensive" = /ask, /backtest, semantic search (burns quota-B)
+     */
+    costClass: CostClass;
+    /** Sport slug — defaults to "nfl". Populated for sport-agnostic API. */
+    sport?: string;
+}
+
+const PROJECT_ID = process.env.GCP_PROJECT_ID ?? "cap-alpha-protocol";
+
+function getBigQuery(): BigQuery {
+    return new BigQuery({
+        projectId: PROJECT_ID,
+        credentials:
+            process.env.GCP_CLIENT_EMAIL && process.env.GCP_PRIVATE_KEY
+                ? {
+                      client_email: process.env.GCP_CLIENT_EMAIL,
+                      private_key: process.env.GCP_PRIVATE_KEY.replace(
+                          /\\n/g,
+                          "\n"
+                      ),
+                  }
+                : undefined,
+    });
+}
+
+/**
+ * Hash an IP address for abuse-detection storage.
+ *
+ * Uses SHA-256(METERING_IP_PEPPER || ip). The pepper is never stored and
+ * can be rotated to invalidate all historical hashes (GDPR-friendly).
+ * Logs a warning (but does not fail) when METERING_IP_PEPPER is unset.
+ */
+export function hashIp(ip: string): string {
+    const pepper = process.env.METERING_IP_PEPPER ?? "";
+    if (!pepper) {
+        console.warn(
+            "[metering] METERING_IP_PEPPER is not set — IP hashes are unpepered"
+        );
+    }
+    return createHash("sha256").update(pepper + ip).digest("hex");
+}
+
+/**
+ * Record an API request for metering / usage analytics.
+ *
+ * Fire-and-forget: this function is synchronous from the caller's perspective.
+ * It launches an async BQ insert without awaiting it, so it NEVER throws and
+ * NEVER adds latency to the request path.
+ *
+ * Usage:
+ *   const start = Date.now();
+ *   // ... handle request ...
+ *   recordApiRequest({
+ *     keyId, userId, tier, endpoint, endpointPath, method,
+ *     statusCode: 200, latencyMs: Date.now() - start,
+ *     bytesOut: responseBody.length, ip: req.ip,
+ *     rateLimitHit: false, costClass: "cheap",
+ *   });
+ *   return response;  // returns immediately; metering continues in background
+ */
+export function recordApiRequest(event: MeteringEvent): void {
+    _insertEvent(event).catch((err) => {
+        // BQ outage must not fail the API caller — log and swallow.
+        console.error("[metering] Failed to record API request:", err);
+    });
+}
+
+async function _insertEvent(event: MeteringEvent): Promise<void> {
+    const bq = getBigQuery();
+    const table = bq.dataset("monetization").table("api_requests");
+
+    const row = {
+        ts: new Date().toISOString(),
+        key_id: event.keyId,
+        user_id: event.userId,
+        tier: event.tier,
+        endpoint: event.endpoint,
+        endpoint_path: event.endpointPath,
+        method: event.method.toUpperCase(),
+        status_code: event.statusCode,
+        latency_ms: event.latencyMs,
+        bytes_out: event.bytesOut,
+        user_agent: event.userAgent ?? null,
+        ip_hash: event.ip ? hashIp(event.ip) : null,
+        rate_limit_hit: event.rateLimitHit,
+        cost_class: event.costClass,
+        sport: event.sport ?? "nfl",
+    };
+
+    await table.insert([row], { skipInvalidRows: false });
+}


### PR DESCRIPTION
## Summary

- `web/lib/api-metering.ts` — `MeteringEvent` interface + `recordApiRequest()`: fire-and-forget BQ streaming insert. Returns `void`, never throws — a BQ outage cannot fail the API caller.
- `web/lib/api-metering.sql` — BQ DDL for `monetization.api_requests`: partitioned by day on `ts`, clustered by `(key_id, user_id)`. 15 columns including `cost_class` (cheap/expensive) for two-axis quota enforcement, `sport` for multi-sport API, `endpoint_path` for per-endpoint upsell CTAs, and `ip_hash = SHA-256(METERING_IP_PEPPER || ip)` for abuse detection without storing raw IPs.
- `web/lib/__tests__/api-metering.test.ts` — 19 vitest tests covering: fire-and-forget guarantee, BQ failure swallowing, row payload mapping, IP hashing, pepper rotation.

This was previously in PR #252 which was bulk-closed. Re-landing as a clean cherry-pick from the `feat/auto-approve-workflow` branch onto current main.

Closes #145

## Test plan
- [x] `npx vitest run lib/__tests__/api-metering.test.ts` — 19/19 passing
- [x] BQ outage test: `mockInsert.mockRejectedValueOnce(new Error("BQ unavailable"))` — does NOT throw to caller
- [x] No plaintext API keys stored — `ip_hash` is SHA-256(pepper + ip), no Authorization headers logged
- [x] BQ DDL: `PARTITION BY DATE(ts)`, `CLUSTER BY key_id, user_id`

## Usage

```ts
import { recordApiRequest } from "@/lib/api-metering";

// In your API route handler:
const start = Date.now();
// ... handle request ...
recordApiRequest({
  keyId, userId, tier,
  endpoint: "/v1/pundits/{id}",
  endpointPath: req.url,
  method: req.method,
  statusCode: 200,
  latencyMs: Date.now() - start,
  bytesOut: responseBody.length,
  ip: req.headers.get("x-forwarded-for"),
  rateLimitHit: false,
  costClass: "cheap",
});
return response; // returns immediately; metering runs in background
```

To create the BQ table:
```bash
export PROJECT_ID=cap-alpha-protocol
bq query --use_legacy_sql=false --project_id=$PROJECT_ID < web/lib/api-metering.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)