### PR TITLE
ci(pipeline): add pytest-cov coverage gate at 25%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,16 @@ jobs:
         pytest pipeline/tests/ -v -m "not integration" \
           --ignore=pipeline/tests/test_api.py \
           --ignore=pipeline/tests/test_api_vegas.py \
-          --ignore=pipeline/tests/test_ledger_bq_integration.py
+          --ignore=pipeline/tests/test_ledger_bq_integration.py \
+          --cov=pipeline/src \
+          --cov-report=xml:coverage.xml \
+          --cov-report=term-missing \
+          --cov-config=pipeline/pyproject.toml
+
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.python-version }}
+        path: coverage.xml
+        retention-days: 30

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -70,3 +70,6 @@ exclude_lines = [
     "@abstractmethod",
 ]
 precision = 2
+# Baseline set at 25% — many src modules are scrapers/BQ clients with no unit tests.
+# Raise this incrementally as coverage improves.
+fail_under = 25


### PR DESCRIPTION
## Summary

- Adds `--cov`, `--cov-report=xml`, and `--cov-config` flags to the CI "Run Tests" step so coverage is measured on every PR
- Uploads `coverage.xml` as a 30-day CI artifact so coverage trends are visible without a third-party service
- Sets `fail_under = 25` in `[tool.coverage.report]` in `pipeline/pyproject.toml` — CI will fail if overall coverage drops below this floor

**Why 25%?** Current baseline is 25.99% (520 unit tests passing). Many `pipeline/src/` modules are scrapers and BigQuery clients that require integration tests (excluded from CI). Raise the threshold incrementally as unit test coverage grows.

Closes #297

## Test plan

- [x] `ruff check` and `ruff format --check` pass locally
- [x] 520 unit tests pass locally with `--cov` flags (25.99% coverage, above 25% floor)
- [ ] CI "Run Tests" step passes and coverage artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)