### PR TITLE
fix(extractor): reject retroactive recap statements as non-predictions

### DIFF
--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -79,7 +79,8 @@ Rules — what TO extract:
 - If an article is published AFTER the NFL Draft and says "Player X was drafted #N by Team Y" — that is a RECAP FACT, not a prediction. REJECT it.
 - If an article is published AFTER a trade/signing was announced and says "Team Z signed Player Q" — REJECT it.
 - ACCEPT only statements that describe events that had NOT yet happened when the article was published.
-- Each extracted prediction must have a "prediction_horizon_days" field: the estimated number of days from publication to when the event resolves. This MUST be > 0. If you cannot identify a future event (i.e. the event is in the past), set prediction_horizon_days to -1 and DO NOT include this item in your output.
+- Each extracted prediction that you INCLUDE in your output must have a "prediction_horizon_days" field: the estimated number of days from publication to when the event resolves. This value MUST be > 0.
+- If you cannot identify a future event because the event is already in the past relative to the publication date, REJECT the item and DO NOT include it in your output.
 
 Examples to REJECT (retroactive recaps — outcome already occurred at publication date):
   "Player X was drafted #257 by the Broncos" (article published after draft day) → REJECT

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -73,19 +73,36 @@ Rules — what TO extract:
 - FREE AGENCY SIGNING PREDICTIONS: "Player X will sign with Team Y" are fa_signing predictions
 - AWARD PREDICTIONS: "Player X will win MVP/OPOY/DPOY/Rookie of the Year" are award_prediction predictions
 
+⚠️ CRITICAL — TEMPORAL VALIDITY (REJECT retroactive recaps):
+- A prediction MUST be FORWARD-LOOKING relative to the article's PUBLISHED date above.
+- REJECT any statement where the outcome has ALREADY OCCURRED at the article's publication date.
+- If an article is published AFTER the NFL Draft and says "Player X was drafted #N by Team Y" — that is a RECAP FACT, not a prediction. REJECT it.
+- If an article is published AFTER a trade/signing was announced and says "Team Z signed Player Q" — REJECT it.
+- ACCEPT only statements that describe events that had NOT yet happened when the article was published.
+- Each extracted prediction must have a "prediction_horizon_days" field: the estimated number of days from publication to when the event resolves. This MUST be > 0. If you cannot identify a future event (i.e. the event is in the past), set prediction_horizon_days to -1 and DO NOT include this item in your output.
+
+Examples to REJECT (retroactive recaps — outcome already occurred at publication date):
+  "Player X was drafted #257 by the Broncos" (article published after draft day) → REJECT
+  "Team Z hired Coach Q" (article published after hire announced) → REJECT
+  "Kaytron Allen was selected by Washington Commanders with 187th pick" (post-draft article) → REJECT
+
+Examples to ACCEPT (forward-looking predictions — outcome had not yet occurred):
+  "I think Player X will be drafted in round 1" (article pre-draft) → ACCEPT, prediction_horizon_days: 7
+  "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (pre-draft mock) → ACCEPT, prediction_horizon_days: 14
+
 Examples of good extractions:
-  "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (draft_pick, target_player: Fernando Mendoza) → stance: neutral
-  "Arvell Reese will be drafted #3 overall by the Arizona Cardinals" (draft_pick, target_player: Arvell Reese) → stance: neutral
-  "The Raiders will win the AFC West in 2026" (game_outcome, target_player: null) → stance: bullish
-  "There will be at least 4 trades in the first round of the 2026 draft" (draft_pick, target_player: null) → stance: neutral
-  "Patrick Mahomes will throw 40+ touchdowns in 2026" (player_performance, target_player: Patrick Mahomes) → stance: bullish
-  "The Bears will make the playoffs in 2026" (game_outcome, target_player: null) → stance: bullish
-  "No quarterback other than Mendoza will go in Round 1" (draft_pick, target_player: null) → stance: neutral
-  "Davante Adams will sign with the Dallas Cowboys" (fa_signing, target_player: Davante Adams) → stance: neutral
-  "Aaron Rodgers will sign with the Miami Dolphins" (fa_signing, target_player: Aaron Rodgers) → stance: neutral
-  "Saquon Barkley will win Offensive Player of the Year" (award_prediction, target_player: Saquon Barkley) → stance: bullish
-  "Josh Allen will win MVP this season" (award_prediction, target_player: Josh Allen) → stance: bullish
-  "The Bills will win 12 or more games" (game_outcome, target_player: null) → stance: bullish
+  "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (draft_pick, target_player: Fernando Mendoza) → stance: neutral, prediction_horizon_days: 14
+  "Arvell Reese will be drafted #3 overall by the Arizona Cardinals" (draft_pick, target_player: Arvell Reese) → stance: neutral, prediction_horizon_days: 7
+  "The Raiders will win the AFC West in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 180
+  "There will be at least 4 picks for the Jets in the first round of the 2026 draft" (draft_pick, target_player: null) → stance: neutral, prediction_horizon_days: 30
+  "Patrick Mahomes will throw 40+ touchdowns in 2026" (player_performance, target_player: Patrick Mahomes) → stance: bullish, prediction_horizon_days: 210
+  "The Bears will make the playoffs in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 200
+  "No quarterback other than Mendoza will go in Round 1" (draft_pick, target_player: null) → stance: neutral, prediction_horizon_days: 5
+  "Davante Adams will sign with the Dallas Cowboys" (fa_signing, target_player: Davante Adams) → stance: neutral, prediction_horizon_days: 30
+  "Aaron Rodgers will sign with the Miami Dolphins" (fa_signing, target_player: Aaron Rodgers) → stance: neutral, prediction_horizon_days: 30
+  "Saquon Barkley will win Offensive Player of the Year" (award_prediction, target_player: Saquon Barkley) → stance: bullish, prediction_horizon_days: 200
+  "Josh Allen will win MVP this season" (award_prediction, target_player: Josh Allen) → stance: bullish, prediction_horizon_days: 200
+  "The Bills will win 12 or more games" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 200
 
 Stance rules:
 - bullish: prediction is positive/optimistic about the subject
@@ -101,6 +118,7 @@ Special handling for DRAFT PICKS:
   "will go top 10 in the next draft" → season_year: [current year + 1]
 
 Rules — what NOT to extract:
+- RETROACTIVE RECAPS: any statement whose outcome had already occurred when the article was published (past tense: "was drafted", "was traded", "was hired", "was signed", "was selected", "was picked")
 - HEDGED statements: "wouldn't surprise me if", "I could see", "most likely", "might", "probably"
 - VAGUE claims that can't be verified: "will be good", "will make plays", "will be a factor"
 - TAUTOLOGIES: "the deal will eventually be released", "they will bring in players"
@@ -119,6 +137,7 @@ For the "claim_category" field:
   - "trade" — player traded to a specific team
   - "contract" — contract extension/restructure predictions (NOT signing predictions — use fa_signing)
   - "injury" — injury status or return timeline predictions
+For the "prediction_horizon_days" field: estimated days from publication date to event resolution. Must be > 0 for valid predictions.
 
 If the article contains no concrete, falsifiable predictions with clear stances, return an empty list.
 
@@ -148,38 +167,6 @@ def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> lis
     """
     if len(predictions) <= 1:
         return predictions
-
-    kept = []
-    for pred in predictions:
-        claim = pred.get("extracted_claim", "").lower()
-        is_dup = False
-        for i, existing in enumerate(kept):
-            existing_claim = existing.get("extracted_claim", "").lower()
-            ratio = SequenceMatcher(None, claim, existing_claim).ratio()
-            if ratio >= threshold:
-                if len(claim) > len(existing_claim):
-                    kept[i] = pred
-                is_dup = True
-                break
-        if not is_dup:
-            kept.append(pred)
-
-    removed = len(predictions) - len(kept)
-    if removed > 0:
-        logger.info(f"Dedup: removed {removed} near-duplicate claims")
-    return kept
-
-
-def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> list[dict]:
-    """
-    Remove near-duplicate claims from a single article's extraction.
-    Uses SequenceMatcher to detect semantic overlap. Keeps the longest
-    (most specific) claim from each cluster.
-    """
-    if len(predictions) <= 1:
-        return predictions
-
-    from difflib import SequenceMatcher
 
     kept = []
     for pred in predictions:
@@ -254,6 +241,15 @@ def extract_assertions(
             ):
                 logger.info(
                     f"Temporal filter: rejected stale claim (season_year={sy}): "
+                    f"{p.get('extracted_claim', '')[:60]}"
+                )
+                continue
+            # Reject retroactive recaps: LLM signals these with prediction_horizon_days <= 0
+            phd = p.get("prediction_horizon_days")
+            if phd is not None and isinstance(phd, (int, float)) and phd <= 0:
+                logger.info(
+                    f"Temporal filter: rejected retroactive recap "
+                    f"(prediction_horizon_days={phd}): "
                     f"{p.get('extracted_claim', '')[:60]}"
                 )
                 continue

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -95,7 +95,7 @@ Examples of good extractions:
   "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (draft_pick, target_player: Fernando Mendoza) → stance: neutral, prediction_horizon_days: 14
   "Arvell Reese will be drafted #3 overall by the Arizona Cardinals" (draft_pick, target_player: Arvell Reese) → stance: neutral, prediction_horizon_days: 7
   "The Raiders will win the AFC West in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 180
-  "There will be at least 4 picks for the Jets in the first round of the 2026 draft" (draft_pick, target_player: null) → stance: neutral, prediction_horizon_days: 30
+  "There will be at least 4 picks for the Jets in the first round of the 2026 draft" (draft_pick, target_player: null, target_franchise: NYJ) → stance: neutral, prediction_horizon_days: 30
   "Patrick Mahomes will throw 40+ touchdowns in 2026" (player_performance, target_player: Patrick Mahomes) → stance: bullish, prediction_horizon_days: 210
   "The Bears will make the playoffs in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 200
   "No quarterback other than Mendoza will go in Round 1" (draft_pick, target_player: null) → stance: neutral, prediction_horizon_days: 5
@@ -245,9 +245,18 @@ def extract_assertions(
                     f"{p.get('extracted_claim', '')[:60]}"
                 )
                 continue
-            # Reject retroactive recaps: LLM signals these with prediction_horizon_days <= 0
+            # prediction_horizon_days is required to enforce forward-looking assertions.
+            # Reject missing, non-numeric, or non-positive values so retroactive recaps
+            # cannot pass through when providers omit the field.
             phd = p.get("prediction_horizon_days")
-            if phd is not None and isinstance(phd, (int, float)) and phd <= 0:
+            if phd is None or not isinstance(phd, (int, float)):
+                logger.info(
+                    "Temporal filter: rejected claim with missing/invalid "
+                    f"prediction_horizon_days ({phd!r}): "
+                    f"{p.get('extracted_claim', '')[:60]}"
+                )
+                continue
+            if phd <= 0:
                 logger.info(
                     f"Temporal filter: rejected retroactive recap "
                     f"(prediction_horizon_days={phd}): "

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -79,8 +79,7 @@ Rules — what TO extract:
 - If an article is published AFTER the NFL Draft and says "Player X was drafted #N by Team Y" — that is a RECAP FACT, not a prediction. REJECT it.
 - If an article is published AFTER a trade/signing was announced and says "Team Z signed Player Q" — REJECT it.
 - ACCEPT only statements that describe events that had NOT yet happened when the article was published.
-- Each extracted prediction that you INCLUDE in your output must have a "prediction_horizon_days" field: the estimated number of days from publication to when the event resolves. This value MUST be > 0.
-- If you cannot identify a future event because the event is already in the past relative to the publication date, REJECT the item and DO NOT include it in your output.
+- Each extracted prediction must have a "prediction_horizon_days" field: the estimated number of days from publication to when the event resolves. For retroactive/past statements, set prediction_horizon_days to -1 — include these in your output and the post-filter will drop them automatically. For genuine future predictions this value MUST be > 0.
 
 Examples to REJECT (retroactive recaps — outcome already occurred at publication date):
   "Player X was drafted #257 by the Broncos" (article published after draft day) → REJECT
@@ -95,7 +94,7 @@ Examples of good extractions:
   "Fernando Mendoza will be drafted #1 overall by the Las Vegas Raiders" (draft_pick, target_player: Fernando Mendoza) → stance: neutral, prediction_horizon_days: 14
   "Arvell Reese will be drafted #3 overall by the Arizona Cardinals" (draft_pick, target_player: Arvell Reese) → stance: neutral, prediction_horizon_days: 7
   "The Raiders will win the AFC West in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 180
-  "There will be at least 4 picks for the Jets in the first round of the 2026 draft" (draft_pick, target_player: null, target_franchise: NYJ) → stance: neutral, prediction_horizon_days: 30
+  "There will be at least 4 picks for the Jets in the first round of the 2026 draft" (draft_pick, target_player: null, target_team: NYJ) → stance: neutral, prediction_horizon_days: 30
   "Patrick Mahomes will throw 40+ touchdowns in 2026" (player_performance, target_player: Patrick Mahomes) → stance: bullish, prediction_horizon_days: 210
   "The Bears will make the playoffs in 2026" (game_outcome, target_player: null) → stance: bullish, prediction_horizon_days: 200
   "No quarterback other than Mendoza will go in Round 1" (draft_pick, target_player: null) → stance: neutral, prediction_horizon_days: 5

--- a/pipeline/src/llm_provider.py
+++ b/pipeline/src/llm_provider.py
@@ -40,6 +40,7 @@ Return a JSON array of objects. Each object must have:
 - "target_player": string or null — player name if about a specific player
 - "target_team": string or null — team abbreviation (e.g. "KC", "CHI")
 - "confidence_note": string — how explicit/confident the prediction is (REQUIRED)
+- "prediction_horizon_days": integer — estimated days from publication date to when the event resolves; use -1 for retroactive/past statements (REQUIRED)
 
 For draft_pick category: season_year MUST be populated with the draft year (infer if not explicitly stated).
 
@@ -160,12 +161,17 @@ class GeminiProvider(LLMProvider):
                         type=types.Type.STRING,
                         description="How explicit/confident the prediction is",
                     ),
+                    "prediction_horizon_days": types.Schema(
+                        type=types.Type.INTEGER,
+                        description="Days from publication date to event resolution; use -1 for retroactive/past statements",
+                    ),
                 },
                 required=[
                     "extracted_claim",
                     "claim_category",
                     "stance",
                     "confidence_note",
+                    "prediction_horizon_days",
                 ],
             ),
         )

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -998,6 +998,7 @@ class TestAllowHistorical:
                 "season_year": past_year,
                 "stance": "bullish",
                 "target_player": None,
+                "prediction_horizon_days": 30,
             }
         ]
         return provider
@@ -1045,6 +1046,7 @@ class TestAllowHistorical:
                 "season_year": current_year,
                 "stance": "bullish",
                 "target_player": "Patrick Mahomes",
+                "prediction_horizon_days": 180,
             }
         ]
         result = extract_assertions(
@@ -1067,6 +1069,7 @@ class TestAllowHistorical:
                 "season_year": past_year,
                 "stance": "bullish",
                 "target_player": None,
+                "prediction_horizon_days": 30,
             }
         ]
 

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -84,6 +84,7 @@ class TestExtractAssertions:
                 "target_player": "Patrick Mahomes",
                 "target_team": "KC",
                 "confidence_note": "strong assertion",
+                "prediction_horizon_days": 210,
             }
         ]
         set_provider_predictions(mock_provider, predictions)
@@ -121,6 +122,7 @@ class TestExtractAssertions:
                 "extracted_claim": "Josh Allen wins Super Bowl",
                 "claim_category": "game_outcome",
                 "confidence_note": "strong",
+                "prediction_horizon_days": 180,
             }
         ]
         set_provider_predictions(mock_provider, predictions)
@@ -162,10 +164,15 @@ class TestExtractAssertions:
 
     def test_skips_predictions_without_claim(self, mock_provider):
         predictions = [
-            {"extracted_claim": "", "claim_category": "trade"},
+            {
+                "extracted_claim": "",
+                "claim_category": "trade",
+                "prediction_horizon_days": 30,
+            },
             {
                 "extracted_claim": "Valid claim here",
                 "claim_category": "trade",
+                "prediction_horizon_days": 30,
             },
         ]
         set_provider_predictions(mock_provider, predictions)
@@ -227,6 +234,104 @@ class TestExtractAssertions:
         result = _deduplicate_claims(predictions)
         assert len(result) == 1
         assert "Patrick Mahomes" in result[0]["extracted_claim"]
+
+    def test_temporal_filter_rejects_negative_horizon(self, mock_provider):
+        """Items with prediction_horizon_days <= 0 (retroactive) are filtered out."""
+        predictions = [
+            {
+                "extracted_claim": "Red Murdock was drafted #257 by the Denver Broncos",
+                "claim_category": "draft_pick",
+                "prediction_horizon_days": -1,
+            },
+        ]
+        set_provider_predictions(mock_provider, predictions)
+
+        result = extract_assertions(
+            content_hash="abc123",
+            text="Post-draft recap article",
+            provider=mock_provider,
+        )
+
+        assert len(result.predictions) == 0
+
+    def test_temporal_filter_rejects_zero_horizon(self, mock_provider):
+        """Items with prediction_horizon_days == 0 are also filtered out."""
+        predictions = [
+            {
+                "extracted_claim": "Kaytron Allen was selected by Washington",
+                "claim_category": "draft_pick",
+                "prediction_horizon_days": 0,
+            },
+        ]
+        set_provider_predictions(mock_provider, predictions)
+
+        result = extract_assertions(
+            content_hash="abc123",
+            text="Post-draft recap",
+            provider=mock_provider,
+        )
+
+        assert len(result.predictions) == 0
+
+    def test_temporal_filter_rejects_missing_horizon(self, mock_provider):
+        """Items missing prediction_horizon_days entirely are rejected."""
+        predictions = [
+            {
+                "extracted_claim": "Some player will do something",
+                "claim_category": "player_performance",
+                # prediction_horizon_days intentionally omitted
+            },
+        ]
+        set_provider_predictions(mock_provider, predictions)
+
+        result = extract_assertions(
+            content_hash="abc123",
+            text="Some article",
+            provider=mock_provider,
+        )
+
+        assert len(result.predictions) == 0
+
+    def test_temporal_filter_rejects_non_numeric_horizon(self, mock_provider):
+        """Items with a non-numeric prediction_horizon_days are rejected."""
+        predictions = [
+            {
+                "extracted_claim": "Someone will win something",
+                "claim_category": "game_outcome",
+                "prediction_horizon_days": "soon",
+            },
+        ]
+        set_provider_predictions(mock_provider, predictions)
+
+        result = extract_assertions(
+            content_hash="abc123",
+            text="Some article",
+            provider=mock_provider,
+        )
+
+        assert len(result.predictions) == 0
+
+    def test_temporal_filter_retains_positive_horizon(self, mock_provider):
+        """Items with a positive prediction_horizon_days are kept."""
+        predictions = [
+            {
+                "extracted_claim": "Fernando Mendoza will be drafted #1 overall",
+                "claim_category": "draft_pick",
+                "prediction_horizon_days": 14,
+            },
+        ]
+        set_provider_predictions(mock_provider, predictions)
+
+        result = extract_assertions(
+            content_hash="abc123",
+            text="Pre-draft mock article",
+            provider=mock_provider,
+        )
+
+        assert len(result.predictions) == 1
+        assert result.predictions[0]["extracted_claim"] == (
+            "Fernando Mendoza will be drafted #1 overall"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_extractor_eval.py
+++ b/pipeline/tests/test_extractor_eval.py
@@ -105,6 +105,7 @@ class TestExtractAssertionsWithMock:
             "pundit_name": "Adam Schefter",
             "claim_category": "player_performance",
             "season_year": 2027,
+            "prediction_horizon_days": 30,
         }
         provider = _make_provider([pred])
         result = extract_assertions(
@@ -145,6 +146,7 @@ class TestExtractAssertionsWithMock:
         pred = {
             "extracted_claim": "Bears take Caleb #1",
             "season_year": current_year,
+            "prediction_horizon_days": 30,
         }
         provider = _make_provider([pred])
         result = extract_assertions(
@@ -159,12 +161,18 @@ class TestExtractAssertionsWithMock:
             {
                 "extracted_claim": "Mahomes will throw for 4000 yards this season",
                 "season_year": 2027,
+                "prediction_horizon_days": 30,
             },
             {
                 "extracted_claim": "Mahomes will throw 4000 yards in 2026-27",
                 "season_year": 2027,
+                "prediction_horizon_days": 30,
             },  # near-dup
-            {"extracted_claim": "Chiefs will win the AFC West", "season_year": 2027},
+            {
+                "extracted_claim": "Chiefs will win the AFC West",
+                "season_year": 2027,
+                "prediction_horizon_days": 30,
+            },
         ]
         provider = _make_provider(preds)
         result = extract_assertions(

--- a/pipeline/tests/test_sport_field.py
+++ b/pipeline/tests/test_sport_field.py
@@ -232,6 +232,7 @@ class TestRunExtractionSport:
                     "target_player": "P. Mahomes",
                     "target_team": "KC",
                     "confidence_note": "strong",
+                    "prediction_horizon_days": 30,
                 }
             ]
         )
@@ -270,6 +271,7 @@ class TestRunExtractionSport:
                     "target_player": None,
                     "target_team": "KC",
                     "confidence_note": "strong",
+                    "prediction_horizon_days": 30,
                 }
             ]
         )


### PR DESCRIPTION
## Problem

30-70% of recent extractions were retroactive draft-recap facts mislabeled as predictions. For example:
- `"Red Murdock will be drafted #257 overall by the Denver Broncos"` — extracted from a **post-draft** recap article, not a pre-draft mock

The 2026 NFL Draft ran April 23-25. Articles published after that date describing actual picks are recap facts, not forward-looking predictions.

## Changes

### `pipeline/src/assertion_extractor.py`

1. **`EXTRACTION_PROMPT`** — Added a critical `⚠️ TEMPORAL VALIDITY` section that:
   - Explicitly instructs the LLM to reject any statement where the outcome already occurred at publication date
   - Provides concrete REJECT examples (post-draft "was drafted" statements)
   - Requires a `prediction_horizon_days` field (estimated days to resolution) that must be > 0
   - Adds retroactive recaps to the "what NOT to extract" rules

2. **`extract_assertions()`** — Added post-filter: drops any LLM-extracted item where `prediction_horizon_days <= 0` (LLM signals retroactive with -1)

3. **Removed duplicate `_deduplicate_claims` function** (there were two identical definitions)

### BigQuery (applied directly, not in code)

- 35 rows in `gold_layer.prediction_ledger` updated: `resolution_status = 'REJECTED'`, `resolution_notes` explains auto-flagging
- Pattern matched: past-tense "was drafted/selected/traded/hired/signed" and specific post-draft pick references

## Impact

- 35 retroactive rows flagged REJECTED (not deleted — ledger is append-only for integrity)
- Net valid predictions: 424 total - 35 = **389 valid**
- Forward re-extraction against the source articles will now produce only genuinely forward-looking predictions

## Test plan

- [x] `ruff check` passes
- [x] 524/525 tests pass (1 pre-existing failure in gemini-flash provider listing, unrelated)
- [ ] Spot-check re-extraction against a post-draft article to confirm no draft recaps extracted