### PR TITLE
chore(ci): add pyproject.toml to git — ruff-only, remove dead black/isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+# ruff is the single formatter/linter — see pipeline/pyproject.toml for full config
+[tool.ruff]
+extend = "pipeline/pyproject.toml"


### PR DESCRIPTION
## Summary
- Adds root `pyproject.toml` to version control (it existed on disk but was never committed)
- Removes dead `[tool.black]` and `[tool.isort]` sections — ruff handles formatting and import ordering
- Keeps `[tool.ruff]` with `extend = "pipeline/pyproject.toml"` so the pipeline directory remains the single source of truth for all ruff config

Closes #301

## Test plan
- [x] `make lint` passes (ruff check + format on pipeline/src and pipeline/tests)
- [x] Pre-commit hook runs ruff successfully (no black/isort conflicts)
- [x] `pipeline/pyproject.toml` remains the canonical ruff config; root just extends it

🤖 Generated with [Claude Code](https://claude.com/claude-code)