### PR TITLE
feat(healing): self-healing pipeline foundation (Healer + circuit breakers + run_daily)

### DIFF
--- a/pipeline/src/healing.py
+++ b/pipeline/src/healing.py
@@ -1,0 +1,294 @@
+"""Self-healing playbook framework.
+
+Wraps pipeline stages with detect → diagnose → remediate. Each playbook
+matches an error signature and applies a specific remediation strategy.
+Outcomes are logged to gold_layer.healing_events; novel breakages are
+filed as GitHub issues.
+
+Usage:
+    from src.healing import Healer, register_default_playbooks
+
+    healer = Healer()
+    register_default_playbooks(healer)
+    outcome = healer.run("media_ingest", lambda: media_ingest_stage())
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+HEALING_EVENTS_TABLE = "healing_events"
+
+HEALING_EVENTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS healing_events (
+  event_id STRING NOT NULL,
+  stage STRING NOT NULL,
+  error_signature STRING,
+  playbook STRING,
+  attempts INT64,
+  outcome STRING NOT NULL,
+  detail STRING,
+  occurred_at TIMESTAMP NOT NULL,
+  run_date DATE NOT NULL
+)
+PARTITION BY run_date
+"""
+
+
+@dataclass
+class HealingOutcome:
+    stage: str
+    outcome: str  # "healed" | "escalated" | "skipped" | "ok"
+    playbook: Optional[str] = None
+    attempts: int = 0
+    error_signature: Optional[str] = None
+    detail: Optional[str] = None
+    result: object = None
+
+
+@dataclass
+class Playbook:
+    """A single remediation strategy."""
+
+    name: str
+    matches: Callable[[BaseException], bool]
+    remediate: Callable[[BaseException, int], bool]
+    max_attempts: int = 3
+    backoff_s: float = 5.0
+
+
+def _signature(exc: BaseException) -> str:
+    """Stable error signature for grouping. Strips line numbers / tokens."""
+    msg = f"{type(exc).__name__}: {exc}"
+    msg = re.sub(r"0x[0-9a-fA-F]+", "0x?", msg)
+    msg = re.sub(r"\b\d{3,}\b", "?", msg)
+    msg = re.sub(r"https?://\S+", "<url>", msg)
+    return msg[:200]
+
+
+class Healer:
+    def __init__(self):
+        self.playbooks: list[Playbook] = []
+        self._novel_signatures: set[str] = set()
+
+    def register(self, pb: Playbook) -> None:
+        self.playbooks.append(pb)
+
+    def run(
+        self,
+        stage: str,
+        fn: Callable[[], object],
+        max_total_attempts: int = 5,
+    ) -> HealingOutcome:
+        attempts = 0
+        last_exc: Optional[BaseException] = None
+        last_pb: Optional[Playbook] = None
+
+        while attempts < max_total_attempts:
+            attempts += 1
+            try:
+                result = fn()
+                if attempts == 1:
+                    return HealingOutcome(stage=stage, outcome="ok", result=result)
+                return HealingOutcome(
+                    stage=stage,
+                    outcome="healed",
+                    playbook=last_pb.name if last_pb else None,
+                    attempts=attempts,
+                    error_signature=_signature(last_exc) if last_exc else None,
+                    result=result,
+                )
+            except BaseException as exc:
+                last_exc = exc
+                pb = next((p for p in self.playbooks if p.matches(exc)), None)
+                if pb is None:
+                    sig = _signature(exc)
+                    logger.error("[%s] no playbook for %s — escalating", stage, sig)
+                    self._maybe_file_novel_issue(stage, sig, exc)
+                    return HealingOutcome(
+                        stage=stage,
+                        outcome="escalated",
+                        attempts=attempts,
+                        error_signature=sig,
+                        detail=str(exc)[:500],
+                    )
+                last_pb = pb
+                if attempts > pb.max_attempts:
+                    return HealingOutcome(
+                        stage=stage,
+                        outcome="escalated",
+                        playbook=pb.name,
+                        attempts=attempts,
+                        error_signature=_signature(exc),
+                        detail=f"playbook {pb.name} exhausted: {exc}"[:500],
+                    )
+                logger.warning(
+                    "[%s] applying playbook %s (attempt %d/%d)",
+                    stage,
+                    pb.name,
+                    attempts,
+                    pb.max_attempts,
+                )
+                healed = False
+                try:
+                    healed = pb.remediate(exc, attempts)
+                except BaseException as rem_exc:
+                    logger.error(
+                        "[%s] playbook %s remediation crashed: %s",
+                        stage,
+                        pb.name,
+                        rem_exc,
+                    )
+                if not healed:
+                    time.sleep(pb.backoff_s * (2 ** (attempts - 1)))
+
+        return HealingOutcome(
+            stage=stage,
+            outcome="escalated",
+            playbook=last_pb.name if last_pb else None,
+            attempts=attempts,
+            error_signature=_signature(last_exc) if last_exc else None,
+            detail=f"max total attempts ({max_total_attempts}) exhausted",
+        )
+
+    def _maybe_file_novel_issue(
+        self, stage: str, signature: str, exc: BaseException
+    ) -> None:
+        if signature in self._novel_signatures:
+            return
+        self._novel_signatures.add(signature)
+        try:
+            title = f"[self-heal] novel breakage in {stage}: {signature[:80]}"
+            body = (
+                f"Self-healing orchestrator encountered an unmapped error.\n\n"
+                f"**Stage:** `{stage}`\n"
+                f"**Signature:** `{signature}`\n"
+                f"**Error:** ```\n{exc}\n```\n\n"
+                f"_Auto-filed by `pipeline/src/healing.py`. "
+                f"Add a playbook to remediate, or close if not actionable._"
+            )
+            subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--title",
+                    title,
+                    "--body",
+                    body,
+                    "--label",
+                    "self-heal,bug",
+                ],
+                check=False,
+                capture_output=True,
+                timeout=15,
+            )
+        except Exception as e:
+            logger.warning("failed to file novel-breakage issue: %s", e)
+
+
+def persist_outcome(db, outcome: HealingOutcome) -> None:
+    """Append a healing event row to gold_layer.healing_events."""
+    if outcome.outcome == "ok":
+        return
+    import pandas as pd
+
+    now = datetime.now(timezone.utc)
+    df = pd.DataFrame(
+        [
+            {
+                "event_id": uuid.uuid4().hex,
+                "stage": outcome.stage,
+                "error_signature": outcome.error_signature,
+                "playbook": outcome.playbook,
+                "attempts": outcome.attempts,
+                "outcome": outcome.outcome,
+                "detail": outcome.detail,
+                "occurred_at": now,
+                "run_date": now.date(),
+            }
+        ]
+    )
+    try:
+        db.append_dataframe_to_table(df, HEALING_EVENTS_TABLE)
+    except Exception as e:
+        logger.warning("failed to persist healing event: %s", e)
+
+
+def ensure_healing_table(db) -> None:
+    if not db.table_exists(HEALING_EVENTS_TABLE):
+        db.execute(HEALING_EVENTS_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# Default playbooks
+# ---------------------------------------------------------------------------
+
+
+def _is_transient_http(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return any(
+        s in msg
+        for s in (
+            "503",
+            "502",
+            "504",
+            "429",
+            "timeout",
+            "timed out",
+            "connection reset",
+        )
+    )
+
+
+def _is_llm_rate_limit(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return ("rate" in msg and "limit" in msg) or "429" in msg or "quota" in msg
+
+
+def _is_json_parse(exc: BaseException) -> bool:
+    name = type(exc).__name__
+    return name in ("JSONDecodeError", "ValidationError") or "json" in str(exc).lower()
+
+
+def register_default_playbooks(healer: Healer) -> None:
+    """Register the baseline set of playbooks. Extend per-stage as needed."""
+
+    healer.register(
+        Playbook(
+            name="transient_http_retry",
+            matches=_is_transient_http,
+            remediate=lambda exc, n: False,  # backoff-only
+            max_attempts=4,
+            backoff_s=10.0,
+        )
+    )
+
+    healer.register(
+        Playbook(
+            name="llm_rate_limit_backoff",
+            matches=_is_llm_rate_limit,
+            remediate=lambda exc, n: False,
+            max_attempts=5,
+            backoff_s=30.0,
+        )
+    )
+
+    healer.register(
+        Playbook(
+            name="json_parse_strict_retry",
+            matches=_is_json_parse,
+            remediate=lambda exc, n: False,
+            max_attempts=2,
+            backoff_s=2.0,
+        )
+    )

--- a/pipeline/tests/test_healing.py
+++ b/pipeline/tests/test_healing.py
@@ -1,0 +1,178 @@
+"""Tests for src.healing — playbook framework."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.healing import (
+    Healer,
+    Playbook,
+    _signature,
+    register_default_playbooks,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    import src.healing as H
+
+    monkeypatch.setattr(H.time, "sleep", lambda *_: None)
+
+
+@pytest.fixture(autouse=True)
+def _no_gh(monkeypatch):
+    """Don't actually shell out to gh during tests."""
+    import src.healing as H
+
+    monkeypatch.setattr(H.subprocess, "run", lambda *a, **k: None)
+
+
+def _healer():
+    h = Healer()
+    register_default_playbooks(h)
+    return h
+
+
+def test_ok_path_no_retry():
+    out = _healer().run("stage", lambda: 42)
+    assert out.outcome == "ok"
+    assert out.result == 42
+    assert out.attempts == 0
+
+
+def test_heals_after_transient_503():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("HTTP 503 from upstream")
+        return "recovered"
+
+    out = _healer().run("stage", flaky)
+    assert out.outcome == "healed"
+    assert out.result == "recovered"
+    assert out.playbook == "transient_http_retry"
+
+
+def test_novel_error_escalates():
+    def bomb():
+        raise KeyError("never-seen-this")
+
+    out = _healer().run("stage", bomb)
+    assert out.outcome == "escalated"
+    assert out.playbook is None
+    assert "KeyError" in out.error_signature
+
+
+def test_signature_normalizes_addresses_and_numbers():
+    sig1 = _signature(RuntimeError("failed at 0xdeadbeef row 12345"))
+    sig2 = _signature(RuntimeError("failed at 0xcafebabe row 67890"))
+    assert sig1 == sig2
+
+
+def test_signature_normalizes_urls():
+    sig1 = _signature(RuntimeError("fetch failed for https://a.example/x"))
+    sig2 = _signature(RuntimeError("fetch failed for https://b.example/y"))
+    assert sig1 == sig2
+
+
+def test_playbook_exhaustion_escalates():
+    h = Healer()
+    h.register(
+        Playbook(
+            name="always_fail",
+            matches=lambda exc: True,
+            remediate=lambda exc, n: False,
+            max_attempts=2,
+            backoff_s=0.0,
+        )
+    )
+
+    def always():
+        raise RuntimeError("nope")
+
+    out = h.run("stage", always, max_total_attempts=10)
+    assert out.outcome == "escalated"
+    assert out.playbook == "always_fail"
+    assert out.attempts == 3  # max_attempts=2 means we try twice, then escalate
+
+
+def test_remediate_returns_true_skips_backoff():
+    """If remediate returns True (already fixed), the next attempt should still try."""
+    state = {"healed": False}
+
+    def remediate(exc, n):
+        state["healed"] = True
+        return True
+
+    pb = Playbook(
+        name="self_fix",
+        matches=lambda exc: True,
+        remediate=remediate,
+        max_attempts=3,
+        backoff_s=0.0,
+    )
+    h = Healer()
+    h.register(pb)
+
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise RuntimeError("fix me")
+        return "ok"
+
+    out = h.run("stage", fn)
+    assert out.outcome == "healed"
+    assert state["healed"] is True
+
+
+def test_first_matching_playbook_wins():
+    """Playbooks are matched in registration order."""
+    h = Healer()
+    fired = []
+    h.register(
+        Playbook(
+            name="first",
+            matches=lambda exc: True,
+            remediate=lambda exc, n: fired.append("first") or False,
+            max_attempts=1,
+            backoff_s=0.0,
+        )
+    )
+    h.register(
+        Playbook(
+            name="second",
+            matches=lambda exc: True,
+            remediate=lambda exc, n: fired.append("second") or False,
+            max_attempts=1,
+            backoff_s=0.0,
+        )
+    )
+
+    def bomb():
+        raise RuntimeError("x")
+
+    h.run("stage", bomb)
+    assert fired == ["first"]
+
+
+def test_novel_signature_filed_only_once():
+    h = Healer()
+    filed = []
+
+    import src.healing as H
+
+    def fake_run(*a, **k):
+        filed.append(a[0])
+
+    H.subprocess.run = fake_run  # type: ignore[assignment]
+
+    def bomb():
+        raise KeyError("same-novel")
+
+    h.run("stage", bomb)
+    h.run("stage", bomb)
+    assert len(filed) == 1


### PR DESCRIPTION
## Summary
First slice of the self-healing daily pipeline. Three pieces:

1. **\`src.healing\`** — \`Healer\` wraps any callable, matches errors to playbooks, retries with exponential backoff, escalates novel breakages by auto-filing GitHub issues. Three default playbooks: transient HTTP (5xx/timeout), LLM rate-limit, JSON parse. \`gold_layer.healing_events\` table for outcome tracking.

2. **\`src.source_health\`** — \`CircuitBreakerRegistry\` tracks each RSS feed/YouTube channel/Wayback host through \`CLOSED → OPEN → HALF_OPEN\` states. Sources opening after 3 consecutive failures are skipped for 60min, then probed once. State persists to \`gold_layer.source_health\` across runs. **Fixes the obvious leak from today's run** (96/96 YT, 140/140 Wayback failures with no backoff).

3. **\`run_daily.py --self-heal\`** — wires the Healer into the existing orchestrator. Each stage runs through the playbook framework when the flag is set; default behavior unchanged.

## Why
User ask: "self healing meaning breakages of all kinds need to be tended to." This is the foundation; the playbook + circuit-breaker substrate that lets follow-ups plug in:
- LLM-fallback playbook (Pro → Flash → Haiku on schema fail)
- Drift detector (alarm on \`target_player_name\` fill-rate <50% — currently 0/788)
- Per-pundit health (auto-quarantine dead accounts)
- Auto-issue-filer for unmapped errors (already in Healer)

## Test plan
- [x] \`pytest pipeline/tests/test_healing.py\` — 9/9
- [x] \`pytest pipeline/tests/test_source_health.py\` — 9/9
- [x] \`pytest pipeline/tests/test_run_daily_healing.py\` — 3/3
- [ ] Live integration once CI green and a follow-up wires the BigQuery persist paths into a real \`run_daily\` invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)