### PR TITLE
feat(ops): cost discipline — auto-applied model selection + delta usage log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,3 +155,20 @@ make test-e2e
 - **Recognize when you're spinning wheels.** 2-3 attempts at the same fix without convergence = stop. Summarize and hand back.
 - Diagnose before retrying. Try a *different* approach.
 - Stay on target. No speculative refactoring or gold-plating.
+
+## Model selection — auto-applied, no slash command required
+
+Every Agent/subagent dispatch on this project must pick a model by classifying the task. Do not default by reflex.
+
+| Task class | Model | Examples |
+|---|---|---|
+| **Planning** (architectural, strategic, optimization) | `claude-opus-4-7` | system design, sprint scoping, cost/CI optimization, prompt redesign, validity-logic decisions |
+| **Coding + major follow-ups** | `claude-sonnet-4-6` | feature implementation, multi-file edits, real bug fixes, recurring monitors needing reasoning, substantive code review |
+| **Triage + minor fixes** | `claude-haiku-4-5-20251001` | counts, log tails, PR-list scans, status reports, single-file typo/lint fixes, label changes |
+
+Rules:
+- **Cap concurrent Opus at 1** (parent counts). For fan-out, use Sonnet × N or Haiku × N.
+- **Anchor Haiku prompts** with "answer ONLY from tool output" — it hallucinates without grounding.
+- **When in doubt between two tiers**, pick the cheaper one and upgrade only if output is visibly inadequate.
+
+**Why:** On 2026-04-26 ~$1,895 burned in 2h with Opus = 79% of spend, mostly routine progress checks Sonnet/Haiku could have done at 5–20× lower cost. The user wants Opus reserved for planning where plan quality compounds, Sonnet for coding, Haiku for cheap status work.

--- a/pipeline/scripts/usage_log_append.py
+++ b/pipeline/scripts/usage_log_append.py
@@ -1,0 +1,188 @@
+"""Append a delta row to .claude/usage_log.jsonl without recomputing history.
+
+Issue #329: prior monitors re-summed every transcript on each run, double-counting
+prior sessions and producing a $4k false reading on 2026-04-26 (true ~$1,895).
+
+Algorithm:
+  1. Read the last row of .claude/usage_log.jsonl -> last_cumulative_usd, last_ts.
+  2. Scan ~/.claude/projects/<project>/*.jsonl for assistant turns with ts > last_ts.
+  3. Sum tokens per model over that delta only, multiply by per-M-tok rates.
+  4. new_cumulative = last_cumulative + delta. Append one row.
+
+Usage:
+    python pipeline/scripts/usage_log_append.py
+    python pipeline/scripts/usage_log_append.py --dry-run
+
+Per-M-tok rates (USD), as published 2026-04-26:
+    Opus    in 15  / out 75 / cache_read 1.50 / cache_create 18.75
+    Sonnet  in  3  / out 15 / cache_read 0.30 / cache_create  3.75
+    Haiku   in 0.80/ out  4 / cache_read 0.08 / cache_create  1.00
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+USAGE_LOG = REPO_ROOT / ".claude" / "usage_log.jsonl"
+
+_DEFAULT_TRANSCRIPT_DIR = (
+    Path.home()
+    / ".claude"
+    / "projects"
+    / "-Users-andrewsmith-portfolio-nfl-dead-money"
+)
+TRANSCRIPT_DIR = Path(os.environ.get("CLAUDE_TRANSCRIPT_DIR", str(_DEFAULT_TRANSCRIPT_DIR)))
+
+# Sanity-check thresholds: refuse to append rows that look obviously wrong
+# unless --force is passed. Prevents the kind of $4k false reading from #329.
+MAX_PLAUSIBLE_DELTA_USD = 500.0
+MAX_PLAUSIBLE_CUMULATIVE_MULTIPLIER = 2.0
+
+RATES = {
+    "opus": {"in": 15.0, "out": 75.0, "cache_read": 1.50, "cache_create": 18.75},
+    "sonnet": {"in": 3.0, "out": 15.0, "cache_read": 0.30, "cache_create": 3.75},
+    "haiku": {"in": 0.80, "out": 4.0, "cache_read": 0.08, "cache_create": 1.00},
+}
+
+
+def model_family(model_id: str) -> str | None:
+    m = (model_id or "").lower()
+    if "opus" in m:
+        return "opus"
+    if "sonnet" in m:
+        return "sonnet"
+    if "haiku" in m:
+        return "haiku"
+    return None
+
+
+def load_last_cumulative() -> tuple[float, str | None]:
+    if not USAGE_LOG.exists():
+        return 0.0, None
+    last = None
+    with USAGE_LOG.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                last = line
+    if not last:
+        return 0.0, None
+    row = json.loads(last)
+    return float(row.get("cumulative_usd", 0.0)), row.get("last_ts")
+
+
+def iter_assistant_turns(since_ts: str | None):
+    """Yield (ts, model_family, usage_dict) for assistant turns newer than since_ts."""
+    if not TRANSCRIPT_DIR.exists():
+        return
+    for path in sorted(TRANSCRIPT_DIR.glob("*.jsonl")):
+        try:
+            with path.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        evt = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if evt.get("type") != "assistant":
+                        continue
+                    ts = evt.get("timestamp") or evt.get("ts")
+                    # Skip events whose ts is missing or not a string — comparing
+                    # mixed types (e.g. int epoch vs ISO string) raises TypeError.
+                    if ts is not None and not isinstance(ts, str):
+                        continue
+                    if since_ts and ts and ts <= since_ts:
+                        continue
+                    msg = evt.get("message") or {}
+                    usage = msg.get("usage") or {}
+                    if not usage:
+                        continue
+                    fam = model_family(msg.get("model", ""))
+                    if fam is None:
+                        continue
+                    yield ts, fam, usage
+        except OSError:
+            continue
+
+
+def cost_for(fam: str, usage: dict) -> float:
+    r = RATES[fam]
+    return (
+        usage.get("input_tokens", 0) * r["in"]
+        + usage.get("output_tokens", 0) * r["out"]
+        + usage.get("cache_read_input_tokens", 0) * r["cache_read"]
+        + usage.get("cache_creation_input_tokens", 0) * r["cache_create"]
+    ) / 1_000_000.0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="bypass sanity-check guards on implausibly large delta/cumulative",
+    )
+    args = parser.parse_args()
+
+    last_cumulative, last_ts = load_last_cumulative()
+    by_model = {"opus": 0.0, "sonnet": 0.0, "haiku": 0.0}
+    newest_ts = last_ts
+
+    for ts, fam, usage in iter_assistant_turns(last_ts):
+        by_model[fam] += cost_for(fam, usage)
+        if ts and (newest_ts is None or ts > newest_ts):
+            newest_ts = ts
+
+    delta = sum(by_model.values())
+    new_cumulative = last_cumulative + delta
+
+    row = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "delta_usd": round(delta, 4),
+        "cumulative_usd": round(new_cumulative, 4),
+        "by_model": {k: round(v, 4) for k, v in by_model.items()},
+        "last_ts": newest_ts,
+    }
+
+    print(json.dumps(row, indent=2))
+
+    if args.dry_run:
+        return 0
+
+    if not args.force:
+        if delta > MAX_PLAUSIBLE_DELTA_USD:
+            print(
+                f"ERROR: delta ${delta:.2f} exceeds plausible threshold "
+                f"${MAX_PLAUSIBLE_DELTA_USD:.2f}. Re-run with --force to write anyway.",
+                file=sys.stderr,
+            )
+            return 2
+        if (
+            last_cumulative > 0
+            and new_cumulative > last_cumulative * MAX_PLAUSIBLE_CUMULATIVE_MULTIPLIER
+        ):
+            print(
+                f"ERROR: new cumulative ${new_cumulative:.2f} is more than "
+                f"{MAX_PLAUSIBLE_CUMULATIVE_MULTIPLIER}× prior ${last_cumulative:.2f}. "
+                f"Re-run with --force to write anyway.",
+                file=sys.stderr,
+            )
+            return 2
+
+    USAGE_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with USAGE_LOG.open("a") as fh:
+        fh.write(json.dumps(row) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replaces #331 with a clean diff (2 files instead of 70+). Closes #322. Addresses #326-#329.

## Summary
- **CLAUDE.md**: adds "Model selection — auto-applied" section. Three-tier ladder (Opus=planning, Sonnet=coding, Haiku=triage). Concurrent Opus capped at 1.
- **pipeline/scripts/usage_log_append.py**: appends a delta row to \`.claude/usage_log.jsonl\` from \`last_cumulative + delta\` only. Replaces the prior re-sum monitor that produced a \$4k false reading on 2026-04-26. Includes \`CLAUDE_TRANSCRIPT_DIR\` env override, robust ts comparison, and \`--force\`-gated sanity checks.

## Why a new PR
#331 inherited 3 stale-base commits and bled 60+ submodule pointer changes plus 8 unrelated web/api files into the diff. Every push ran the full CI matrix (including the not-required E2E Docker job that was failing on 60+ irrelevant files). This PR is the same intended scope, off current main.

## Test plan
- [x] \`make lint\` passes
- [x] \`pipeline/.venv/bin/python pipeline/scripts/usage_log_append.py --dry-run\` produces a sane row
- [ ] CI green on required checks (Lint, Data Quality 3.10/3.11, test 3.10, preflight-build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)