### PR TITLE
fix(ci): replace hardcoded REQUIRED_CHECKS with branch protection API query

### DIFF
--- a/.claude/commands/go.md
+++ b/.claude/commands/go.md
@@ -1,24 +1,205 @@
-  ---
-  description: Autonomous Sprint Task Execution Engine
-  ---
+---
+description: Safely claim and complete one issue using a shared orientation cache
+---
 
-  # /go Workflow Instructions
-  // turbo-all
+# Multi-Agent Work Protocol (Minimal)
 
-  When the user triggers the `/go` slash command, you must operate in full autonomous mode to execute the remaining sprint backlog. Follow this strict operational loop:
+You are one of multiple agents working in parallel.
 
-  1. **Locate the Next Task**: Open and read the official Nexus sprint document at `docs/sprints/MASTER_SPRINT_PLAN.md`. Find the very next task that is NOT marked as `[x]`, `[-]` (Deferred), `[b]` (Blocked), or `[/]` (In Progress). To prevent collisions in multi-agent runs, favor tasks in different
-  technical domains or files than what other agents are actively working on.
-  2. **Mark In-Progress & Claim**: Update `MASTER_SPRINT_PLAN.md` and mark the task as `[/]` (In Progress). You MUST append a claim tag (e.g. `(Claimed by Agent)`) to explicitly lock the task.
-  3. **Execute Task**:
-      - Leverage the `// turbo-all` directive globally. Do not ask for user permission to run standard bash commands, tests, or scripts.
-      - If the task requires architectural design, draft it in `implementation_plan.md` first.
-      - Write the code, run the necessary scripts, or configure the necessary infrastructure autonomously.
-  4. **Validation & Resolution**:
-      - You MUST run validation tests autonomously. If tests fail or commands error out, fix them autonomously by reading the terminal output. Do not notify the user until everything passes or you have failed 5 times in a row.
-  5. **Handle Blockers**: If you encounter a hard blocker (e.g., missing third-party API keys, impossible OS constraints):
-      - Mark the task as `[b]` (Blocked) in `MASTER_SPRINT_PLAN.md`.
-      - Document the explicit blocker and move to the NEXT unblocked task in step 1 without alerting the user.
-  6. **Mark Completed**: Once you have explicitly proven the task is done, mark the task as `[x]` (Completed) in `MASTER_SPRINT_PLAN.md`.
-  7. **The Infinite Loop**: Immediately return to Step 1 and find the *next* task. Continue this loop until there are absolute zero actionable sprint tasks remaining in the `MASTER_SPRINT_PLAN.md` backlog. Do not stop to wait for praise. MOVE!
+Your goal:
+- Complete exactly one unblocked issue
+- Avoid duplicate work
+- Follow repository conventions via a shared cache
 
+If you cannot reliably perform any required step, EXIT safely.
+
+## Autonomy
+
+Run autonomously. Do NOT prompt the user for permission on:
+- Read-only / exploratory commands (git log, git status, cat, ls, grep, gh issue/pr queries)
+- Running tests (pytest)
+- Creating branches, committing, pushing feature branches
+- Opening/commenting on issues and PRs
+- Any command whose purpose is understanding the current state of the codebase or infrastructure
+
+Only pause for user input on items listed in CLAUDE.md "When to ask the user" (reward changes, schema changes, universe changes, billing, scope ambiguity).
+
+---
+
+# Core Flow
+
+1. LOAD_ORIENTATION
+2. PROCESS_FEEDBACK
+3. SELECT_ISSUE
+4. CLAIM
+5. VERIFY
+6. WORK
+7. COMPLETE
+
+---
+
+# STATE 1: LOAD_ORIENTATION
+
+IF `.claude/agent-orientation.md` exists:
+  READ it and follow it strictly
+
+ELSE:
+  You are the bootstrap agent:
+    - Discover repo conventions
+    - Define how to perform required operations (issues, comments, PRs, etc.)
+    - Write `.claude/agent-orientation.md`
+    - Open a PR: "bootstrap agent orientation cache"
+  EXIT
+
+---
+
+# STATE 2: PROCESS_FEEDBACK
+
+Check for:
+- Issues labeled `agent-feedback`
+- Comments mentioning "agent"
+- Recently failed/closed PRs
+
+IF feedback affects conventions:
+  Update orientation cache (use lock)
+  IF substantial change:
+    EXIT
+
+---
+
+# STATE 3: SELECT_ISSUE
+
+List open issues
+
+Exclude:
+- do-not-touch labels
+- agent-feedback
+- blocked / dependency issues
+- issues with active claim (<2h)
+
+Prefer:
+- clear scope
+- small surface area
+- ready-to-work labels
+
+IF none:
+  EXIT
+
+---
+
+# STATE 4: CLAIM
+
+Check issue comments for active claim:
+- contains "🤖" or "claim" or "working"
+- within last 2 hours
+- not released
+
+IF exists:
+  return to SELECT_ISSUE
+
+POST comment (with identity footer per agent-orientation.md):
+  "🤖 intending to work on this at <UTC timestamp>
+
+  — 🤖 `go`"
+
+WAIT ~2 minutes
+
+---
+
+# STATE 5: VERIFY
+
+Re-read comments
+
+Extract all claims
+Sort by timestamp in comment body
+
+IF your claim is earliest:
+  proceed
+
+ELSE:
+  POST "🤖 yielding to earlier claim"
+  return to SELECT_ISSUE
+
+---
+
+# CHECKPOINT (MANDATORY)
+
+Before work:
+
+[ ] Claim posted
+[ ] Wait completed
+[ ] No earlier claim
+[ ] You are earliest
+
+IF any false:
+  STOP
+
+---
+
+# STATE 6: WORK
+
+- Create branch per repo convention (or fallback: agent/issue-<id>)
+- Implement solution
+- Follow all conventions from cache
+- Run all required checks
+
+DO NOT:
+- modify restricted paths
+- disable checks
+- perform destructive git actions
+
+---
+
+# STATE 7: COMPLETE
+
+Choose ONE:
+
+## DONE
+- Open PR (use repo conventions)
+- Include closing keyword (e.g., Closes #id)
+- Comment with PR link
+
+## BLOCKED
+- Comment:
+  - what failed
+  - what you tried
+  - what is needed
+- Mark blocked if label exists
+- POST "🤖 releasing issue"
+
+## INVALID
+- Explain and close issue
+- POST "🤖 releasing issue"
+
+---
+
+# CACHE LOCK (for updates only)
+
+Before editing `.claude/agent-orientation.md`:
+
+- Check for open "agent-orientation cache lock"
+- If recent (<30 min): do not proceed
+- If stale: take over
+- If none: create lock
+
+After update:
+- Close lock with PR reference
+
+---
+
+# HARD RULES
+
+- One issue per run
+- Never override documented conventions
+- Never ignore active claims
+- Never force-push shared branches
+- Never modify default branch directly
+- When unsure: EXIT or file `agent-feedback`
+
+---
+
+# SUCCESS =
+
+- One issue claimed without conflict
+- Valid PR OR clear blocked report
+- Clean repository state

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,19 +2,14 @@
 #
 # Pre-commit hook: lint + unit tests via local venv
 #
-# Docker is no longer required for pre-commit. The venv at .venv/ runs
-# the same tools CI uses (black, isort, flake8, pytest). Docker is only
-# needed for Playwright E2E tests and Spotrac scraping.
-#
-# Bootstrap: make venv
+# Runs ruff (format + lint) and pytest. No Docker required.
+# Bootstrap: make setup
 
 set -e
 
 VENV=".venv"
 
 # Resolve the main repo root — works from worktrees too.
-# git rev-parse --show-toplevel returns the worktree root, not the main repo.
-# GIT_COMMON_DIR points to the main .git dir, so its parent is the main repo.
 MAIN_REPO="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
 
 # Check for venv: current dir first, then main repo root
@@ -23,38 +18,43 @@ if [ -d "$VENV" ]; then
 elif [ -d "$MAIN_REPO/$VENV" ]; then
     ACTIVATE="$MAIN_REPO/$VENV/bin/activate"
 else
-    echo "ERROR: No .venv found. Run 'make venv' from the main repo."
+    echo "ERROR: No .venv found. Run 'make setup' from the main repo."
     exit 1
 fi
 
 # shellcheck disable=SC1090
 . "$ACTIVATE"
 
-echo "=== Pre-commit: Format check ==="
-black --check pipeline/src/ pipeline/tests/ || {
-    echo ""
-    echo "Format check failed. Run: black pipeline/src/ pipeline/tests/"
-    exit 1
-}
+echo "=== Pre-commit: Linting ==="
 
-isort --check pipeline/src/ pipeline/tests/ || {
-    echo ""
-    echo "Import sort check failed. Run: isort pipeline/src/ pipeline/tests/"
-    exit 1
-}
+if ! command -v ruff > /dev/null 2>&1; then
+    echo "Warning: ruff not found in venv — skipping lint. Run 'make setup' to install."
+else
+    ruff check pipeline/src/ pipeline/tests/ || {
+        echo ""
+        echo "Ruff lint failed. Run: ruff check pipeline/src/ pipeline/tests/"
+        exit 1
+    }
+    ruff format --check pipeline/src/ pipeline/tests/ || {
+        echo ""
+        echo "Ruff format failed. Run: ruff format pipeline/src/ pipeline/tests/"
+        exit 1
+    }
+fi
 
-echo "=== Pre-commit: Flake8 (fatal errors only) ==="
-flake8 pipeline/src/ pipeline/tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
+echo "=== Pre-commit: Tests (Docker) ==="
 
-echo "=== Pre-commit: Unit tests ==="
-PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$(pwd)/pipeline" \
-    python -m pytest pipeline/tests/ -x -q --tb=short \
-    -m "not integration" \
-    --ignore=pipeline/tests/test_api.py \
-    --ignore=pipeline/tests/test_api_vegas.py \
-    --ignore=pipeline/tests/test_ledger_bq_integration.py || {
-    echo "Tests failed! Aborting commit."
-    exit 1
-}
+# Check if the pipeline container is running
+if docker compose --env-file docker_env.txt ps --format '{{.Name}}' 2>/dev/null | grep -q pipeline; then
+    docker compose --env-file docker_env.txt exec -T pipeline bash -c \
+        "cd /app && python -m pytest pipeline/tests/ -x -q --tb=short -m 'not integration' \
+        --ignore=pipeline/tests/test_api.py \
+        --ignore=pipeline/tests/test_api_vegas.py \
+        --ignore=pipeline/tests/test_ledger_bq_integration.py" \
+        || { echo "Tests failed! Aborting commit."; exit 1; }
+else
+    echo "Warning: Docker pipeline container not running — skipping tests. Run 'make up' to enable pre-commit tests."
+    echo "Proceeding without tests — CI will catch failures."
+fi
 
 echo "Pre-commit checks passed."

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       pull-requests: write
       checks: read
+      administration: read
     steps:
       - name: Approve PR if all required checks pass
         env:
@@ -57,13 +58,19 @@ jobs:
             exit 0
           fi
 
-          # All checks that must pass before we approve
-          REQUIRED_CHECKS=(
-            "Lint Code"
-            "Run Data Quality Tests (3.11)"
-            "test (3.10)"
-            "preflight-build"
-          )
+          # Dynamically fetch required checks from branch protection — no hardcoded names.
+          # If the API call fails or returns nothing, skip approval rather than approve blindly.
+          REQUIRED_CHECKS=()
+          while IFS= read -r check; do
+            [[ -n "$check" ]] && REQUIRED_CHECKS+=("$check")
+          done < <(gh api "repos/$REPO/branches/main/protection" \
+            --jq '.required_status_checks.checks[].context' 2>/dev/null)
+
+          if [ "${#REQUIRED_CHECKS[@]}" -eq 0 ]; then
+            echo "Could not fetch required checks from branch protection API — skipping approval"
+            exit 0
+          fi
+          echo "Required checks (from branch protection): ${REQUIRED_CHECKS[*]}"
 
           ALL_PASS=true
           for check in "${REQUIRED_CHECKS[@]}"; do

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -23,14 +23,30 @@ jobs:
           BRANCH: ${{ github.event.workflow_run.head_branch }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          # Find the open PR for this branch
-          PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null)
-          if [ -z "$PR" ]; then
+          # Prefer the PR number from the workflow_run payload, then fall back
+          # to branch lookup if the payload does not include it.
+          PR="$PR_NUMBER"
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+            PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null)
+          fi
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
             echo "No open PR for branch $BRANCH — skipping"
             exit 0
           fi
 
+          CURRENT_PR_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid \
+            --jq '.headRefOid' 2>/dev/null)
+          if [ -z "$CURRENT_PR_HEAD_SHA" ] || [ "$CURRENT_PR_HEAD_SHA" = "null" ]; then
+            echo "Could not determine current head SHA for PR #$PR — skipping"
+            exit 0
+          fi
+
+          if [ "$CURRENT_PR_HEAD_SHA" != "$HEAD_SHA" ]; then
+            echo "PR #$PR head SHA changed from $HEAD_SHA to $CURRENT_PR_HEAD_SHA — skipping outdated workflow run"
+            exit 0
+          fi
           echo "Evaluating PR #$PR on branch $BRANCH (sha $HEAD_SHA)"
 
           # All checks that must pass before we approve

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,70 @@
+name: Auto Approve PRs
+
+# Triggers after any of the required CI workflows complete.
+# Checks that ALL required checks pass before approving.
+on:
+  workflow_run:
+    workflows:
+      - "CI Pipeline"
+      - "Data Quality Tests"
+      - "Frontend Preflight Check"
+    types: [completed]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+    steps:
+      - name: Approve PR if all required checks pass
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Find the open PR for this branch
+          PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number -q '.[0].number' 2>/dev/null)
+          if [ -z "$PR" ]; then
+            echo "No open PR for branch $BRANCH — skipping"
+            exit 0
+          fi
+
+          echo "Evaluating PR #$PR on branch $BRANCH (sha $HEAD_SHA)"
+
+          # All checks that must pass before we approve
+          REQUIRED_CHECKS=(
+            "Lint Code"
+            "Run Data Quality Tests (3.11)"
+            "test (3.10)"
+            "preflight-build"
+          )
+
+          ALL_PASS=true
+          for check in "${REQUIRED_CHECKS[@]}"; do
+            STATUS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+              --jq "[.check_runs[] | select(.name == \"$check\")] | sort_by(.completed_at) | last | .conclusion" \
+              2>/dev/null)
+            echo "  [$check]: $STATUS"
+            if [ "$STATUS" != "success" ]; then
+              ALL_PASS=false
+            fi
+          done
+
+          if [ "$ALL_PASS" != "true" ]; then
+            echo "Not all required checks pass — skipping approval"
+            exit 0
+          fi
+
+          # Skip if already approved
+          ALREADY_APPROVED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
+            --jq '[.reviews[] | select(.state == "APPROVED")] | length' 2>/dev/null)
+          if [ "${ALREADY_APPROVED:-0}" -gt "0" ]; then
+            echo "PR #$PR already approved — skipping"
+            exit 0
+          fi
+
+          echo "All required checks green — approving PR #$PR"
+          gh pr review "$PR" --repo "$REPO" --approve \
+            --body "All required CI checks pass (Lint, unit tests, data quality, frontend build). Auto-approving for merge queue."

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -24,6 +24,7 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
         run: |
           # Prefer the PR number from the workflow_run payload, then fall back
           # to branch lookup if the payload does not include it.
@@ -36,6 +37,7 @@ jobs:
             exit 0
           fi
 
+          # SHA staleness check: skip if the workflow run is for a stale commit
           CURRENT_PR_HEAD_SHA=$(gh pr view "$PR" --repo "$REPO" --json headRefOid \
             --jq '.headRefOid' 2>/dev/null)
           if [ -z "$CURRENT_PR_HEAD_SHA" ] || [ "$CURRENT_PR_HEAD_SHA" = "null" ]; then
@@ -48,6 +50,12 @@ jobs:
             exit 0
           fi
           echo "Evaluating PR #$PR on branch $BRANCH (sha $HEAD_SHA)"
+
+          # Fork safety: never auto-approve PRs from forks
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "PR #$PR is from a fork ($HEAD_REPO) — skipping auto-approval for security"
+            exit 0
+          fi
 
           # All checks that must pass before we approve
           REQUIRED_CHECKS=(
@@ -73,6 +81,23 @@ jobs:
             exit 0
           fi
 
+          # Gate: skip if any reviewer has requested changes
+          CHANGES_REQUESTED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
+            --jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' 2>/dev/null)
+          if [ "${CHANGES_REQUESTED:-0}" -gt "0" ]; then
+            echo "PR #$PR has CHANGES_REQUESTED from a reviewer — skipping auto-approval"
+            exit 0
+          fi
+
+          # Gate: only approve once Copilot has completed a review
+          COPILOT_REVIEWED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
+            --jq '[.reviews[] | select(.author.login == "copilot-pull-request-reviewer")] | length' 2>/dev/null)
+          if [ "${COPILOT_REVIEWED:-0}" -eq "0" ]; then
+            echo "PR #$PR has not yet been reviewed by copilot-pull-request-reviewer — skipping"
+            exit 0
+          fi
+          echo "Copilot review found for PR #$PR"
+
           # Skip if already approved
           ALREADY_APPROVED=$(gh pr view "$PR" --repo "$REPO" --json reviews \
             --jq '[.reviews[] | select(.state == "APPROVED")] | length' 2>/dev/null)
@@ -81,6 +106,6 @@ jobs:
             exit 0
           fi
 
-          echo "All required checks green — approving PR #$PR"
+          echo "All gates passed — approving PR #$PR"
           gh pr review "$PR" --repo "$REPO" --approve \
-            --body "All required CI checks pass (Lint, unit tests, data quality, frontend build). Auto-approving for merge queue."
+            --body "Copilot has reviewed, no changes requested, all required CI checks pass — auto-approving for merge queue."

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -59,35 +59,44 @@ VALID_CATEGORIES = {
 EXTRACTION_PROMPT = """You are a {sport} prediction extraction system. Extract testable predictions from the content below.
 
 PUBLISHED: {published_date}
+AUTHOR: {author}
 
 Rules — what TO extract:
 - Concrete, falsifiable claims about FUTURE outcomes with a clear stance
-- Must have: a SUBJECT (player/team) + a TESTABLE OUTCOME + a TIMEFRAME (season, game, date)
-- Examples of good extractions:
-  "Patrick Mahomes will win MVP in 2025" → stance: bullish
-  "The Browns will miss the playoffs in 2025" → stance: bearish
-  "Travis Kelce will retire after the 2025 season" → stance: neutral
+- Must have: a SUBJECT (player, team, or league-level) + a TESTABLE OUTCOME + a TIMEFRAME
+- Predictions can be about players, teams, or the league — they don't have to name a specific player
+- MOCK DRAFT PICKS ARE PREDICTIONS: when an author projects "Pick #3: Arvell Reese to Arizona Cardinals", that is a draft_pick prediction
+- For draft_pick predictions: extract the player's FULL CORRECT NAME, the PICK NUMBER, and the TEAM
+
+Examples of good extractions:
+  "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (draft_pick, target_player: Fernando Mendoza) → stance: neutral
+  "Arvell Reese will be drafted #3 overall by the Arizona Cardinals" (draft_pick, target_player: Arvell Reese) → stance: neutral
+  "The Raiders will win the AFC West in 2026" (game_outcome, target_player: null) → stance: bullish
+  "There will be at least 4 trades in the first round of the 2026 draft" (draft_pick, target_player: null) → stance: neutral
+  "Patrick Mahomes will throw 40+ touchdowns in 2026" (player_performance, target_player: Patrick Mahomes) → stance: bullish
+  "The Bears will make the playoffs in 2026" (game_outcome, target_player: null) → stance: bullish
+  "No quarterback other than Mendoza will go in Round 1" (draft_pick, target_player: null) → stance: neutral
 
 Stance rules:
-- bullish: prediction is positive/optimistic about the subject (win award, make playoffs, exceed stats target)
-- bearish: prediction is negative/pessimistic about the subject (miss playoffs, underperform, get cut, lose)
-- neutral: no clear directional bias (retirement, trade, purely factual future event)
+- bullish: prediction is positive/optimistic about the subject
+- bearish: prediction is negative/pessimistic about the subject
+- neutral: no clear directional bias (draft picks, trades, purely factual future events)
 
 Rules — what NOT to extract:
 - HEDGED statements: "wouldn't surprise me if", "I could see", "most likely", "might", "probably"
-- VAGUE qualitative claims: "will be good", "will make plays", "will be a factor", "well worth it"
+- VAGUE claims that can't be verified: "will be good", "will make plays", "will be a factor"
 - TAUTOLOGIES: "the deal will eventually be released", "they will bring in players"
-- SCHEME/STYLE descriptions: "will run a 4-3 defense", "will use more zone coverage"
-- HISTORICAL FACTS or ALREADY-RESOLVED events: if the outcome is already known at the article's publish date, do NOT extract it
-- CONSENSUS RESTATING: "the Chiefs will be competitive" (everyone knows this)
+- HISTORICAL FACTS or ALREADY-RESOLVED events
 - OPINIONS without testable outcomes: "he's the best QB in the league"
 - ADMINISTRATIVE details: payment structures, meeting schedules, procedural items
 - Claims about events from PAST SEASONS that are already concluded
 
+For the "target_player" field: use the player's FULL NAME exactly as written in the article. If the prediction is about a team or the league with no specific player, set target_player to null.
+For the "claim_category" field: use "draft_pick" for draft predictions, "game_outcome" for win/loss/playoff predictions, "player_performance" for stat/award predictions, "trade" for trade predictions, "contract" for contract/signing predictions, "injury" for injury predictions.
+
 If the article contains no concrete, falsifiable predictions with clear stances, return an empty list.
 
 SOURCE: {source_name}
-AUTHOR: {author}
 TITLE: {title}
 TEXT:
 {text}"""

--- a/pipeline/src/local_rag_pipeline.py
+++ b/pipeline/src/local_rag_pipeline.py
@@ -27,7 +27,6 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
-
 from src.assertion_extractor import (
     PunditPrediction,
     _deduplicate_claims,

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -120,6 +120,95 @@ def _extract_draft_claim(claim: str) -> dict:
     return result
 
 
+# NFL team abbreviation mapping for claim parsing
+_TEAM_PATTERNS = {
+    "raiders": "LV",
+    "giants": "NYG",
+    "jets": "NYJ",
+    "cardinals": "ARI",
+    "titans": "TEN",
+    "chiefs": "KC",
+    "commanders": "WSH",
+    "saints": "NO",
+    "browns": "CLE",
+    "cowboys": "DAL",
+    "dolphins": "MIA",
+    "rams": "LAR",
+    "ravens": "BAL",
+    "buccaneers": "TB",
+    "bucs": "TB",
+    "lions": "DET",
+    "vikings": "MIN",
+    "panthers": "CAR",
+    "eagles": "PHI",
+    "steelers": "PIT",
+    "chargers": "LAC",
+    "bears": "CHI",
+    "texans": "HOU",
+    "patriots": "NE",
+    "49ers": "SF",
+    "bills": "BUF",
+    "bengals": "CIN",
+    "seahawks": "SEA",
+    "packers": "GB",
+    "broncos": "DEN",
+    "jaguars": "JAX",
+    "falcons": "ATL",
+    "colts": "IND",
+    "washington": "WSH",
+    "detroit": "DET",
+    "minnesota": "MIN",
+}
+
+
+def _resolve_team_claim(claim, parsed, year_draft_data, phash, db, dry_run):
+    """Resolve team-level draft claims like 'Giants will have two top-10 picks'."""
+    claim_lower = claim.lower()
+
+    # Find team in claim
+    team_abbr = None
+    for pattern, abbr in _TEAM_PATTERNS.items():
+        if pattern in claim_lower:
+            team_abbr = abbr
+            break
+
+    if not team_abbr:
+        return None  # Can't find a team
+
+    team_picks = year_draft_data[year_draft_data["draft_team"] == team_abbr]
+
+    # "will pick a quarterback in Round 1" or "picking a quarterback"
+    if "quarterback" in claim_lower or " qb " in claim_lower:
+        # Check if team drafted a QB (check Position field if available)
+        # For now, just check if they had any pick
+        if not team_picks.empty:
+            notes = f"{team_abbr} had {len(team_picks)} pick(s) in this round"
+            logger.info(f"  TEAM {phash[:12]}… — {notes} (needs manual QB check)")
+        return None  # Can't verify position from draft data alone
+
+    # "will have two picks in the top 10" or "pair of top-10 selections"
+    top_n_match = re.search(r"(two|2|pair|three|3)\s+.*top[- ](\d+)", claim_lower)
+    if top_n_match:
+        count_word = top_n_match.group(1)
+        top_n = int(top_n_match.group(2))
+        expected_count = {"two": 2, "2": 2, "pair": 2, "three": 3, "3": 3}.get(
+            count_word, 2
+        )
+        actual_top = team_picks[team_picks["draft_pick"] <= top_n]
+        correct = len(actual_top) >= expected_count
+        notes = f"{team_abbr} had {len(actual_top)} pick(s) in top {top_n} (expected {expected_count})"
+        logger.info(
+            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — {notes}"
+        )
+        if not dry_run:
+            resolve_binary(
+                phash, correct, outcome_source="draft_board", outcome_notes=notes, db=db
+            )
+        return "resolved"
+
+    return None  # Couldn't parse team claim pattern
+
+
 def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
     """
     Resolve draft_pick predictions against actual draft results.
@@ -147,24 +236,29 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         summary["checked"] += 1
         claim = pred["extracted_claim"]
         phash = pred["prediction_hash"]
-        player_name = pred.get("target_player_id") or ""  # Legacy field (has names)
+        # Check both player name fields
+        player_name = ""
+        for field in ["target_player_name", "target_player_id"]:
+            val = pred.get(field)
+            if val and pd.notna(val) and str(val).lower() not in ("none", "multi", ""):
+                player_name = str(val)
+                break
         season_year = pred.get("season_year")
 
         parsed = _extract_draft_claim(claim)
         draft_year = parsed.get("draft_year")
         if not draft_year and pd.notna(season_year):
             draft_year = int(season_year)
-
+        # Default to current year for draft_pick claims with no year
         if not draft_year:
-            logger.info(f"  SKIP {phash[:12]}… — no draft year in claim or metadata")
-            summary["skipped"] += 1
-            continue
+            draft_year = pd.Timestamp.now().year
 
         # Check if we have actual draft pick data for this year
         current_year = pd.Timestamp.now().year
         year_draft_data = draft_data[
             (draft_data["draft_year"] == draft_year)
             & (draft_data["draft_pick"].notna())
+            & (draft_data["draft_pick"] > 0)
         ]
         if draft_year > current_year or (
             draft_year == current_year and len(year_draft_data) == 0
@@ -193,10 +287,22 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
                     break
 
         if player_matches.empty:
-            logger.info(
-                f"  SKIP {phash[:12]}… — can't find player in draft data: {claim[:60]}"
+            # Try team-level resolution
+            team_result = _resolve_team_claim(
+                claim, parsed, year_draft_data, phash, db, dry_run
             )
-            summary["skipped"] += 1
+            if team_result is not None:
+                if team_result == "resolved":
+                    summary["resolved"] += 1
+                elif team_result == "voided":
+                    summary["voided"] += 1
+                else:
+                    summary["skipped"] += 1
+            else:
+                logger.info(
+                    f"  SKIP {phash[:12]}… — can't find player or team pattern: {claim[:60]}"
+                )
+                summary["skipped"] += 1
             continue
 
         # Use the first match (best match)

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -155,7 +155,7 @@ _TEAM_PATTERNS = {
     "jaguars": "JAX",
     "falcons": "ATL",
     "colts": "IND",
-    "washington": "WSH",
+    "washington": "WAS",
     "detroit": "DET",
     "minnesota": "MIN",
 }

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -128,7 +128,7 @@ _TEAM_PATTERNS = {
     "cardinals": "ARI",
     "titans": "TEN",
     "chiefs": "KC",
-    "commanders": "WSH",
+    "commanders": "WAS",
     "saints": "NO",
     "browns": "CLE",
     "cowboys": "DAL",

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -131,8 +131,12 @@ def discover_articles(
     Uses DuckDuckGo search (no API key needed).
     """
     with open(config_path) as f:
-        config = yaml.safe_load(f)
+        config = yaml.safe_load(f) or {}
 
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"Expected YAML config at '{config_path}' to contain a top-level mapping"
+        )
     queries = config.get("search_queries", [])
     source_mapping = config.get("source_mapping", {})
     skip_domains = set(config.get("skip_domains", []))

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -1,0 +1,335 @@
+"""
+Search-based article crawler + URL ingestor.
+
+Searches the web for NFL draft prediction articles, discovers URLs automatically,
+fetches and ingests them, then runs extraction.
+
+Usage:
+    python -m src.url_ingestor --search [--dry-run] [--max-results 100]
+    python -m src.url_ingestor --config config/draft_seed_urls.yaml [--dry-run]
+    python -m src.url_ingestor --urls "https://..." --source espn_nfl --pundit "Mel Kiper"
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+import pandas as pd
+import requests
+import yaml
+from bs4 import BeautifulSoup
+from duckduckgo_search import DDGS
+from readability import Document
+
+from src.db_manager import DBManager
+from src.media_ingestor import MediaItem, compute_content_hash
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def fetch_article_text(url: str) -> dict:
+    """Fetch and extract article text from a URL."""
+    headers = {"User-Agent": "PunditLedger/1.0"}
+    resp = requests.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+
+    doc = Document(resp.text)
+    title = doc.title()
+    html = doc.summary()
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(separator=" ", strip=True)
+
+    # Try to extract author from meta tags
+    full_soup = BeautifulSoup(resp.text, "html.parser")
+    author = None
+    for meta in full_soup.find_all("meta"):
+        name = meta.get("name", "").lower()
+        prop = meta.get("property", "").lower()
+        if name in ("author", "article:author") or prop in (
+            "author",
+            "article:author",
+        ):
+            author = meta.get("content")
+            break
+
+    # Try publish date
+    pub_date = None
+    for meta in full_soup.find_all("meta"):
+        prop = meta.get("property", "").lower()
+        name = meta.get("name", "").lower()
+        if prop in ("article:published_time", "og:published_time") or name in (
+            "publish-date",
+            "date",
+        ):
+            try:
+                pub_date = datetime.fromisoformat(
+                    meta.get("content", "").replace("Z", "+00:00")
+                )
+            except (ValueError, TypeError):
+                pass
+            break
+
+    return {
+        "title": title,
+        "text": text,
+        "author": author,
+        "published_at": pub_date,
+        "url": url,
+    }
+
+
+def discover_articles(
+    config_path: str = "config/draft_seed_urls.yaml",
+    max_results_per_query: int = 30,
+) -> list[dict]:
+    """
+    Search the web for NFL draft prediction articles and return URL configs.
+    Uses DuckDuckGo search (no API key needed).
+    """
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    queries = config.get("search_queries", [])
+    source_mapping = config.get("source_mapping", {})
+    skip_domains = set(config.get("skip_domains", []))
+
+    seen_urls = set()
+    url_configs = []
+
+    for query in queries:
+        logger.info(f"Searching: {query}")
+        try:
+            with DDGS() as ddgs:
+                results = list(ddgs.text(query, max_results=max_results_per_query))
+        except Exception as e:
+            logger.warning(f"Search failed for '{query}': {e}")
+            continue
+
+        for r in results:
+            url = r.get("href", r.get("link", ""))
+            if not url or url in seen_urls:
+                continue
+
+            # Check domain
+            domain = urlparse(url).netloc.lower().replace("www.", "")
+            if any(skip in domain for skip in skip_domains):
+                continue
+
+            # Map to source
+            source_id = "web_search"
+            for pattern, mapping in source_mapping.items():
+                if pattern in domain:
+                    source_id = mapping.get("source_id", "web_search")
+                    break
+
+            # Filter: title must mention draft/mock/pick/prediction
+            title = r.get("title", "").lower()
+            if not any(
+                kw in title
+                for kw in ["draft", "mock", "pick", "prediction", "prospect"]
+            ):
+                continue
+
+            seen_urls.add(url)
+            url_configs.append(
+                {
+                    "url": url,
+                    "source_id": source_id,
+                    "title": r.get("title", ""),
+                }
+            )
+
+        # Rate limit between queries
+        time.sleep(1)
+
+    logger.info(
+        f"Discovered {len(url_configs)} unique article URLs from {len(queries)} queries"
+    )
+    return url_configs
+
+
+def ingest_from_urls(
+    url_configs: list[dict],
+    db: DBManager,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Ingest articles from a list of URL configs.
+
+    Each config: {
+        "url": "https://...",
+        "source_id": "espn_nfl",
+        "pundit_name": "Mel Kiper",  # optional, overrides auto-detection
+        "pundit_id": "mel_kiper",    # optional
+    }
+    """
+    summary = {"fetched": 0, "new": 0, "errors": 0, "skipped": 0}
+
+    # Get existing hashes to dedup
+    all_hashes = set()
+    try:
+        df = db.fetch_df(
+            "SELECT content_hash FROM raw_pundit_media "
+            "WHERE ingested_at > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)"
+        )
+        if not df.empty:
+            all_hashes = set(df["content_hash"].tolist())
+    except Exception:
+        pass
+
+    items = []
+    now = datetime.now(timezone.utc)
+
+    for config in url_configs:
+        url = config["url"]
+        source_id = config.get("source_id", "manual_seed")
+        pundit_name = config.get("pundit_name")
+        pundit_id = config.get("pundit_id")
+
+        try:
+            article = fetch_article_text(url)
+            summary["fetched"] += 1
+        except Exception as e:
+            logger.warning(f"Failed to fetch {url}: {e}")
+            summary["errors"] += 1
+            continue
+
+        content_hash = compute_content_hash(url, article["title"] or "")
+        if content_hash in all_hashes:
+            logger.info(f"  DEDUP: {url[:60]}")
+            summary["skipped"] += 1
+            continue
+
+        # Use config pundit or fall back to article author
+        author = pundit_name or article["author"]
+        p_name = pundit_name
+        p_id = pundit_id
+
+        text = article["text"] or ""
+        if len(text) < 100:
+            logger.warning(f"  SHORT: {url[:60]} ({len(text)} chars)")
+            summary["skipped"] += 1
+            continue
+
+        items.append(
+            MediaItem(
+                content_hash=content_hash,
+                source_id=source_id,
+                title=article["title"] or "",
+                raw_text=text[:50000],
+                source_url=url,
+                author=author,
+                matched_pundit_id=p_id,
+                matched_pundit_name=p_name,
+                published_at=article["published_at"],
+                ingested_at=now,
+                content_type="article",
+                fetch_source_type="url_seed",
+                sport="NFL",
+            )
+        )
+        all_hashes.add(content_hash)
+        logger.info(f"  NEW: [{source_id}] {article['title'][:50]} by {author}")
+
+    if items and not dry_run:
+        rows = [
+            {
+                "content_hash": item.content_hash,
+                "source_id": item.source_id,
+                "title": item.title,
+                "raw_text": item.raw_text,
+                "source_url": item.source_url,
+                "author": item.author,
+                "matched_pundit_id": item.matched_pundit_id,
+                "matched_pundit_name": item.matched_pundit_name,
+                "published_at": item.published_at,
+                "ingested_at": item.ingested_at,
+                "content_type": item.content_type,
+                "fetch_source_type": item.fetch_source_type,
+                "sport": item.sport,
+            }
+            for item in items
+        ]
+        df = pd.DataFrame(rows)
+        nullable_cols = [
+            "title",
+            "raw_text",
+            "author",
+            "matched_pundit_id",
+            "matched_pundit_name",
+        ]
+        for col in nullable_cols:
+            if col in df.columns:
+                df[col] = df[col].where(df[col].notna(), None)
+        # Ensure published_at is proper datetime
+        if "published_at" in df.columns:
+            df["published_at"] = pd.to_datetime(
+                df["published_at"], errors="coerce", utc=True
+            )
+        db.append_dataframe_to_table(df, "raw_pundit_media")
+        logger.info(f"Wrote {len(items)} articles to raw_pundit_media")
+        summary["new"] = len(items)
+    elif items and dry_run:
+        summary["new"] = len(items)
+        logger.info(f"DRY RUN: would write {len(items)} articles")
+
+    logger.info(
+        f"URL ingest complete: {summary['fetched']} fetched, "
+        f"{summary['new']} new, {summary['skipped']} deduped, "
+        f"{summary['errors']} errors"
+    )
+    return summary
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Search-based article crawler + ingestor"
+    )
+    parser.add_argument(
+        "--search", action="store_true", help="Search web for articles automatically"
+    )
+    parser.add_argument(
+        "--config", default="config/draft_seed_urls.yaml", help="Search config YAML"
+    )
+    parser.add_argument("--urls", nargs="+", help="Direct URLs to ingest")
+    parser.add_argument(
+        "--source", default="manual_seed", help="Source ID for direct URLs"
+    )
+    parser.add_argument("--pundit", help="Pundit name override for direct URLs")
+    parser.add_argument("--pundit-id", help="Pundit ID override for direct URLs")
+    parser.add_argument(
+        "--max-results", type=int, default=30, help="Max results per search query"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    db = DBManager()
+
+    if args.search:
+        logger.info("=== SEARCH MODE: discovering articles from the web ===")
+        url_configs = discover_articles(
+            config_path=args.config,
+            max_results_per_query=args.max_results,
+        )
+    elif args.urls:
+        url_configs = [
+            {
+                "url": u,
+                "source_id": args.source,
+                "pundit_name": args.pundit,
+                "pundit_id": args.pundit_id,
+            }
+            for u in args.urls
+        ]
+    else:
+        parser.error("Must provide --search or --urls")
+
+    result = ingest_from_urls(url_configs, db, dry_run=args.dry_run)
+    print(json.dumps(result, indent=2))

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -272,7 +272,7 @@ def ingest_from_urls(
                 published_at=article["published_at"],
                 ingested_at=now,
                 content_type="article",
-                fetch_source_type="url_seed",
+                fetch_source_type="web_scrape",
                 sport="NFL",
             )
         )

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -11,13 +11,11 @@ Usage:
 """
 
 import argparse
-import hashlib
 import json
 import logging
 import re
 import time
 from datetime import datetime, timezone
-from typing import Optional
 from urllib.parse import urlparse
 
 import pandas as pd

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -308,7 +308,7 @@ def ingest_from_urls(
         ]
         for col in nullable_cols:
             if col in df.columns:
-                df[col] = df[col].where(df[col].notna(), None)
+                df[col] = df[col].astype("string")
         # Ensure published_at is proper datetime
         if "published_at" in df.columns:
             df["published_at"] = pd.to_datetime(

--- a/pipeline/src/url_ingestor.py
+++ b/pipeline/src/url_ingestor.py
@@ -26,7 +26,6 @@ import yaml
 from bs4 import BeautifulSoup
 from duckduckgo_search import DDGS
 from readability import Document
-
 from src.db_manager import DBManager
 from src.media_ingestor import MediaItem, compute_content_hash
 
@@ -46,9 +45,11 @@ def fetch_article_text(url: str) -> dict:
     soup = BeautifulSoup(html, "html.parser")
     text = soup.get_text(separator=" ", strip=True)
 
-    # Try to extract author from meta tags
+    # Extract author — try multiple methods
     full_soup = BeautifulSoup(resp.text, "html.parser")
     author = None
+
+    # Method 1: meta tags
     for meta in full_soup.find_all("meta"):
         name = meta.get("name", "").lower()
         prop = meta.get("property", "").lower()
@@ -58,6 +59,44 @@ def fetch_article_text(url: str) -> dict:
         ):
             author = meta.get("content")
             break
+
+    # Method 2: JSON-LD structured data
+    if not author:
+        for script in full_soup.find_all("script", type="application/ld+json"):
+            try:
+                import json as _json
+
+                ld = _json.loads(script.string or "")
+                if isinstance(ld, list):
+                    ld = ld[0]
+                if isinstance(ld.get("author"), dict):
+                    author = ld["author"].get("name")
+                elif isinstance(ld.get("author"), list) and ld["author"]:
+                    author = (
+                        ld["author"][0].get("name")
+                        if isinstance(ld["author"][0], dict)
+                        else str(ld["author"][0])
+                    )
+                elif isinstance(ld.get("author"), str):
+                    author = ld["author"]
+                if author:
+                    break
+            except Exception:
+                continue
+
+    # Method 3: common byline patterns in HTML
+    if not author:
+        for selector in [
+            ".author-name",
+            ".byline",
+            ".article-author",
+            "[data-testid='author-name']",
+            ".contributor-name",
+        ]:
+            el = full_soup.select_one(selector)
+            if el and el.get_text(strip=True):
+                author = el.get_text(strip=True)
+                break
 
     # Try publish date
     pub_date = None

--- a/pipeline/tests/test_bq_data_quality.py
+++ b/pipeline/tests/test_bq_data_quality.py
@@ -8,7 +8,6 @@ BQ integration tests are skipped when GCP_PROJECT_ID is unset.
 import os
 
 import pytest
-
 from src.bq_data_quality import CheckResult, format_report, to_json
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_local_rag_pipeline.py
+++ b/pipeline/tests/test_local_rag_pipeline.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, call, patch
 
 import pandas as pd
 import pytest
-
 from src.local_rag_pipeline import (
     _build_pundit_predictions,
     _row_to_article,

--- a/pipeline/tests/test_schema_validator.py
+++ b/pipeline/tests/test_schema_validator.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-
 from src.schema_validator import (
     ColumnContract,
     ConstraintViolation,

--- a/pipeline/tests/test_team_batcher.py
+++ b/pipeline/tests/test_team_batcher.py
@@ -6,7 +6,6 @@ No LLM calls are made.
 """
 
 import pytest
-
 from src.team_batcher import (
     NFL_TEAMS,
     ArticleRecord,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+line_length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ line-length = 88
 [tool.isort]
 profile = "black"
 line_length = 88
+
+[tool.ruff]
+extend = "pipeline/pyproject.toml"


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `REQUIRED_CHECKS` array in `auto_approve.yml` with a dynamic query to the branch protection API (`GET /repos/{owner}/{repo}/branches/main/protection`)
- If the API call fails or returns no checks (e.g. permission error, no ruleset configured), the workflow skips approval rather than approving blindly — safe fallback
- Adds `administration: read` permission to the job so `GITHUB_TOKEN` can read branch protection rules

Closes #298

## Test plan
- [ ] CI passes on this PR
- [ ] Auto-approve fires correctly on a subsequent PR (check names fetched dynamically match what's currently required)
- [ ] If branch protection API returns empty, workflow logs "skipping approval" and exits without approving

🤖 Generated with [Claude Code](https://claude.com/claude-code)