### PR TITLE
chore(skills): persist PR-landing + self-healing protocol as skills/commands

### DIFF
--- a/.claude/commands/audit-prs.md
+++ b/.claude/commands/audit-prs.md
@@ -1,0 +1,52 @@
+---
+description: Audit every open PR for unresolved review threads before reporting status
+---
+
+# /audit-prs
+
+Before ever telling the user a PR is "blocked" or "waiting," prove every reviewer
+thread is resolved across the open backlog. Reporting `mergeStateStatus=BLOCKED`
+without a thread audit shifts triage onto the user — that's the rule.
+
+## Procedure
+
+1. **List open PRs**
+   ```bash
+   gh pr list --state open --limit 50 --json number,title,reviewDecision,mergeStateStatus
+   ```
+
+2. **For each PR, count unresolved threads** via GraphQL (REST `/comments` does
+   not expose thread resolution state):
+   ```bash
+   for n in <numbers>; do
+     gh api graphql -f query="query { repository(owner: \"cap-alpha\", name: \"cap-alpha-protocol\") { pullRequest(number: $n) { reviewThreads(first: 100) { nodes { isResolved } } reviewDecision mergeStateStatus } } }" \
+       --jq '"PR #'$n': \(.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length) unresolved | review=\(.data.repository.pullRequest.reviewDecision // "none") | merge=\(.data.repository.pullRequest.mergeStateStatus)"'
+   done
+   ```
+
+3. **Triage non-zero counts**
+   - For each PR with `>0` unresolved: pull the actual thread bodies and IDs:
+     ```bash
+     gh api graphql -f query='query { repository(owner: "cap-alpha", name: "cap-alpha-protocol") { pullRequest(number: <N>) { reviewThreads(first: 100) { nodes { id isResolved path line comments(first: 1) { nodes { body author { login } } } } } } } }' \
+       --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))'
+     ```
+   - Dispatch a Sonnet subagent per PR with: branch, worktree path, the thread
+     ID list, and the comment bodies. The subagent fixes, pushes, and resolves
+     each thread via the GraphQL mutation in `pr-comments` skill.
+
+4. **Verify clean state**
+   - Re-run step 2. Confirm `0 unresolved` for every PR before any "blocked" status update.
+   - `BLOCKED` is fine to report only when threads are clean — that means the
+     blocker is genuinely CI / approval / merge-queue, not pending review work.
+
+## Anti-pattern
+
+- ❌ Reporting "PR #N is blocked" while comments sit unaddressed.
+- ❌ Using `gh pr view --json reviews` alone — that returns review *summaries*, not thread resolution state.
+- ❌ Trusting `gh pr view --json comments` — those are issue comments, not review threads.
+
+## Exit criteria
+
+A status update is allowed once: every open PR shows `0 unresolved`, and the
+remaining `BLOCKED`/`UNKNOWN` states are due to CI, approval, or merge queue —
+which the user can see at a glance.

--- a/.claude/commands/land-prs.md
+++ b/.claude/commands/land-prs.md
@@ -1,0 +1,65 @@
+---
+description: End-to-end landing flow for the open PR backlog — audit, fix, resolve, queue, verify
+---
+
+# /land-prs
+
+Drive every open PR to merged or to a clean blocker the user can see at a
+glance. Composes `/audit-prs` (thread sweep) with the per-PR fix-and-resolve
+loop. Run autonomously — no permission needed for diagnostic commands.
+
+## Procedure
+
+1. **Audit** — run `/audit-prs` to get the unresolved-thread map.
+
+2. **Fix in parallel** — for each PR with unresolved threads, dispatch a
+   Sonnet subagent (fan out — they're independent). Each subagent must:
+   - Work in the PR's existing worktree (find via `git worktree list` or
+     create one off the PR branch with `git worktree add`)
+   - Apply the requested fix per thread; add tests where the comment asks
+   - Run `make lint` (or `ruff format` + `ruff check`) and the relevant
+     pytest subset until green
+   - Commit with a message that names each thread it addresses
+   - `git push`
+   - Resolve each thread via the GraphQL mutation in the `pr-comments` skill
+   - Confirm `gh pr merge <n> --rebase --auto` is queued
+   - Never approve a PR — only the user does that
+
+3. **Cherry-pick stale-base bleeds** — if a PR rebase fails on commits that
+   already landed on main as different SHAs (the "stale-base bleed"), recover
+   it cleanly:
+   ```bash
+   git fetch origin main
+   git reset --hard origin/main
+   git cherry-pick <unique-commit-sha>
+   git push --force-with-lease
+   ```
+   Only do this for the unique commits in the branch — never reset away work.
+
+4. **Re-audit** — run `/audit-prs` again. Every PR must show `0 unresolved`.
+   Only after this is the loop allowed to report status.
+
+5. **Watch CI** — for PRs queued via `--rebase --auto`, the merge queue
+   handles the rest. If a PR shows `mergeStateStatus=DIRTY`, that's a
+   genuine merge conflict — re-dispatch a subagent to rebase it.
+
+## What to never do
+
+- Squash. Always `--rebase --auto` per `feedback_rebase_only.md`.
+- Direct merge. Always go through the merge queue per CLAUDE.md.
+- Force-push to `main`. Force-push only with `--force-with-lease` on feature branches.
+- Approve the user's own PRs as themselves. The user approves; we queue.
+- Report "blocked" before the audit is clean. See `feedback_never_report_blocked_with_unresolved_comments.md`.
+
+## Output format
+
+When the loop terminates, surface a tight table:
+
+```
+PR  | title (≤60 chars)              | unresolved | review     | merge
+----+--------------------------------+------------+------------+--------
+336 | fix(pipeline): ...             | 0          | APPROVED   | CLEAN
+324 | feat(sources): ...             | 0          | none       | BLOCKED (CI)
+```
+
+Plus one line per still-open thread (none if clean). Nothing else.

--- a/.claude/skills/pr-comments.md
+++ b/.claude/skills/pr-comments.md
@@ -1,0 +1,86 @@
+---
+description: Protocol for resolving Copilot/reviewer threads on a PR — fetch, fix, resolve via GraphQL
+---
+
+# PR review-thread resolution skill
+
+Reviewer threads (especially Copilot) come back as a JSON list with stable IDs.
+The merge queue's `required_review_thread_resolution` rule blocks landing
+until every thread is `isResolved: true`. This skill is the canonical recipe.
+
+## Step 1 — Pull only the unresolved threads
+
+```bash
+gh api graphql -f query='query { repository(owner: "cap-alpha", name: "cap-alpha-protocol") { pullRequest(number: <N>) { reviewThreads(first: 100) { nodes { id isResolved path line comments(first: 1) { nodes { body author { login } } } } } } } }' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | .[] | {id, path, line, body: .comments.nodes[0].body[0:400]}'
+```
+
+REST endpoints (`/pulls/<n>/comments`) **do not expose `isResolved`** — they
+will return resolved threads too, wasting subagent attention. Always use the
+GraphQL `reviewThreads` query.
+
+## Step 2 — Fix in the PR's worktree
+
+- Find or create a worktree on the PR branch:
+  ```bash
+  gh pr view <N> --json headRefName -q .headRefName
+  git worktree list | grep <branch>     # or: git worktree add .claude/worktrees/<name> -b <branch> origin/<branch>
+  ```
+- Apply the requested change. When a Copilot comment includes a code suggestion
+  block, prefer that exact text unless it conflicts with another thread.
+- For each comment that asks for a test, **write the test** — Copilot is
+  consistently right that test gaps need filling.
+- `make check` (or the equivalent ruff format/check + pytest subset).
+- Commit with a message that names each thread you addressed.
+- `git push`.
+
+## Step 3 — Resolve threads via GraphQL
+
+```bash
+gh api graphql -f query='mutation($id: ID!) { resolveReviewThread(input: {threadId: $id}) { thread { id isResolved } } }' -f id="<THREAD_ID>"
+```
+
+For bulk resolution after a sweep:
+
+```bash
+gh api graphql -f query='query { repository(owner: "cap-alpha", name: "cap-alpha-protocol") { pullRequest(number: <N>) { reviewThreads(first: 100) { nodes { id isResolved } } } } }' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | .[].id' \
+  | while read tid; do
+      gh api graphql -f query='mutation($id: ID!) { resolveReviewThread(input: {threadId: $id}) { thread { isResolved } } }' -f id="$tid"
+    done
+```
+
+## Step 4 — Confirm and queue
+
+- Re-query unresolved count. It must be `0`.
+- Confirm auto-merge: `gh pr merge <N> --rebase --auto` (rebase only — never
+  squash, per `feedback_rebase_only.md`).
+- Never `gh pr review --approve` your own work; the user approves.
+
+## When to dispatch a subagent vs do it inline
+
+- **>2 threads, or threads spanning >1 file**: dispatch a Sonnet subagent with
+  the worktree path, the thread ID list, and each comment body. Resolve threads
+  in the subagent prompt — don't make a second turn for it.
+- **1 trivial thread (typo, unused import)**: just fix it inline.
+- **A thread asking a product question**: surface to the user, do not guess.
+
+## Heuristics on what Copilot is usually right about
+
+- Schema/contract drift — when a new field is filtered on but never emitted
+  by the provider schema, Copilot catches that almost every time.
+- Test gaps — if Copilot asks for a test, write the test. Don't argue.
+- Hardcoded project IDs / dataset names — convert to `{project_id}` placeholder
+  to match other scripts in `pipeline/scripts/`.
+
+## Heuristics on what Copilot is sometimes wrong about
+
+- "Consider extracting a shared helper" — only do this if the duplication is
+  both real and load-bearing. Two short functions ≠ premature abstraction.
+- "This could grow expensive" — usually fine to defer with a TODO unless the
+  table is already known to be large.
+- "Update PR description" — do it if the description is genuinely misleading
+  about scope, but don't rewrite it just because Copilot asked.
+
+When you decide a Copilot suggestion is wrong, **resolve the thread anyway**
+with a one-line reply via `gh pr comment` explaining why. Don't leave it open.

--- a/.claude/skills/self-healing-pipeline.md
+++ b/.claude/skills/self-healing-pipeline.md
@@ -1,0 +1,104 @@
+---
+description: Architecture and conventions for the self-healing daily pipeline (Healer + circuit breakers + drift)
+---
+
+# Self-healing pipeline skill
+
+Reference for any work that touches the daily ingest → extract → resolve loop.
+The goal is "breakages of all kinds get tended to" — auto-detect, auto-remediate
+where the playbook is known, escalate cleanly when novel.
+
+## Building blocks (already in `pipeline/src/`)
+
+| Module | Role |
+|---|---|
+| `healing.py` | `Healer` wraps any callable; matches errors to playbooks; retries with exponential backoff; auto-files GitHub issues for novel signatures |
+| `source_health.py` | `CircuitBreakerRegistry` — per-source CLOSED → OPEN → HALF_OPEN; persists to `gold_layer.source_health`; opens after 3 consecutive failures, cools for 60min |
+| `pipeline_telemetry.py` | `PipelineRun` — per-stage timing/counts; persists to `gold_layer.pipeline_runs` |
+| `run_daily.py` | Orchestrator. `--self-heal` flag wraps each stage in `Healer` |
+
+## When to add a new playbook
+
+A new playbook goes into `register_default_playbooks()` (or a sibling
+registrar) when **all three** are true:
+
+1. The error has a stable signature you can match on (status code, exception
+   class, message substring).
+2. The remediation is mechanical — backoff, fallback model, refresh token,
+   re-fetch from a different source. Anything requiring human judgment
+   stays out of the playbook.
+3. The breakage has happened ≥2 times. Don't pre-build playbooks for
+   hypothetical errors.
+
+Skeleton:
+
+```python
+healer.register(
+    Playbook(
+        name="<short_descriptive_name>",
+        matches=lambda exc: <bool>,
+        remediate=lambda exc, attempt_n: <bool>,  # True = already fixed, False = backoff and retry
+        max_attempts=<3-5>,
+        backoff_s=<10-30>,
+    )
+)
+```
+
+`remediate` returning `True` means "I've fixed the underlying state; please
+retry without sleeping." Returning `False` means "no state change; sleep and
+retry." Most playbooks return `False` — only fancy ones (token refresh,
+provider failover) return `True`.
+
+## When to add a new circuit breaker
+
+Any external resource that's been seen to fail in production. Wire it like:
+
+```python
+cb = CircuitBreakerRegistry.load_from_bigquery(db)
+for source in sources:
+    if cb.is_open(source.id):
+        continue
+    try:
+        result = fetch(source)
+        cb.record_success(source.id, source.kind)
+    except Exception as e:
+        cb.record_failure(source.id, str(e), source.kind)
+cb.persist(db)
+```
+
+Don't open the breaker on individual *items* (a single video that 403s) —
+breakers are per-*source* (the channel). One bad item shouldn't take down a
+whole feed; one bad feed should be skipped for an hour.
+
+## What still needs building (next-up)
+
+- LLM-fallback playbook: Gemini Pro → Flash → Haiku on rate limit / schema
+  validation failure. Pairs with provider abstraction in `llm_provider.py`.
+- Drift detector: alarm if `target_player_name` fill-rate drops below 50%
+  over a rolling window (today the structured-field fill-rate is the
+  smoking gun on extraction quality).
+- Per-pundit health: same circuit-breaker pattern, source-id keyed by
+  pundit. Auto-quarantines dead accounts after 3 consecutive empty fetches.
+- Auto-issue closer: if `healing_events` shows the same novel signature has
+  not recurred in 7 days, auto-close the filed issue.
+
+## Anti-patterns
+
+- ❌ Wrapping the whole pipeline in one big `try/except` — that loses the
+  per-stage signature the Healer needs.
+- ❌ Catching `BaseException` and re-raising in a way that strips the type —
+  `_signature()` keys on `type(exc).__name__`.
+- ❌ Running `--self-heal` against a stage that's *known* broken (e.g., a
+  config typo). The Healer will retry-and-escalate, wasting credits. Fix the
+  config first, run with `--self-heal` once it's stable.
+- ❌ Persisting `source_health` rows without first calling `is_open()` on
+  every probe — the HALF_OPEN transition only happens via `is_open()`.
+
+## Cost discipline
+
+- Default fallback delays are 10s / 30s. Don't drop below 5s without a
+  measured reason; thrashing on transient 5xx burns rate-limit budget faster
+  than it saves time.
+- Novel-issue filer is rate-limited by signature: same signature files at
+  most one issue per process. If you reload state across runs, dedupe on the
+  signature column in `healing_events` before filing.


### PR DESCRIPTION
## Summary
Promotes four pieces of operational knowledge from memory/conversation into checked-in skills + commands so other agents (and future sessions) inherit them automatically.

- \`.claude/commands/audit-prs.md\` — must-run-before-status thread audit. Direct response to user feedback: never report \"blocked\" while comments sit unaddressed.
- \`.claude/commands/land-prs.md\` — full backlog landing flow (audit → parallel fix → resolve → queue → re-audit). Includes stale-base cherry-pick recipe.
- \`.claude/skills/pr-comments.md\` — canonical GraphQL recipe for unresolved thread sweep + bulk \`resolveReviewThread\` mutation; heuristics on when to trust vs push back on Copilot.
- \`.claude/skills/self-healing-pipeline.md\` — architecture reference for \`healing.py\` / \`source_health.py\` / \`run_daily.py --self-heal\`; when to add a playbook, where breakers go, what's still to build.

## Why
Memory entries are session-scoped. Skills/commands are repo-scoped — every agent on this codebase reads them.

## Test plan
- [x] No code changes — docs only
- [ ] Verify other agents pick up \`/audit-prs\` and \`/land-prs\` on their next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)