### PR TITLE
feat(pipeline): YouTube transcript bulk ingestor — parallel fetch, 11 channels, allow_historical (#262)

### DIFF
--- a/.agent/activity.log
+++ b/.agent/activity.log
@@ -4,5 +4,5 @@
 # Resources: issue:<n>  pr:<n>  file:<path>  branch:<name>
 # Rotation: entries older than 7 days are pruned weekly via .agent/claim.sh
 #
-2026-04-08T03:03:50Z | agent-test | CLAIM | issue:test-coord
-2026-04-08T03:03:50Z | agent-test | RELEASE | issue:test-coord
+2026-04-26T19:40:00Z | claude-sonnet-1777232399 | CLAIM | issue:youtube-transcripts
+2026-04-26T19:40:39Z | claude-sonnet-1777232439 | CLAIM | file:pipeline/config/media_sources.yaml

--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -176,6 +176,98 @@ sources:
         name: "Stephen A. Smith"
         match_authors: ["Stephen A. Smith", "Stephen A"]
 
+  # ── Tier 2 YouTube Expansion (issue #262) ─────────────────────────────────
+  - id: bussin_with_the_boys
+    name: "Bussin' With The Boys"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEJeEfpnO_2J3DVovs-0Pkw"
+    enabled: true
+    pundits:
+      - id: taylor_lewan
+        name: "Taylor Lewan"
+        match_authors: ["Taylor Lewan", "Lewan"]
+      - id: will_compton
+        name: "Will Compton"
+        match_authors: ["Will Compton", "Compton"]
+
+  - id: brett_kollmann
+    name: "Brett Kollmann"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCHGx4e5K0-_n3RMcWHiTb4A"
+    enabled: true
+    pundits:
+      - id: brett_kollmann
+        name: "Brett Kollmann"
+        match_authors: ["Brett Kollmann", "Kollmann"]
+
+  - id: warren_sharp
+    name: "Warren Sharp / Sharp Football"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCcaGl7bsLaVBnDlK-TGFKqA"
+    enabled: true
+    pundits:
+      - id: warren_sharp
+        name: "Warren Sharp"
+        match_authors: ["Warren Sharp", "Sharp Football"]
+
+  - id: locked_on_nfl
+    name: "Locked On NFL"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCFkI6HvC2a-Y33IfiBqLKhg"
+    enabled: true
+    default_pundit:
+      id: locked_on_nfl_staff
+      name: "Locked On NFL Staff"
+    pundits: []
+
+  - id: the_ringer_nfl_yt
+    name: "The Ringer NFL Show (YouTube)"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCMqF6BdstA43vNQzs2BMR0w"
+    enabled: true
+    default_pundit:
+      id: ringer_nfl_staff
+      name: "The Ringer NFL"
+    pundits: []
+
+  - id: pff_nfl
+    name: "PFF (Pro Football Focus)"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCijBMkVMuT1hl4vAAGjxJPA"
+    enabled: true
+    default_pundit:
+      id: pff_staff
+      name: "PFF Staff"
+    pundits: []
+
+  - id: move_the_sticks
+    name: "Move The Sticks (Daniel Jeremiah)"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCaWLWkqRKcVgkz3jocJUjHg"
+    enabled: true
+    pundits:
+      - id: daniel_jeremiah
+        name: "Daniel Jeremiah"
+        match_authors: ["Daniel Jeremiah", "Jeremiah"]
+
+  - id: athletic_football_yt
+    name: "The Athletic Football Show (YouTube)"
+    sport: "NFL"
+    type: youtube_transcript
+    url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCEShWcVeWL3jL0lNfM4kO8Q"
+    enabled: true
+    default_pundit:
+      id: athletic_nfl_staff
+      name: "The Athletic NFL Staff"
+    pundits: []
+
   # ── Tier 1 YouTube Expansion (issue #129) ──────────────────────────────────
   - id: the_herd
     name: "The Herd with Colin Cowherd"

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -190,6 +190,7 @@ def extract_assertions(
     sport: str = "NFL",
     published_date: str = "",
     provider: Optional[LLMProvider] = None,
+    allow_historical: bool = False,
     # Legacy parameter — ignored if provider is set
     client=None,
 ) -> ExtractionResult:
@@ -216,13 +217,16 @@ def extract_assertions(
         predictions = provider.extract_predictions(prompt)
         # Filter empty claims, then deduplicate near-identical ones
         valid = [p for p in predictions if p.get("extracted_claim", "").strip()]
-        # Hard temporal filter: reject predictions about past seasons/drafts
+        # Hard temporal filter: reject predictions about past seasons/drafts.
+        # Bypassed with allow_historical=True for backfill ingestion of
+        # already-completed seasons (2020–2024) where outcomes ARE known.
         current_year = datetime.now().year
         filtered = []
         for p in valid:
             sy = p.get("season_year")
             if (
-                sy is not None
+                not allow_historical
+                and sy is not None
                 and isinstance(sy, (int, float))
                 and int(sy) < current_year
             ):
@@ -383,6 +387,7 @@ def run_extraction(
     provider: Optional[LLMProvider] = None,
     provider_name: Optional[str] = None,
     disable_filter: bool = False,
+    allow_historical: bool = False,
     # Legacy parameter — ignored if provider is set
     gemini_client=None,
 ) -> dict:
@@ -485,6 +490,7 @@ def run_extraction(
                 sport=str(row.get("sport", sport)),
                 published_date=pub_date,
                 provider=provider,
+                allow_historical=allow_historical,
             )
 
             if result.error:
@@ -624,6 +630,14 @@ if __name__ == "__main__":
             "so those items are re-extracted on the next run. Exits after reset."
         ),
     )
+    parser.add_argument(
+        "--allow-historical",
+        action="store_true",
+        help=(
+            "Bypass the temporal filter that drops past-season predictions. "
+            "Use for historical backfill (2020-2024 content) where outcomes are known."
+        ),
+    )
     args = parser.parse_args()
 
     if args.reset_processed is not None:
@@ -638,5 +652,6 @@ if __name__ == "__main__":
             sport=args.sport,
             include_unmatched=args.include_unmatched,
             provider_name=args.provider,
+            allow_historical=args.allow_historical,
         )
         print(json.dumps(result, indent=2))

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -327,6 +327,19 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
 
 TRANSCRIPT_CHUNK_SIZE = 3500
 
+# Prediction-dense title filter — skip YouTube videos that are clearly not
+# prediction content (game recaps, highlight compilations, interviews, etc.)
+_PREDICTION_TITLE_RE = re.compile(
+    r"""
+    predict|bold|will\s|won['']?t|preview|grade|rank|MVP|
+    playoff|over[.\-/]under|win\s+total|lock\s+of|pick\s|picks\s|
+    bold\s+call|super\s+bowl|nfl\s+draft|free\s+agent|hot\s+take|
+    week\s+\d+|game\s+day|breakdown|who\s+wins|should\s+the|
+    bet|prop|sleeper|bust|breakout|fantasy
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 def _chunk_transcript(text: str, max_chars: int = TRANSCRIPT_CHUNK_SIZE) -> list[str]:
     """Split transcript text into chunks of ~max_chars, splitting at sentence boundaries."""
@@ -385,19 +398,31 @@ def _fetch_transcript(video_id: str) -> str:
         return " ".join(segment["text"] for segment in transcript_data)
 
 
+_MAX_YOUTUBE_DURATION_SECONDS = 90 * 60  # 90 minutes
+_MIN_YOUTUBE_PUBLISH_YEAR = 2020
+
+
 def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
     """
     Fetches recent videos from a YouTube channel via RSS, then downloads
     auto-generated transcripts for each video.
+
+    Applies optional filters from source config:
+      - title_filter: false (default, opt-in) — set true to only fetch prediction-dense titles
+      - max_duration_seconds: skip videos longer than N seconds (default 5400 = 90 min)
+      - min_publish_year: skip videos published before this year (default 2020)
     """
     url = source["url"]
     source_id = source["id"]
     pundits = source.get("pundits", [])
     sport = source.get("sport", "NFL")
     max_items = defaults.get("max_items_per_feed", 50)
+    apply_title_filter = source.get("title_filter", False)
+    max_duration = source.get("max_duration_seconds", _MAX_YOUTUBE_DURATION_SECONDS)
+    min_year = source.get("min_publish_year", _MIN_YOUTUBE_PUBLISH_YEAR)
 
     # Default pundit for YouTube channels (usually single-pundit channels)
-    default_pundit = pundits[0] if pundits else {}
+    default_pundit = pundits[0] if pundits else source.get("default_pundit", {})
     author = default_pundit.get("name")
     pundit_id = default_pundit.get("id")
     pundit_name = default_pundit.get("name")
@@ -416,8 +441,13 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
 
     items = []
     now = datetime.now(timezone.utc)
+    skipped_title = 0
+    skipped_date = 0
 
-    for entry in feed.entries[:max_items]:
+    for entry in feed.entries[: max_items * 3]:  # over-fetch to allow for filtering
+        if len(items) >= max_items:
+            break
+
         title = entry.get("title", "")
         link = entry.get("link", "")
         if not link:
@@ -427,6 +457,12 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
         # and don't contain full-length pundit commentary worth extracting.
         if _is_youtube_short(link):
             logger.debug(f"[{source_id}] Skipping Short: {title}")
+            continue
+
+        # Title filter: skip videos that are clearly not prediction content
+        if apply_title_filter and not _PREDICTION_TITLE_RE.search(title):
+            skipped_title += 1
+            logger.debug(f"[{source_id}] Title filter skipped: {title}")
             continue
 
         video_id = _extract_video_id(link)
@@ -441,6 +477,14 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
                 published = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
             except Exception:
                 pass
+
+        # Date filter: skip pre-2020 content (resolver coverage limit)
+        if published is not None and published.year < min_year:
+            skipped_date += 1
+            logger.debug(
+                f"[{source_id}] Date filter skipped ({published.year}): {title}"
+            )
+            continue
 
         # Download transcript
         try:
@@ -482,6 +526,14 @@ def fetch_youtube_transcripts(source: dict, defaults: dict) -> list[MediaItem]:
                 )
             )
 
+    if skipped_title:
+        logger.info(
+            f"[{source_id}] Title filter skipped {skipped_title} non-prediction videos"
+        )
+    if skipped_date:
+        logger.info(
+            f"[{source_id}] Date filter skipped {skipped_date} pre-{min_year} videos"
+        )
     if not items and feed.entries:
         logger.warning(
             f"[{source_id}] Feed had {len(feed.entries)} entries "

--- a/pipeline/src/youtube_transcript_ingestor.py
+++ b/pipeline/src/youtube_transcript_ingestor.py
@@ -1,0 +1,1084 @@
+"""
+YouTube Transcript Bulk Ingestor (Issue #262)
+
+Fetches auto-generated transcripts from NFL prediction-dense YouTube channels,
+stores them as bronze-layer raw_pundit_media rows, then optionally runs the
+assertion extractor to convert them to structured predictions.
+
+Design goals:
+  - Parallelised transcript fetching (ThreadPoolExecutor, ≤10 workers)
+  - Title-regex filtering: only prediction-dense videos get processed
+  - Duration guard: skip videos longer than 90 minutes (cost control)
+  - Date guard: skip videos published before 2020 (resolver coverage)
+  - yt-dlp fallback when youtube-transcript-api reports "transcripts disabled"
+  - Writes to raw_pundit_media with fetch_source_type="youtube_transcript"
+  - Runs extraction with allow_historical=True so past-season predictions land
+
+Usage:
+    # Dry run — print what would be fetched, no BQ writes
+    python -m src.youtube_transcript_ingestor --dry-run
+
+    # Ingest + extract for all enabled channels (writes to BQ)
+    python -m src.youtube_transcript_ingestor --run-extraction
+
+    # Single channel
+    python -m src.youtube_transcript_ingestor --source bussin_with_the_boys --run-extraction
+
+    # Explicit video URL list (good for targeted backfill)
+    python -m src.youtube_transcript_ingestor --urls https://youtube.com/watch?v=ABC123 --run-extraction
+
+    # Sample test: 5 videos, dry-run
+    python -m src.youtube_transcript_ingestor --limit 5 --dry-run
+"""
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse, parse_qs
+
+import feedparser
+import pandas as pd
+
+try:
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    _yt_client: Optional[YouTubeTranscriptApi] = None
+    try:
+        _yt_client = YouTubeTranscriptApi()
+        _YT_API_V1 = True
+    except TypeError:
+        _YT_API_V1 = False
+    _YT_AVAILABLE = True
+except ImportError:
+    _YT_AVAILABLE = False
+    _YT_API_V1 = False
+    _yt_client = None
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RAW_MEDIA_TABLE = "raw_pundit_media"
+PROCESSED_TABLE = "processed_media_hashes"
+
+# Videos matching any of these patterns in the title are worth processing
+PREDICTION_TITLE_RE = re.compile(
+    r"""
+    predict|bold|will\s|won['']?t|preview|grade|rank|MVP|
+    playoff|over[.\-/]under|win\s+total|lock\s+of|pick\s|picks\s|
+    bold\s+call|super\s+bowl|nfl\s+draft|free\s+agent|hot\s+take|
+    week\s+\d+|game\s+day|breakdown|who\s+wins|should\s+the|
+    bet|prop|sleeper|bust|breakout|fantasy
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Skip videos longer than this (in seconds)
+MAX_DURATION_SECONDS = 90 * 60  # 90 minutes
+
+# Skip videos published before this year
+MIN_PUBLISH_YEAR = 2020
+
+# Parallelism cap for transcript fetches
+MAX_WORKERS = 10
+
+# How many videos per channel to consider (limited to keep batches fast)
+DEFAULT_MAX_VIDEOS = 25
+
+# ---------------------------------------------------------------------------
+# Channel registry
+# Used by --list-sources and when no --source / --urls is given.
+# channel_id: YouTube channel ID, used to build the Atom feed URL.
+# ---------------------------------------------------------------------------
+
+CHANNEL_REGISTRY: list[dict] = [
+    {
+        "id": "pat_mcafee_show",
+        "name": "The Pat McAfee Show",
+        "channel_id": "UCxcTeAKWJca6XyJ37_ZoKIQ",
+        "pundits": [{"id": "pat_mcafee", "name": "Pat McAfee"}],
+        "enabled": True,
+    },
+    {
+        "id": "bussin_with_the_boys",
+        "name": "Bussin' With The Boys",
+        "channel_id": "UCEJeEfpnO_2J3DVovs-0Pkw",
+        "pundits": [
+            {"id": "taylor_lewan", "name": "Taylor Lewan"},
+            {"id": "will_compton", "name": "Will Compton"},
+        ],
+        "enabled": True,
+    },
+    {
+        "id": "brett_kollmann",
+        "name": "Brett Kollmann",
+        "channel_id": "UCHGx4e5K0-_n3RMcWHiTb4A",
+        "pundits": [{"id": "brett_kollmann", "name": "Brett Kollmann"}],
+        "enabled": True,
+    },
+    {
+        "id": "warren_sharp",
+        "name": "Warren Sharp / Sharp Football",
+        "channel_id": "UCcaGl7bsLaVBnDlK-TGFKqA",
+        "pundits": [{"id": "warren_sharp", "name": "Warren Sharp"}],
+        "enabled": True,
+    },
+    {
+        "id": "locked_on_nfl",
+        "name": "Locked On NFL",
+        "channel_id": "UCFkI6HvC2a-Y33IfiBqLKhg",
+        "pundits": [{"id": "locked_on_nfl_staff", "name": "Locked On NFL Staff"}],
+        "enabled": True,
+    },
+    {
+        "id": "the_ringer_nfl",
+        "name": "The Ringer NFL Show",
+        "channel_id": "UCMqF6BdstA43vNQzs2BMR0w",
+        "pundits": [{"id": "ringer_nfl_staff", "name": "The Ringer NFL"}],
+        "enabled": True,
+    },
+    {
+        "id": "pff_nfl",
+        "name": "PFF (Pro Football Focus)",
+        "channel_id": "UCijBMkVMuT1hl4vAAGjxJPA",
+        "pundits": [{"id": "pff_staff", "name": "PFF Staff"}],
+        "enabled": True,
+    },
+    {
+        "id": "move_the_sticks",
+        "name": "Move The Sticks (Daniel Jeremiah)",
+        "channel_id": "UCaWLWkqRKcVgkz3jocJUjHg",
+        "pundits": [{"id": "daniel_jeremiah", "name": "Daniel Jeremiah"}],
+        "enabled": True,
+    },
+    {
+        "id": "athletic_football_show",
+        "name": "The Athletic Football Show",
+        "channel_id": "UCEShWcVeWL3jL0lNfM4kO8Q",
+        "pundits": [{"id": "athletic_nfl_staff", "name": "The Athletic NFL Staff"}],
+        "enabled": True,
+    },
+    {
+        "id": "rich_eisen_show",
+        "name": "The Rich Eisen Show",
+        "channel_id": "UCqMtxjKnR7ySbEZSs2N-v0Q",
+        "pundits": [{"id": "rich_eisen", "name": "Rich Eisen"}],
+        "enabled": True,
+    },
+    {
+        "id": "dan_patrick_show",
+        "name": "The Dan Patrick Show",
+        "channel_id": "UCORy0Yqzd8bVj2Gb4xyq6HA",
+        "pundits": [{"id": "dan_patrick", "name": "Dan Patrick"}],
+        "enabled": True,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VideoMeta:
+    """Metadata for a YouTube video before transcript fetch."""
+
+    video_id: str
+    url: str
+    title: str
+    published_at: Optional[datetime]
+    channel_id: str
+    source_id: str
+    pundit_id: Optional[str]
+    pundit_name: Optional[str]
+    duration_seconds: Optional[int] = None
+    # True once transcript has been fetched
+    transcript_fetched: bool = False
+
+
+@dataclass
+class TranscriptResult:
+    """Result of a single transcript fetch attempt."""
+
+    video_id: str
+    url: str
+    transcript_text: Optional[str]
+    error: Optional[str] = None
+    used_ytdlp: bool = False
+
+
+@dataclass
+class IngestSummary:
+    source_id: str
+    videos_considered: int = 0
+    videos_skipped_title: int = 0
+    videos_skipped_duration: int = 0
+    videos_skipped_date: int = 0
+    videos_skipped_dedup: int = 0
+    transcripts_fetched: int = 0
+    transcripts_failed: int = 0
+    transcripts_disabled_count: int = 0
+    items_written: int = 0
+    predictions_extracted: int = 0
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# YouTube helpers
+# ---------------------------------------------------------------------------
+
+
+def _channel_feed_url(channel_id: str) -> str:
+    return f"https://www.youtube.com/feeds/videos.xml?channel_id={channel_id}"
+
+
+def _extract_video_id(url: str) -> Optional[str]:
+    """Extract 11-char video ID from various YouTube URL formats."""
+    # Standard watch URL
+    match = re.search(r"[?&]v=([a-zA-Z0-9_-]{11})", url)
+    if match:
+        return match.group(1)
+    # Shortened youtu.be/ID
+    match = re.search(r"youtu\.be/([a-zA-Z0-9_-]{11})", url)
+    if match:
+        return match.group(1)
+    # Shorts
+    match = re.search(r"/shorts/([a-zA-Z0-9_-]{11})", url)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _is_short(url: str) -> bool:
+    return "/shorts/" in url
+
+
+def _passes_title_filter(title: str) -> bool:
+    """Return True if the video title suggests prediction-dense content."""
+    return bool(PREDICTION_TITLE_RE.search(title))
+
+
+def _passes_date_filter(published_at: Optional[datetime]) -> bool:
+    """Return True if the video was published in MIN_PUBLISH_YEAR or later."""
+    if published_at is None:
+        return True  # optimistic: don't reject unknowns
+    return published_at.year >= MIN_PUBLISH_YEAR
+
+
+def _parse_duration_iso(duration_str: str) -> Optional[int]:
+    """Parse ISO 8601 duration (PT1H30M45S) → seconds. Returns None on parse failure."""
+    if not duration_str:
+        return None
+    match = re.match(
+        r"PT(?:(?P<h>\d+)H)?(?:(?P<m>\d+)M)?(?:(?P<s>\d+)S)?", duration_str
+    )
+    if not match:
+        return None
+    h = int(match.group("h") or 0)
+    m = int(match.group("m") or 0)
+    s = int(match.group("s") or 0)
+    return h * 3600 + m * 60 + s
+
+
+# ---------------------------------------------------------------------------
+# Transcript fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_transcript_yt_api(video_id: str) -> str:
+    """Fetch transcript via youtube-transcript-api. Raises on failure."""
+    if not _YT_AVAILABLE:
+        raise ImportError("youtube-transcript-api not installed")
+    if _YT_API_V1 and _yt_client is not None:
+        result = _yt_client.fetch(video_id)
+        return " ".join(snippet.text for snippet in result)
+    else:
+        transcript_data = YouTubeTranscriptApi.get_transcript(video_id)
+        return " ".join(seg["text"] for seg in transcript_data)
+
+
+def _fetch_transcript_ytdlp(video_id: str) -> str:
+    """
+    Fallback: use yt-dlp to download auto-generated subtitles as a VTT file,
+    then strip the VTT markup and return plain text.
+    Raises subprocess.CalledProcessError on failure.
+    """
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_template = str(Path(tmpdir) / "%(id)s.%(ext)s")
+        subprocess.run(
+            [
+                "yt-dlp",
+                "--write-auto-sub",
+                "--sub-lang",
+                "en",
+                "--skip-download",
+                "--convert-subs",
+                "vtt",
+                "-o",
+                out_template,
+                url,
+            ],
+            check=True,
+            capture_output=True,
+            timeout=120,
+        )
+        # Find the downloaded VTT file
+        vtt_files = list(Path(tmpdir).glob("*.vtt"))
+        if not vtt_files:
+            raise FileNotFoundError(f"yt-dlp produced no VTT for {video_id}")
+        vtt_text = vtt_files[0].read_text(encoding="utf-8", errors="ignore")
+    # Strip VTT markup: remove header, timestamps, tags
+    lines = []
+    for line in vtt_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("WEBVTT") or line.startswith("NOTE"):
+            continue
+        if re.match(r"^\d{2}:\d{2}:\d{2}", line):
+            continue
+        if re.match(r"^<\d{2}:\d{2}:\d{2}", line):
+            continue
+        # Strip inline VTT tags like <00:00:01.000> and <c>
+        cleaned = re.sub(r"<[^>]+>", "", line).strip()
+        if cleaned:
+            lines.append(cleaned)
+    return " ".join(lines)
+
+
+def fetch_single_transcript(video_id: str) -> TranscriptResult:
+    """
+    Fetch transcript for a single video ID, trying youtube-transcript-api first,
+    then falling back to yt-dlp.
+    Returns a TranscriptResult (never raises).
+    """
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    # Attempt 1: youtube-transcript-api
+    try:
+        text = _fetch_transcript_yt_api(video_id)
+        if text.strip():
+            return TranscriptResult(video_id=video_id, url=url, transcript_text=text)
+    except Exception as e1:
+        err_msg = str(e1)
+        disabled = "disabled" in err_msg.lower() or "no transcript" in err_msg.lower()
+
+        if disabled:
+            # Attempt 2: yt-dlp fallback
+            try:
+                text = _fetch_transcript_ytdlp(video_id)
+                if text.strip():
+                    return TranscriptResult(
+                        video_id=video_id,
+                        url=url,
+                        transcript_text=text,
+                        used_ytdlp=True,
+                    )
+            except Exception as e2:
+                return TranscriptResult(
+                    video_id=video_id,
+                    url=url,
+                    transcript_text=None,
+                    error=f"yt-api: {e1}; yt-dlp: {e2}",
+                )
+        else:
+            return TranscriptResult(
+                video_id=video_id,
+                url=url,
+                transcript_text=None,
+                error=str(e1),
+            )
+    return TranscriptResult(
+        video_id=video_id,
+        url=url,
+        transcript_text=None,
+        error="Empty transcript returned",
+    )
+
+
+def fetch_transcripts_parallel(
+    video_ids: list[str],
+    max_workers: int = MAX_WORKERS,
+) -> list[TranscriptResult]:
+    """Fetch transcripts for multiple video IDs in parallel."""
+    results: list[TranscriptResult] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        future_map = {
+            pool.submit(fetch_single_transcript, vid): vid for vid in video_ids
+        }
+        for future in as_completed(future_map):
+            results.append(future.result())
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Channel feed parsing
+# ---------------------------------------------------------------------------
+
+
+def list_channel_videos(
+    channel_id: str,
+    source_id: str,
+    pundit_id: Optional[str],
+    pundit_name: Optional[str],
+    max_videos: int = DEFAULT_MAX_VIDEOS,
+    title_filter: bool = True,
+    skip_shorts: bool = True,
+) -> tuple[list[VideoMeta], int]:
+    """
+    Fetch a channel's Atom feed and return VideoMeta objects for videos that
+    pass the title/date/shorts filters.
+
+    Returns (filtered_videos, total_skipped_by_title).
+    """
+    feed_url = _channel_feed_url(channel_id)
+    feed = feedparser.parse(
+        feed_url, request_headers={"User-Agent": "PunditLedger/1.0"}
+    )
+
+    videos: list[VideoMeta] = []
+    skipped_title = 0
+
+    for entry in feed.entries[: max_videos * 3]:  # fetch 3x to allow for filtering
+        title = entry.get("title", "")
+        link = entry.get("link", "")
+        if not link:
+            continue
+
+        if skip_shorts and _is_short(link):
+            continue
+
+        video_id = _extract_video_id(link)
+        if not video_id:
+            continue
+
+        # Title filter
+        if title_filter and not _passes_title_filter(title):
+            skipped_title += 1
+            continue
+
+        # Parse published date
+        published: Optional[datetime] = None
+        if hasattr(entry, "published_parsed") and entry.published_parsed:
+            try:
+                published = datetime(*entry.published_parsed[:6], tzinfo=timezone.utc)
+            except Exception:
+                pass
+
+        # Date filter
+        if not _passes_date_filter(published):
+            continue
+
+        # Parse duration from yt:statistics or media:group if available
+        duration_seconds: Optional[int] = None
+        for ns_key in ("yt_duration", "media_duration"):
+            val = entry.get(ns_key)
+            if val:
+                duration_seconds = _parse_duration_iso(str(val))
+                break
+
+        videos.append(
+            VideoMeta(
+                video_id=video_id,
+                url=link,
+                title=title,
+                published_at=published,
+                channel_id=channel_id,
+                source_id=source_id,
+                pundit_id=pundit_id,
+                pundit_name=pundit_name,
+                duration_seconds=duration_seconds,
+            )
+        )
+
+        if len(videos) >= max_videos:
+            break
+
+    return videos, skipped_title
+
+
+# ---------------------------------------------------------------------------
+# Content hashing and dedup
+# ---------------------------------------------------------------------------
+
+
+def _content_hash(url: str, chunk_index: int = 0) -> str:
+    chunk_suffix = f"|chunk_{chunk_index}" if chunk_index > 0 else ""
+    return hashlib.sha256(f"{url}{chunk_suffix}".encode()).hexdigest()
+
+
+def _get_existing_hashes(db, source_id: str) -> set:
+    """Fetch all previously ingested content_hashes for this source (all-time)."""
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    try:
+        df = db.fetch_df(
+            f"""
+            SELECT content_hash
+            FROM `{project_id}.nfl_dead_money.{RAW_MEDIA_TABLE}`
+            WHERE source_id = '{source_id}'
+        """
+        )
+        return set(df["content_hash"].tolist()) if not df.empty else set()
+    except Exception as e:
+        logger.warning(f"Could not fetch existing hashes for {source_id}: {e}")
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+CHUNK_SIZE = 3500
+
+
+def _chunk_text(text: str) -> list[str]:
+    if len(text) <= CHUNK_SIZE:
+        return [text]
+    chunks: list[str] = []
+    remaining = text
+    while remaining:
+        if len(remaining) <= CHUNK_SIZE:
+            chunks.append(remaining)
+            break
+        split_at = CHUNK_SIZE
+        last_sentence = -1
+        for m in re.finditer(r"[.!?]\s", remaining[:CHUNK_SIZE]):
+            last_sentence = m.end()
+        if last_sentence > 0:
+            split_at = last_sentence
+        else:
+            last_space = remaining[:CHUNK_SIZE].rfind(" ")
+            if last_space > 0:
+                split_at = last_space + 1
+        chunks.append(remaining[:split_at].strip())
+        remaining = remaining[split_at:].strip()
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Core ingest function
+# ---------------------------------------------------------------------------
+
+
+def ingest_channel(
+    channel_cfg: dict,
+    db=None,
+    dry_run: bool = False,
+    max_videos: int = DEFAULT_MAX_VIDEOS,
+    title_filter: bool = True,
+    run_extraction: bool = False,
+) -> IngestSummary:
+    """
+    Full ingest pipeline for a single channel:
+      1. Fetch channel feed
+      2. Filter videos (title, date, duration)
+      3. Parallel transcript fetch
+      4. Dedup + write to raw_pundit_media
+      5. (Optional) Run assertion extractor on new items
+
+    Returns IngestSummary with counts for observability.
+    """
+    source_id = channel_cfg["id"]
+    channel_id = channel_cfg["channel_id"]
+    pundits = channel_cfg.get("pundits", [])
+    pundit = pundits[0] if pundits else {}
+    pundit_id = pundit.get("id")
+    pundit_name = pundit.get("name")
+
+    summary = IngestSummary(source_id=source_id)
+
+    logger.info(f"[{source_id}] Fetching channel feed: {channel_cfg['name']}")
+    try:
+        videos, skipped_title = list_channel_videos(
+            channel_id=channel_id,
+            source_id=source_id,
+            pundit_id=pundit_id,
+            pundit_name=pundit_name,
+            max_videos=max_videos,
+            title_filter=title_filter,
+        )
+    except Exception as e:
+        summary.error = f"Feed fetch failed: {e}"
+        logger.error(f"[{source_id}] {summary.error}")
+        return summary
+
+    summary.videos_considered = len(videos) + skipped_title
+    summary.videos_skipped_title = skipped_title
+
+    # Duration filter (applied after feed parse since duration isn't always in feed)
+    duration_filtered = []
+    for v in videos:
+        if v.duration_seconds is not None and v.duration_seconds > MAX_DURATION_SECONDS:
+            summary.videos_skipped_duration += 1
+            logger.debug(
+                f"[{source_id}] Skipping long video ({v.duration_seconds}s): {v.title}"
+            )
+        else:
+            duration_filtered.append(v)
+
+    videos = duration_filtered
+
+    if not videos:
+        logger.warning(f"[{source_id}] No videos passed filters")
+        return summary
+
+    logger.info(
+        f"[{source_id}] Fetching transcripts for {len(videos)} videos (parallel)"
+    )
+
+    # Dedup against BQ before fetching transcripts
+    existing_hashes: set = set()
+    if db is not None and not dry_run:
+        existing_hashes = _get_existing_hashes(db, source_id)
+
+    # Check which videos we'd dedup before even fetching
+    videos_to_fetch = []
+    for v in videos:
+        h = _content_hash(v.url)
+        if h in existing_hashes:
+            summary.videos_skipped_dedup += 1
+        else:
+            videos_to_fetch.append(v)
+
+    if not videos_to_fetch:
+        logger.info(f"[{source_id}] All videos already ingested (dedup)")
+        return summary
+
+    # Parallel transcript fetch
+    video_ids = [v.video_id for v in videos_to_fetch]
+    transcript_results = fetch_transcripts_parallel(video_ids, max_workers=MAX_WORKERS)
+
+    # Map results back to VideoMeta
+    result_by_id = {r.video_id: r for r in transcript_results}
+    disabled_count = sum(
+        1
+        for r in transcript_results
+        if r.error and "disabled" in (r.error or "").lower()
+    )
+    summary.transcripts_disabled_count = disabled_count
+
+    # Stop condition: >50% transcripts disabled
+    if len(transcript_results) > 0:
+        disabled_ratio = disabled_count / len(transcript_results)
+        if disabled_ratio > 0.5:
+            logger.warning(
+                f"[{source_id}] {disabled_ratio:.0%} of transcripts disabled — "
+                "yt-dlp fallback already attempted; channel may not support captions"
+            )
+
+    # Build MediaItem rows
+    rows: list[dict] = []
+    now = datetime.now(timezone.utc)
+
+    for v in videos_to_fetch:
+        result = result_by_id.get(v.video_id)
+        if result is None or result.transcript_text is None:
+            summary.transcripts_failed += 1
+            continue
+
+        summary.transcripts_fetched += 1
+        chunks = _chunk_text(result.transcript_text)
+
+        for i, chunk in enumerate(chunks):
+            is_chunked = len(chunks) > 1
+            chunk_suffix = f"|chunk_{i}" if is_chunked else ""
+            chunk_title = f"{v.title} (part {i + 1})" if is_chunked else v.title
+            ch = _content_hash(v.url, i)
+
+            if ch in existing_hashes:
+                continue
+
+            metadata = {
+                "used_ytdlp": result.used_ytdlp,
+                "is_historical": v.published_at.year < datetime.now().year
+                if v.published_at
+                else False,
+            }
+
+            rows.append(
+                {
+                    "content_hash": ch,
+                    "source_id": source_id,
+                    "title": chunk_title,
+                    "raw_text": chunk,
+                    "source_url": v.url,
+                    "author": pundit_name,
+                    "matched_pundit_id": pundit_id,
+                    "matched_pundit_name": pundit_name,
+                    "published_at": v.published_at,
+                    "ingested_at": now,
+                    "content_type": "transcript",
+                    "fetch_source_type": "youtube_transcript",
+                    "sport": "NFL",
+                    "raw_metadata": json.dumps(metadata),
+                }
+            )
+
+    summary.items_written = len(rows)
+
+    if rows and not dry_run and db is not None:
+        df = pd.DataFrame(rows)
+        nullable_cols = [
+            "title",
+            "raw_text",
+            "author",
+            "matched_pundit_id",
+            "matched_pundit_name",
+            "published_at",
+            "raw_metadata",
+        ]
+        for col in nullable_cols:
+            if col in df.columns:
+                df[col] = df[col].where(df[col].notna(), None)
+        db.append_dataframe_to_table(df, RAW_MEDIA_TABLE)
+        logger.info(f"[{source_id}] Wrote {len(rows)} transcript chunks to BQ")
+    elif dry_run:
+        logger.info(f"[{source_id}] DRY RUN: would write {len(rows)} transcript chunks")
+
+    # Optional: run assertion extractor on newly ingested items
+    if run_extraction and rows and not dry_run and db is not None:
+        hashes_just_written = [r["content_hash"] for r in rows]
+        n_predictions = _run_extraction_for_hashes(hashes_just_written, db)
+        summary.predictions_extracted = n_predictions
+
+    return summary
+
+
+def _run_extraction_for_hashes(content_hashes: list[str], db) -> int:
+    """Run assertion extraction on a specific set of content_hashes (just written)."""
+    try:
+        from src.assertion_extractor import (
+            extract_assertions,
+            get_unprocessed_media,
+            mark_as_processed,
+            run_extraction,
+        )
+        from src.llm_provider import get_provider_with_fallback, load_llm_config
+
+        llm_cfg = load_llm_config()
+        provider = get_provider_with_fallback(llm_cfg)
+
+        # Use run_extraction with a high limit so it picks up our new rows
+        # allow_historical=True to preserve past-season predictions
+        result = run_extraction(
+            limit=len(content_hashes) * 3,  # margin for dedup/concurrency
+            dry_run=False,
+            sport="NFL",
+            include_unmatched=False,
+            db=db,
+            provider=provider,
+            allow_historical=True,
+        )
+        n = result.get("predictions_ingested", 0)
+        logger.info(
+            f"Extraction: {n} predictions from {len(content_hashes)} transcript chunks"
+        )
+        return n
+    except Exception as e:
+        logger.error(f"Extraction failed: {e}")
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Ingest from explicit URL list
+# ---------------------------------------------------------------------------
+
+
+def ingest_urls(
+    urls: list[str],
+    source_id: str = "youtube_backfill",
+    pundit_id: Optional[str] = None,
+    pundit_name: Optional[str] = None,
+    db=None,
+    dry_run: bool = False,
+    run_extraction: bool = False,
+) -> IngestSummary:
+    """
+    Ingest transcripts from an explicit list of YouTube video URLs.
+    Useful for targeted backfill without needing channel feed access.
+    """
+    summary = IngestSummary(source_id=source_id)
+    existing_hashes: set = set()
+    if db is not None and not dry_run:
+        existing_hashes = _get_existing_hashes(db, source_id)
+
+    video_ids_to_fetch: list[tuple[str, str]] = []  # (video_id, url)
+    for url in urls:
+        if "/shorts/" in url:
+            logger.debug(f"Skipping Short: {url}")
+            continue
+        vid = _extract_video_id(url)
+        if not vid:
+            logger.warning(f"Could not extract video ID: {url}")
+            continue
+        h = _content_hash(url)
+        if h in existing_hashes:
+            summary.videos_skipped_dedup += 1
+            continue
+        video_ids_to_fetch.append((vid, url))
+
+    summary.videos_considered = len(urls)
+
+    if not video_ids_to_fetch:
+        logger.info(f"[{source_id}] All URLs already ingested or invalid")
+        return summary
+
+    transcript_results = fetch_transcripts_parallel(
+        [vid for vid, _ in video_ids_to_fetch], max_workers=MAX_WORKERS
+    )
+    result_by_id = {r.video_id: r for r in transcript_results}
+
+    rows: list[dict] = []
+    now = datetime.now(timezone.utc)
+
+    for vid, url in video_ids_to_fetch:
+        result = result_by_id.get(vid)
+        if result is None or result.transcript_text is None:
+            summary.transcripts_failed += 1
+            continue
+        summary.transcripts_fetched += 1
+        chunks = _chunk_text(result.transcript_text)
+        for i, chunk in enumerate(chunks):
+            ch = _content_hash(url, i)
+            if ch in existing_hashes:
+                continue
+            rows.append(
+                {
+                    "content_hash": ch,
+                    "source_id": source_id,
+                    "title": f"YouTube video {vid}"
+                    + (f" (part {i + 1})" if len(chunks) > 1 else ""),
+                    "raw_text": chunk,
+                    "source_url": url,
+                    "author": pundit_name,
+                    "matched_pundit_id": pundit_id,
+                    "matched_pundit_name": pundit_name,
+                    "published_at": None,
+                    "ingested_at": now,
+                    "content_type": "transcript",
+                    "fetch_source_type": "youtube_transcript",
+                    "sport": "NFL",
+                    "raw_metadata": json.dumps({"used_ytdlp": result.used_ytdlp}),
+                }
+            )
+
+    summary.items_written = len(rows)
+
+    if rows and not dry_run and db is not None:
+        df = pd.DataFrame(rows)
+        nullable_cols = [
+            "title",
+            "raw_text",
+            "author",
+            "matched_pundit_id",
+            "matched_pundit_name",
+            "published_at",
+            "raw_metadata",
+        ]
+        for col in nullable_cols:
+            if col in df.columns:
+                df[col] = df[col].where(df[col].notna(), None)
+        db.append_dataframe_to_table(df, RAW_MEDIA_TABLE)
+        logger.info(f"[{source_id}] Wrote {len(rows)} chunks for {len(urls)} URLs")
+    elif dry_run:
+        logger.info(f"[{source_id}] DRY RUN: would write {len(rows)} chunks")
+
+    if run_extraction and rows and not dry_run and db is not None:
+        n = _run_extraction_for_hashes([r["content_hash"] for r in rows], db)
+        summary.predictions_extracted = n
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Multi-channel orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_all_channels(
+    db=None,
+    dry_run: bool = False,
+    source_filter: Optional[str] = None,
+    max_videos: int = DEFAULT_MAX_VIDEOS,
+    title_filter: bool = True,
+    run_extraction: bool = False,
+) -> list[IngestSummary]:
+    """Run ingest for all enabled channels (or a single one via source_filter)."""
+    summaries: list[IngestSummary] = []
+
+    for cfg in CHANNEL_REGISTRY:
+        if not cfg.get("enabled", True):
+            continue
+        if source_filter and cfg["id"] != source_filter:
+            continue
+
+        summary = ingest_channel(
+            channel_cfg=cfg,
+            db=db,
+            dry_run=dry_run,
+            max_videos=max_videos,
+            title_filter=title_filter,
+            run_extraction=run_extraction,
+        )
+        summaries.append(summary)
+
+    total_written = sum(s.items_written for s in summaries)
+    total_predictions = sum(s.predictions_extracted for s in summaries)
+    total_failed = sum(s.transcripts_failed for s in summaries)
+    logger.info(
+        f"YouTube ingest complete: {len(summaries)} channels, "
+        f"{total_written} chunks written, {total_predictions} predictions extracted, "
+        f"{total_failed} transcript failures"
+    )
+    return summaries
+
+
+# ---------------------------------------------------------------------------
+# Yield monitor
+# ---------------------------------------------------------------------------
+
+
+def check_yield(summaries: list[IngestSummary]) -> None:
+    """
+    Warn if prediction yield per transcript is below the 1 pred/transcript threshold.
+    This is a signal to re-tune the extractor prompt.
+    """
+    total_transcripts = sum(s.transcripts_fetched for s in summaries)
+    total_predictions = sum(s.predictions_extracted for s in summaries)
+    if total_transcripts == 0:
+        return
+    yield_rate = total_predictions / total_transcripts
+    if yield_rate < 1.0 and total_predictions > 0:
+        logger.warning(
+            f"Low extraction yield: {yield_rate:.2f} predictions/transcript "
+            f"({total_predictions}/{total_transcripts}). "
+            "Consider re-tuning the extraction prompt."
+        )
+    elif total_predictions == 0 and total_transcripts >= 5:
+        logger.error(
+            "STOP CONDITION: 0 predictions extracted from "
+            f"{total_transcripts} transcripts. Check extractor."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="YouTube Transcript Bulk Ingestor for Pundit Prediction Ledger"
+    )
+    parser.add_argument(
+        "--source", help="Run a single channel by source ID (e.g. bussin_with_the_boys)"
+    )
+    parser.add_argument(
+        "--urls",
+        nargs="+",
+        metavar="URL",
+        help="Explicit YouTube video URLs to ingest (backfill mode)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview without writing to BigQuery",
+    )
+    parser.add_argument(
+        "--run-extraction",
+        action="store_true",
+        help="Run assertion extractor on newly ingested transcripts",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_MAX_VIDEOS,
+        help=f"Max videos per channel (default: {DEFAULT_MAX_VIDEOS})",
+    )
+    parser.add_argument(
+        "--no-title-filter",
+        action="store_true",
+        help="Disable title-based prediction filter (process all videos)",
+    )
+    parser.add_argument(
+        "--list-sources",
+        action="store_true",
+        help="Print registered channels and exit",
+    )
+    args = parser.parse_args()
+
+    if args.list_sources:
+        print(f"\n{'ID':<35} {'Name':<40} {'Enabled'}")
+        print("-" * 85)
+        for cfg in CHANNEL_REGISTRY:
+            print(
+                f"{cfg['id']:<35} {cfg['name']:<40} {'yes' if cfg.get('enabled') else 'no'}"
+            )
+        return
+
+    # Import DBManager here to allow --dry-run / --list-sources without BQ creds
+    from src.db_manager import DBManager
+
+    db = None if args.dry_run else DBManager()
+
+    try:
+        if args.urls:
+            summary = ingest_urls(
+                urls=args.urls,
+                source_id=args.source or "youtube_backfill",
+                db=db,
+                dry_run=args.dry_run,
+                run_extraction=args.run_extraction,
+            )
+            summaries = [summary]
+        else:
+            summaries = run_all_channels(
+                db=db,
+                dry_run=args.dry_run,
+                source_filter=args.source,
+                max_videos=args.limit,
+                title_filter=not args.no_title_filter,
+                run_extraction=args.run_extraction,
+            )
+
+        # Print summary table
+        print(
+            f"\n{'Source':<35} {'Vids':>5} {'Skip-T':>7} {'Skip-D':>7} "
+            f"{'TxFetch':>8} {'Fail':>5} {'Chunks':>7} {'Preds':>6} {'Status'}"
+        )
+        print("-" * 100)
+        for s in summaries:
+            status = "OK" if not s.error else f"ERR: {s.error[:25]}"
+            print(
+                f"{s.source_id:<35} {s.videos_considered:>5} {s.videos_skipped_title:>7} "
+                f"{s.videos_skipped_duration:>7} {s.transcripts_fetched:>8} "
+                f"{s.transcripts_failed:>5} {s.items_written:>7} "
+                f"{s.predictions_extracted:>6} {status}"
+            )
+
+        if args.run_extraction:
+            check_yield(summaries)
+
+    finally:
+        if db is not None:
+            db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -869,3 +869,112 @@ class TestConstants:
             "contract",
         }
         assert VALID_CATEGORIES == expected
+
+
+# ---------------------------------------------------------------------------
+# allow_historical flag (Issue #262 / PR #319)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowHistorical:
+    """Tests for the allow_historical temporal-filter bypass added in #262."""
+
+    def _make_provider_with_past_prediction(self, past_year: int):
+        provider = MagicMock()
+        provider.model = "mock"
+        provider.extract_predictions.return_value = [
+            {
+                "extracted_claim": f"The Chiefs will win the Super Bowl in {past_year}",
+                "claim_category": "game_outcome",
+                "season_year": past_year,
+                "stance": "bullish",
+                "target_player": None,
+            }
+        ]
+        return provider
+
+    def test_past_season_filtered_by_default(self):
+        """Default: temporal filter should drop past-season predictions."""
+        past_year = 2022
+        provider = self._make_provider_with_past_prediction(past_year)
+        result = extract_assertions(
+            content_hash="hash_hist_1",
+            text="The Chiefs won the Super Bowl in 2022.",
+            provider=provider,
+            allow_historical=False,
+        )
+        assert result.predictions == [], (
+            f"Expected past-season ({past_year}) prediction to be filtered out"
+        )
+
+    def test_past_season_passes_with_allow_historical(self):
+        """allow_historical=True should bypass the temporal filter."""
+        past_year = 2022
+        provider = self._make_provider_with_past_prediction(past_year)
+        result = extract_assertions(
+            content_hash="hash_hist_2",
+            text="The Chiefs will win the Super Bowl in 2022.",
+            provider=provider,
+            allow_historical=True,
+        )
+        assert len(result.predictions) == 1, (
+            "Expected past-season prediction to pass when allow_historical=True"
+        )
+        assert result.predictions[0]["season_year"] == past_year
+
+    def test_current_year_always_passes(self):
+        """Current-year predictions should pass regardless of allow_historical."""
+        import datetime as dt
+
+        current_year = dt.datetime.now().year
+        provider = MagicMock()
+        provider.model = "mock"
+        provider.extract_predictions.return_value = [
+            {
+                "extracted_claim": f"Mahomes will throw 40 TDs in {current_year}",
+                "claim_category": "player_performance",
+                "season_year": current_year,
+                "stance": "bullish",
+                "target_player": "Patrick Mahomes",
+            }
+        ]
+        result = extract_assertions(
+            content_hash="hash_current",
+            text=f"Mahomes will throw 40 TDs in {current_year}.",
+            provider=provider,
+            allow_historical=False,
+        )
+        assert len(result.predictions) == 1
+
+    def test_run_extraction_passes_allow_historical(self, mock_db, mock_provider):
+        """run_extraction should thread allow_historical through to extract_assertions."""
+        past_year = 2023
+        import datetime as dt
+
+        mock_provider.extract_predictions.return_value = [
+            {
+                "extracted_claim": f"The Eagles will win in {past_year}",
+                "claim_category": "game_outcome",
+                "season_year": past_year,
+                "stance": "bullish",
+                "target_player": None,
+            }
+        ]
+
+        media_df = make_raw_media_df(1)
+        mock_db.fetch_df.return_value = media_df
+
+        with patch("src.assertion_extractor.ingest_batch") as mock_ingest:
+            mock_ingest.return_value = ["some_hash"]
+            result = run_extraction(
+                limit=10,
+                dry_run=False,
+                db=mock_db,
+                provider=mock_provider,
+                allow_historical=True,
+            )
+
+        # With allow_historical=True, the past prediction should be kept
+        assert result["predictions_extracted"] >= 1, (
+            "Expected predictions to be extracted with allow_historical=True"
+        )

--- a/pipeline/tests/test_youtube_transcript_ingestor.py
+++ b/pipeline/tests/test_youtube_transcript_ingestor.py
@@ -1,0 +1,602 @@
+"""
+Unit tests for youtube_transcript_ingestor.py (Issue #262).
+No BigQuery or real network access required.
+"""
+
+import json
+from concurrent.futures import Future
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from src.youtube_transcript_ingestor import (
+    CHANNEL_REGISTRY,
+    IngestSummary,
+    TranscriptResult,
+    VideoMeta,
+    _chunk_text,
+    _content_hash,
+    _extract_video_id,
+    _is_short,
+    _parse_duration_iso,
+    _passes_date_filter,
+    _passes_title_filter,
+    check_yield,
+    fetch_single_transcript,
+    fetch_transcripts_parallel,
+    ingest_channel,
+    ingest_urls,
+    list_channel_videos,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVideoId:
+    def test_standard_watch_url(self):
+        assert (
+            _extract_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_shortened_url(self):
+        assert _extract_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_shorts_url(self):
+        assert (
+            _extract_video_id("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_invalid_url(self):
+        assert _extract_video_id("https://example.com/video") is None
+
+    def test_url_with_extra_params(self):
+        assert (
+            _extract_video_id("https://www.youtube.com/watch?v=abcde12345f&t=120")
+            == "abcde12345f"
+        )
+
+
+class TestIsShort:
+    def test_shorts_url(self):
+        assert _is_short("https://www.youtube.com/shorts/abc123")
+
+    def test_regular_url(self):
+        assert not _is_short("https://www.youtube.com/watch?v=abc123")
+
+
+class TestParseDurationIso:
+    def test_full_duration(self):
+        assert _parse_duration_iso("PT1H30M45S") == 5445
+
+    def test_minutes_only(self):
+        assert _parse_duration_iso("PT45M") == 2700
+
+    def test_hours_and_minutes(self):
+        assert _parse_duration_iso("PT2H0M") == 7200
+
+    def test_invalid(self):
+        assert _parse_duration_iso("") is None
+        assert _parse_duration_iso("bad") is None
+
+
+class TestTitleFilter:
+    def test_prediction_keywords(self):
+        assert _passes_title_filter("NFL Week 5 Predictions and Picks")
+        assert _passes_title_filter("Bold Calls for the 2025 NFL Season")
+        assert _passes_title_filter("Who Wins the Super Bowl?")
+        assert _passes_title_filter("MVP Race Breakdown — Week 10")
+        assert _passes_title_filter("Fantasy Football Sleeper Picks")
+        assert _passes_title_filter("Playoff Preview: AFC Championship")
+
+    def test_non_prediction_titles(self):
+        # These are highlights or interviews that don't indicate predictions
+        assert not _passes_title_filter("Patrick Mahomes throws 5 TD passes")
+        assert not _passes_title_filter("Aaron Rodgers talks about his offseason")
+
+    def test_case_insensitive(self):
+        assert _passes_title_filter("PREDICTIONS for Week 1")
+        assert _passes_title_filter("nfl draft grades 2024")
+
+
+class TestDateFilter:
+    def test_recent_video(self):
+        dt = datetime(2023, 9, 1, tzinfo=timezone.utc)
+        assert _passes_date_filter(dt)
+
+    def test_exactly_2020(self):
+        dt = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        assert _passes_date_filter(dt)
+
+    def test_pre_2020(self):
+        dt = datetime(2019, 12, 31, tzinfo=timezone.utc)
+        assert not _passes_date_filter(dt)
+
+    def test_none_date(self):
+        # Optimistic: don't reject unknowns
+        assert _passes_date_filter(None)
+
+
+class TestChunkText:
+    def test_short_text_no_chunking(self):
+        text = "This is a short text."
+        chunks = _chunk_text(text)
+        assert len(chunks) == 1
+        assert chunks[0] == text
+
+    def test_long_text_splits(self):
+        # Create text longer than CHUNK_SIZE (3500)
+        text = "This is a sentence. " * 200  # ~4000 chars
+        chunks = _chunk_text(text)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk) <= 3500 + 100  # slight tolerance for boundary
+
+    def test_chunks_preserve_content(self):
+        text = "Word " * 1000
+        chunks = _chunk_text(text)
+        reconstructed = " ".join(chunks)
+        # All words present (allow whitespace normalization)
+        assert reconstructed.replace("  ", " ").count("Word") == 1000
+
+
+class TestContentHash:
+    def test_reproducible(self):
+        h1 = _content_hash("https://youtube.com/watch?v=abc", 0)
+        h2 = _content_hash("https://youtube.com/watch?v=abc", 0)
+        assert h1 == h2
+
+    def test_different_urls(self):
+        h1 = _content_hash("https://youtube.com/watch?v=abc")
+        h2 = _content_hash("https://youtube.com/watch?v=xyz")
+        assert h1 != h2
+
+    def test_different_chunks(self):
+        url = "https://youtube.com/watch?v=abc"
+        h0 = _content_hash(url, 0)
+        h1 = _content_hash(url, 1)
+        assert h0 != h1
+
+
+# ---------------------------------------------------------------------------
+# Channel registry
+# ---------------------------------------------------------------------------
+
+
+class TestChannelRegistry:
+    def test_all_entries_have_required_fields(self):
+        for ch in CHANNEL_REGISTRY:
+            assert "id" in ch, f"Missing id: {ch}"
+            assert "name" in ch, f"Missing name: {ch}"
+            assert "channel_id" in ch, f"Missing channel_id: {ch}"
+            assert "pundits" in ch or "default_pundit" in ch, (
+                f"Missing pundit config: {ch}"
+            )
+
+    def test_no_duplicate_ids(self):
+        ids = [ch["id"] for ch in CHANNEL_REGISTRY]
+        assert len(ids) == len(set(ids)), "Duplicate channel IDs found"
+
+    def test_target_channels_present(self):
+        ids = {ch["id"] for ch in CHANNEL_REGISTRY}
+        required = {
+            "pat_mcafee_show",
+            "bussin_with_the_boys",
+            "brett_kollmann",
+            "warren_sharp",
+            "locked_on_nfl",
+            "pff_nfl",
+            "move_the_sticks",
+        }
+        missing = required - ids
+        assert not missing, f"Missing expected channels: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Transcript fetching
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSingleTranscript:
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_yt_api")
+    def test_success_via_yt_api(self, mock_api):
+        mock_api.return_value = "This is the transcript text."
+        result = fetch_single_transcript("abc123")
+        assert result.transcript_text == "This is the transcript text."
+        assert result.error is None
+        assert not result.used_ytdlp
+
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_ytdlp")
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_yt_api")
+    def test_fallback_to_ytdlp_on_disabled(self, mock_api, mock_ytdlp):
+        mock_api.side_effect = Exception("Transcripts disabled")
+        mock_ytdlp.return_value = "Fallback transcript text."
+        result = fetch_single_transcript("abc123")
+        assert result.transcript_text == "Fallback transcript text."
+        assert result.used_ytdlp is True
+        assert result.error is None
+
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_ytdlp")
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_yt_api")
+    def test_both_fail(self, mock_api, mock_ytdlp):
+        mock_api.side_effect = Exception("Transcripts disabled")
+        mock_ytdlp.side_effect = Exception("yt-dlp failed")
+        result = fetch_single_transcript("abc123")
+        assert result.transcript_text is None
+        assert result.error is not None
+
+    @patch("src.youtube_transcript_ingestor._fetch_transcript_yt_api")
+    def test_non_disabled_error_no_ytdlp(self, mock_api):
+        """Non-'disabled' errors should NOT fall back to yt-dlp."""
+        mock_api.side_effect = Exception("Network timeout")
+        with patch(
+            "src.youtube_transcript_ingestor._fetch_transcript_ytdlp"
+        ) as mock_ytdlp:
+            result = fetch_single_transcript("abc123")
+            mock_ytdlp.assert_not_called()
+        assert result.transcript_text is None
+
+
+class TestFetchTranscriptsParallel:
+    @patch("src.youtube_transcript_ingestor.fetch_single_transcript")
+    def test_parallel_fetch(self, mock_fetch):
+        mock_fetch.side_effect = lambda vid: TranscriptResult(
+            video_id=vid,
+            url=f"https://youtube.com/watch?v={vid}",
+            transcript_text=f"Transcript for {vid}",
+        )
+        results = fetch_transcripts_parallel(["abc", "def", "ghi"])
+        assert len(results) == 3
+        assert all(r.transcript_text for r in results)
+
+    @patch("src.youtube_transcript_ingestor.fetch_single_transcript")
+    def test_parallel_with_failures(self, mock_fetch):
+        def side_effect(vid):
+            if vid == "fail":
+                return TranscriptResult(
+                    video_id=vid, url="", transcript_text=None, error="error"
+                )
+            return TranscriptResult(video_id=vid, url="", transcript_text="ok")
+
+        mock_fetch.side_effect = side_effect
+        results = fetch_transcripts_parallel(["ok1", "fail", "ok2"])
+        successes = [r for r in results if r.transcript_text]
+        failures = [r for r in results if not r.transcript_text]
+        assert len(successes) == 2
+        assert len(failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# Channel feed parsing
+# ---------------------------------------------------------------------------
+
+
+class TestListChannelVideos:
+    def _make_entry(self, title, link, year=2024):
+        """Create a feedparser-compatible entry mock."""
+        entry = MagicMock()
+        # feedparser entries use .get() like a dict
+        data = {"title": title, "link": link}
+        entry.get.side_effect = lambda k, d="": data.get(k, d)
+        entry.published_parsed = (year, 9, 1, 12, 0, 0, 0, 0, 0)
+        return entry
+
+    # YouTube video IDs must be exactly 11 alphanumeric chars
+    _PRED_VID = "pred001zzzz"  # 11 chars
+    _HILIT_VID = "hilit1zzzz0"  # 11 chars
+    _BOLD_VID = "bold001zzzz"  # 11 chars
+    _SHORT_VID = "short001zzz"  # 11 chars (in /shorts/ path)
+    _FULL_VID = "full001zzzz"  # 11 chars
+    _OLD_VID = "old001zzzzz"  # 11 chars
+    _NEW_VID = "new001zzzzz"  # 11 chars
+
+    @patch("src.youtube_transcript_ingestor.feedparser.parse")
+    def test_title_filter_applied(self, mock_parse):
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            self._make_entry(
+                "NFL Week 5 Predictions",
+                f"https://www.youtube.com/watch?v={self._PRED_VID}",
+            ),
+            self._make_entry(
+                "Highlight reel compilation",
+                f"https://www.youtube.com/watch?v={self._HILIT_VID}",
+            ),
+            self._make_entry(
+                "Bold Calls for Super Bowl",
+                f"https://www.youtube.com/watch?v={self._BOLD_VID}",
+            ),
+        ]
+        mock_parse.return_value = mock_feed
+
+        videos, skipped = list_channel_videos(
+            channel_id="UCtest",
+            source_id="test",
+            pundit_id=None,
+            pundit_name=None,
+            title_filter=True,
+        )
+        assert len(videos) == 2  # pred001 and bold001 pass
+        assert skipped == 1
+
+    @patch("src.youtube_transcript_ingestor.feedparser.parse")
+    def test_shorts_skipped(self, mock_parse):
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [
+            self._make_entry(
+                "NFL Predictions", f"https://www.youtube.com/shorts/{self._SHORT_VID}"
+            ),
+            self._make_entry(
+                "NFL Predictions Full",
+                f"https://www.youtube.com/watch?v={self._FULL_VID}",
+            ),
+        ]
+        mock_parse.return_value = mock_feed
+
+        videos, _ = list_channel_videos(
+            channel_id="UCtest",
+            source_id="test",
+            pundit_id=None,
+            pundit_name=None,
+            title_filter=True,
+        )
+        assert len(videos) == 1
+        assert videos[0].video_id == self._FULL_VID
+
+    @patch("src.youtube_transcript_ingestor.feedparser.parse")
+    def test_date_filter_applied(self, mock_parse):
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        e1 = self._make_entry(
+            "NFL Predictions 2019",
+            f"https://www.youtube.com/watch?v={self._OLD_VID}",
+            year=2019,
+        )
+        e2 = self._make_entry(
+            "NFL Predictions 2023",
+            f"https://www.youtube.com/watch?v={self._NEW_VID}",
+            year=2023,
+        )
+        mock_feed.entries = [e1, e2]
+        mock_parse.return_value = mock_feed
+
+        videos, _ = list_channel_videos(
+            channel_id="UCtest",
+            source_id="test",
+            pundit_id=None,
+            pundit_name=None,
+            title_filter=True,
+        )
+        assert len(videos) == 1
+        assert videos[0].video_id == self._NEW_VID
+
+
+# ---------------------------------------------------------------------------
+# Ingest channel
+# ---------------------------------------------------------------------------
+
+
+class TestIngestChannel:
+    def _make_channel_cfg(self):
+        return {
+            "id": "test_channel",
+            "name": "Test Channel",
+            "channel_id": "UCtest123",
+            "pundits": [{"id": "test_pundit", "name": "Test Pundit"}],
+            "enabled": True,
+        }
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    @patch("src.youtube_transcript_ingestor.list_channel_videos")
+    def test_dry_run_no_bq_writes(self, mock_list, mock_fetch):
+        mock_list.return_value = (
+            [
+                VideoMeta(
+                    video_id="abc123",
+                    url="https://youtube.com/watch?v=abc123",
+                    title="NFL Predictions Week 5",
+                    published_at=datetime(2024, 9, 1, tzinfo=timezone.utc),
+                    channel_id="UCtest",
+                    source_id="test_channel",
+                    pundit_id="test_pundit",
+                    pundit_name="Test Pundit",
+                )
+            ],
+            0,
+        )
+        mock_fetch.return_value = [
+            TranscriptResult(
+                video_id="abc123",
+                url="https://youtube.com/watch?v=abc123",
+                transcript_text="The Chiefs will win the Super Bowl this year.",
+            )
+        ]
+
+        mock_db = MagicMock()
+        summary = ingest_channel(self._make_channel_cfg(), db=mock_db, dry_run=True)
+
+        assert summary.items_written == 1
+        mock_db.append_dataframe_to_table.assert_not_called()
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    @patch("src.youtube_transcript_ingestor.list_channel_videos")
+    def test_bq_write_on_live_run(self, mock_list, mock_fetch):
+        mock_list.return_value = (
+            [
+                VideoMeta(
+                    video_id="xyz789",
+                    url="https://youtube.com/watch?v=xyz789",
+                    title="Bold Playoff Picks",
+                    published_at=datetime(2024, 10, 1, tzinfo=timezone.utc),
+                    channel_id="UCtest",
+                    source_id="test_channel",
+                    pundit_id="test_pundit",
+                    pundit_name="Test Pundit",
+                )
+            ],
+            0,
+        )
+        mock_fetch.return_value = [
+            TranscriptResult(
+                video_id="xyz789",
+                url="https://youtube.com/watch?v=xyz789",
+                transcript_text="I predict the Eagles will beat the Rams.",
+            )
+        ]
+
+        mock_db = MagicMock()
+        mock_db.fetch_df.return_value = __import__(
+            "pandas"
+        ).DataFrame()  # no existing hashes
+
+        summary = ingest_channel(self._make_channel_cfg(), db=mock_db, dry_run=False)
+
+        assert summary.items_written == 1
+        mock_db.append_dataframe_to_table.assert_called_once()
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    @patch("src.youtube_transcript_ingestor.list_channel_videos")
+    def test_dedup_skips_existing(self, mock_list, mock_fetch):
+        url = "https://youtube.com/watch?v=dedup01"
+        existing_hash = _content_hash(url, 0)
+
+        mock_list.return_value = (
+            [
+                VideoMeta(
+                    video_id="dedup01",
+                    url=url,
+                    title="NFL Playoff Predictions",
+                    published_at=datetime(2024, 9, 1, tzinfo=timezone.utc),
+                    channel_id="UCtest",
+                    source_id="test_channel",
+                    pundit_id="test_pundit",
+                    pundit_name="Test Pundit",
+                )
+            ],
+            0,
+        )
+
+        import pandas as pd
+
+        mock_db = MagicMock()
+        mock_db.fetch_df.return_value = pd.DataFrame({"content_hash": [existing_hash]})
+
+        summary = ingest_channel(self._make_channel_cfg(), db=mock_db, dry_run=False)
+
+        # Should be skipped before transcript fetch
+        mock_fetch.assert_not_called()
+        assert summary.videos_skipped_dedup == 1
+        assert summary.items_written == 0
+
+    @patch("src.youtube_transcript_ingestor.list_channel_videos")
+    def test_feed_error_returns_summary_with_error(self, mock_list):
+        mock_list.side_effect = Exception("Feed parse failed")
+        summary = ingest_channel(self._make_channel_cfg(), db=None, dry_run=True)
+        assert summary.error is not None
+        assert "Feed parse failed" in summary.error
+
+
+# ---------------------------------------------------------------------------
+# Ingest from explicit URLs
+# ---------------------------------------------------------------------------
+
+
+class TestIngestUrls:
+    # Use full www.youtube.com URLs so _extract_video_id regex matches (exactly 11 chars)
+    _URL1 = "https://www.youtube.com/watch?v=urlvid1zzzz"
+    _URL2 = "https://www.youtube.com/watch?v=dryrun1zzzz"
+    _VID1 = "urlvid1zzzz"
+    _VID2 = "dryrun1zzzz"
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    def test_basic_url_ingestion(self, mock_fetch):
+        mock_fetch.return_value = [
+            TranscriptResult(
+                video_id=self._VID1,
+                url=self._URL1,
+                transcript_text="This is a great transcript about NFL predictions.",
+            )
+        ]
+        mock_db = MagicMock()
+        mock_db.fetch_df.return_value = __import__("pandas").DataFrame()
+
+        summary = ingest_urls(
+            urls=[self._URL1],
+            source_id="test_backfill",
+            db=mock_db,
+            dry_run=False,
+        )
+        assert summary.transcripts_fetched == 1
+        assert summary.items_written == 1
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    def test_shorts_skipped(self, mock_fetch):
+        summary = ingest_urls(
+            urls=["https://www.youtube.com/shorts/shortid1"],
+            source_id="test_backfill",
+            db=None,
+            dry_run=True,
+        )
+        mock_fetch.assert_not_called()
+        assert summary.items_written == 0
+
+    @patch("src.youtube_transcript_ingestor.fetch_transcripts_parallel")
+    def test_dry_run_no_bq(self, mock_fetch):
+        mock_fetch.return_value = [
+            TranscriptResult(
+                video_id=self._VID2,
+                url=self._URL2,
+                transcript_text="Lots of NFL predictions here.",
+            )
+        ]
+        mock_db = MagicMock()
+        summary = ingest_urls(
+            urls=[self._URL2],
+            source_id="test_backfill",
+            db=mock_db,
+            dry_run=True,
+        )
+        mock_db.append_dataframe_to_table.assert_not_called()
+        assert summary.items_written == 1
+
+
+# ---------------------------------------------------------------------------
+# Yield monitor
+# ---------------------------------------------------------------------------
+
+
+class TestCheckYield:
+    def test_low_yield_warning(self, caplog):
+        summaries = [
+            IngestSummary(
+                source_id="s1", transcripts_fetched=10, predictions_extracted=5
+            )
+        ]
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            check_yield(summaries)
+        assert "Low extraction yield" in caplog.text
+
+    def test_good_yield_no_warning(self, caplog):
+        summaries = [
+            IngestSummary(
+                source_id="s1", transcripts_fetched=10, predictions_extracted=30
+            )
+        ]
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            check_yield(summaries)
+        assert "Low extraction yield" not in caplog.text
+
+    def test_zero_transcripts_no_crash(self):
+        summaries = [IngestSummary(source_id="s1", transcripts_fetched=0)]
+        check_yield(summaries)  # should not raise


### PR DESCRIPTION
## Summary

- **New module** `pipeline/src/youtube_transcript_ingestor.py` — standalone bulk ingestor for NFL prediction-dense YouTube channels
- **11 channels registered** in CHANNEL_REGISTRY: Pat McAfee Show, Bussin' With The Boys, Brett Kollmann, Warren Sharp, Locked On NFL, The Ringer NFL Show, PFF, Move The Sticks, The Athletic Football Show, Rich Eisen Show, Dan Patrick Show
- **8 new channels** added to `media_sources.yaml` Tier 2 expansion
- **Parallelised transcript fetch** via `ThreadPoolExecutor` (≤10 workers) — 10x faster than sequential
- **Title regex filter** selects prediction-dense videos: `predict|bold|will|preview|grade|MVP|playoff|over.under|win total|picks|sleeper|bust|breakout|fantasy|Week \d+`
- **Duration guard** (skip >90 min) and **date guard** (skip pre-2020) for cost control
- **yt-dlp fallback** when `youtube-transcript-api` reports transcripts disabled; warns if >50% disabled
- **`allow_historical` flag** added to `extract_assertions()`, `run_extraction()`, and `--allow-historical` CLI — bypasses the temporal filter that previously dropped all past-season predictions
- `title_filter` in `media_ingestor.fetch_youtube_transcripts` defaults to `False` (backward compat, opt-in per source)

## Projected yield

| Channel | Videos/run | Predictions/transcript | Total |
|---|---|---|---|
| Pat McAfee Show | 20 | 30-50 | 600-1000 |
| Bussin' With The Boys | 15 | 20-40 | 300-600 |
| Brett Kollmann | 10 | 30-50 | 300-500 |
| Warren Sharp | 10 | 40-60 | 400-600 |
| Locked On NFL | 25 | 20-30 | 500-750 |
| Ringer NFL | 15 | 20-40 | 300-600 |
| PFF | 20 | 30-50 | 600-1000 |
| Move The Sticks | 10 | 25-40 | 250-400 |
| **Total** | **125+** | | **3250-5450** |

Combined with PR #319 (historical archive, 420-670 predictions), this should push well past the 1000-prediction milestone.

## How to run

```bash
# Dry run — shows what would be fetched
python -m src.youtube_transcript_ingestor --dry-run

# Full ingest + extraction (writes to BQ)
python -m src.youtube_transcript_ingestor --run-extraction

# Single channel
python -m src.youtube_transcript_ingestor --source pat_mcafee_show --run-extraction --limit 10

# Explicit URLs (targeted backfill)
python -m src.youtube_transcript_ingestor --urls https://youtube.com/watch?v=ABC123 --run-extraction

# List available channels
python -m src.youtube_transcript_ingestor --list-sources
```

## Test plan

- [x] 46 new unit tests in `test_youtube_transcript_ingestor.py` — all pass
- [x] 4 new `allow_historical` tests in `test_assertion_extractor.py` — all pass
- [x] 598 total tests pass (1 pre-existing BQ integration test unrelated to this change)
- [x] Full ruff lint pass (ruff check + format)
- [x] `allow_historical=True` correctly passes 2022 predictions through temporal filter
- [x] `allow_historical=False` (default) still rejects past-season claims
- [x] Title filter correctly selects prediction-dense titles and rejects highlight reels
- [x] yt-dlp fallback tested via mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)