### PR TITLE
test(resolve): TestResolveTeamClaim + make resolve-draft target (#197)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down shell-pipeline venv test lint lint-fix test-e2e pipeline-scrape pipeline-train pipeline-nlp pipeline-validate pipeline-factcheck web-logs setup check
+.PHONY: up down shell-pipeline venv test lint lint-fix test-e2e pipeline-scrape pipeline-train pipeline-nlp pipeline-validate pipeline-factcheck web-logs setup check resolve-draft resolve-draft-dry
 
 PYTHON ?= python3
 VENV := .venv
@@ -79,6 +79,21 @@ pipeline-validate:
 pipeline-factcheck:
 	@echo "Running Automated Gemini Search Grounding on Top 50 Predictions..."
 	$(DOCKER) exec -e GEMINI_MODEL="$(if $(MODEL),$(MODEL),gemini-2.5-flash)" pipeline bash -c "python scripts/fact_check_top_50.py $(if $(TEAM),\"$(TEAM)\",)"
+
+# -----------------------------------------------------------------------------
+# RESOLUTION — run locally with GCP credentials (no Docker required)
+# Set GCP_PROJECT_ID in your environment (or source docker_env.txt first).
+# -----------------------------------------------------------------------------
+
+resolve-draft-dry:
+	@echo "Dry-run: draft_pick resolution pass (no writes)..."
+	$(PY) PYTHONPATH=$$(pwd)/pipeline \
+		python -m src.resolve_daily --category draft_pick --dry-run
+
+resolve-draft:
+	@echo "Running draft_pick resolution pass..."
+	$(PY) PYTHONPATH=$$(pwd)/pipeline \
+		python -m src.resolve_daily --category draft_pick
 
 # -----------------------------------------------------------------------------
 # WEB

--- a/pipeline/tests/test_resolve_daily.py
+++ b/pipeline/tests/test_resolve_daily.py
@@ -14,6 +14,7 @@ from src.resolve_daily import (
     _extract_player_stat_claim,
     _normalize_name,
     _normalize_team,
+    _resolve_team_claim,
     resolve_draft_picks,
     resolve_game_outcomes,
     resolve_player_performance,
@@ -556,3 +557,127 @@ class TestResolvePlayerPerformance:
         )
         summary = resolve_player_performance(mock_db, dry_run=False)
         assert summary["checked"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_team_claim
+# ---------------------------------------------------------------------------
+
+
+_YEAR_DRAFT_DATA_2026 = pd.DataFrame(
+    [
+        {
+            "Name": "Travis Hunter",
+            "name_lower": "travis hunter",
+            "draft_year": 2026,
+            "draft_round": 1,
+            "draft_pick": 2,
+            "draft_team": "NYG",
+        },
+        {
+            "Name": "Shedeur Sanders",
+            "name_lower": "shedeur sanders",
+            "draft_year": 2026,
+            "draft_round": 1,
+            "draft_pick": 5,
+            "draft_team": "CLE",
+        },
+        {
+            "Name": "Ashton Jeanty",
+            "name_lower": "ashton jeanty",
+            "draft_year": 2026,
+            "draft_round": 1,
+            "draft_pick": 6,
+            "draft_team": "LV",
+        },
+        {
+            "Name": "Mason Graham",
+            "name_lower": "mason graham",
+            "draft_year": 2026,
+            "draft_round": 1,
+            "draft_pick": 3,
+            "draft_team": "CLE",
+        },
+    ]
+)
+
+
+class TestResolveTeamClaim:
+    def test_no_team_in_claim_returns_none(self, mock_db):
+        """Claims with no recognizable team are returned as None."""
+        result = _resolve_team_claim(
+            claim="Someone will have two top-10 picks",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=True,
+        )
+        assert result is None
+
+    def test_qb_claim_returns_none(self, mock_db):
+        """QB position claims can't be verified from draft data — returns None."""
+        result = _resolve_team_claim(
+            claim="Browns will pick a quarterback in Round 1",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=True,
+        )
+        assert result is None
+
+    @patch("src.resolve_daily.resolve_binary")
+    def test_two_top_picks_correct(self, mock_resolve, mock_db):
+        """Team with two picks in top-10 resolves as CORRECT."""
+        result = _resolve_team_claim(
+            claim="Browns will have two top-10 picks in the 2026 draft",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=False,
+        )
+        assert result == "resolved"
+        # resolve_binary(phash, correct, ...) — correct is positional arg [1]
+        assert mock_resolve.call_args[0][1] is True
+
+    @patch("src.resolve_daily.resolve_binary")
+    def test_two_top_picks_incorrect(self, mock_resolve, mock_db):
+        """Team with only one top-10 pick resolves as INCORRECT when two expected."""
+        result = _resolve_team_claim(
+            claim="Raiders will have two top-10 picks in the draft",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=False,
+        )
+        assert result == "resolved"
+        # resolve_binary(phash, correct, ...) — correct is positional arg [1]
+        assert mock_resolve.call_args[0][1] is False
+
+    @patch("src.resolve_daily.resolve_binary")
+    def test_dry_run_does_not_call_resolve_binary(self, mock_resolve, mock_db):
+        """dry_run=True suppresses the resolve_binary write."""
+        _resolve_team_claim(
+            claim="Browns will have two top-10 picks in the 2026 draft",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=True,
+        )
+        mock_resolve.assert_not_called()
+
+    def test_unrecognized_team_pattern_returns_none(self, mock_db):
+        """Team found but no resolvable claim pattern → None."""
+        result = _resolve_team_claim(
+            claim="The Giants will do well in the draft this year",
+            parsed={},
+            year_draft_data=_YEAR_DRAFT_DATA_2026,
+            phash=FAKE_HASH,
+            db=mock_db,
+            dry_run=True,
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

- **`TestResolveTeamClaim` (6 tests)** — covers `_resolve_team_claim` which shipped in `cfce13f` (Apr 25) with zero test coverage. Tests:
  - No recognizable team → `None`
  - QB position claim → `None` (can't verify from draft data)
  - Browns with two CLE top-10 picks → CORRECT
  - Raiders with one top-10 pick (expected two) → INCORRECT
  - `dry_run=True` suppresses `resolve_binary` write
  - Team found but no parseable claim pattern → `None`

- **`make resolve-draft` / `make resolve-draft-dry`** — runs the draft_pick resolver locally via `.venv` without Docker. Requires `GCP_PROJECT_ID` set in environment (same credentials used elsewhere for local BQ dev).

## Context

The previous agent dry-run (Apr 25) reported 57 predictions skipped with "no draft year in claim or metadata" — that skip path was already removed in `cfce13f` (current-year fallback added). The agent was running a stale Docker image. The resolver code is now correct; the local Makefile target makes it easy to run without spinning up Docker.

Closes #197

## Test plan
- [x] `pytest pipeline/tests/test_resolve_daily.py` — 39 passed (33 existing + 6 new)
- [x] `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)