### PR TITLE
feat(api): wire API key auth + /v1/me endpoint for public launch

### DIFF
--- a/pipeline/api/api_key_auth.py
+++ b/pipeline/api/api_key_auth.py
@@ -1,0 +1,130 @@
+"""
+API Key Authentication — FastAPI dependency for /v1/* routes.
+
+Schema (monetization.api_keys):
+  key_id         STRING  — primary key, prefix "capk_"
+  key_hash       STRING  — SHA-256(pepper || raw_key)
+  key_last_four  STRING  — last 4 chars of the raw key
+  user_id        STRING  — Clerk user id
+  tier           STRING  — free | pro | api_starter | api_growth | enterprise
+  scopes         REPEATED STRING (nullable)
+  status         STRING  — active | revoked
+  created_at     TIMESTAMP
+  revoked_at     TIMESTAMP (nullable)
+  last_used_at   TIMESTAMP (nullable)
+  last_used_ip   STRING (nullable)
+  name           STRING  — user-supplied label
+
+Hashing: SHA-256(pepper || raw_key).  Pepper from env var API_KEY_PEPPER.
+"""
+
+import hashlib
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import Depends, Header, HTTPException
+from google.cloud.bigquery import QueryJobConfig, ScalarQueryParameter
+
+from src.db_manager import DBManager
+
+logger = logging.getLogger(__name__)
+
+# Table reference helper — project injected at query time via db.project_id
+_API_KEYS_TABLE = "monetization.api_keys"
+
+
+def _full_table(project_id: str) -> str:
+    return f"`{project_id}.{_API_KEYS_TABLE}`"
+
+
+def _hash_key(raw_key: str) -> str:
+    """SHA-256(pepper || raw_key).  Pepper falls back to empty string when unset."""
+    pepper = os.environ.get("API_KEY_PEPPER", "")
+    return hashlib.sha256((pepper + raw_key).encode()).hexdigest()
+
+
+def get_db_for_auth() -> DBManager:
+    """Dependency-injected DBManager for auth path (separate from per-request get_db)."""
+    db = DBManager()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def verify_api_key(
+    x_api_key: str = Header(..., description="API key in the form capk_live_..."),
+    db: DBManager = Depends(get_db_for_auth),
+) -> Dict[str, Any]:
+    """
+    FastAPI dependency that validates an X-API-Key header against BigQuery.
+
+    Returns the key row dict on success.
+    Raises HTTP 401 when key is missing/invalid, HTTP 403 when revoked/expired.
+    """
+    if not x_api_key:
+        raise HTTPException(status_code=401, detail="Missing X-API-Key header")
+
+    key_hash = _hash_key(x_api_key)
+
+    sql = f"""
+        SELECT
+            key_id,
+            user_id,
+            tier,
+            status,
+            scopes,
+            name,
+            created_at,
+            revoked_at,
+            last_used_at,
+            key_last_four
+        FROM {_full_table(db.project_id)}
+        WHERE key_hash = @key_hash
+        LIMIT 1
+    """
+    try:
+        job_config = QueryJobConfig(
+            query_parameters=[ScalarQueryParameter("key_hash", "STRING", key_hash)]
+        )
+        job = db.client.query(sql, job_config=job_config)
+        rows = list(job.result())
+    except Exception as e:
+        logger.error(f"API key lookup failed: {e}")
+        raise HTTPException(status_code=500, detail="Auth service unavailable")
+
+    if not rows:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    # BigQuery Row supports .items(); plain dicts also have .items() — both work.
+    raw = rows[0]
+    row = dict(raw.items()) if hasattr(raw, "items") else dict(raw)
+
+    if row.get("status") != "active":
+        raise HTTPException(status_code=403, detail="API key has been revoked")
+
+    # Best-effort last_used_at update — fire-and-forget, don't block the request
+    try:
+        import datetime
+
+        update_sql = f"""
+            UPDATE {_full_table(db.project_id)}
+            SET last_used_at = @now
+            WHERE key_hash = @key_hash
+        """
+        update_config = QueryJobConfig(
+            query_parameters=[
+                ScalarQueryParameter(
+                    "now",
+                    "TIMESTAMP",
+                    datetime.datetime.utcnow().isoformat() + "Z",
+                ),
+                ScalarQueryParameter("key_hash", "STRING", key_hash),
+            ]
+        )
+        db.client.query(update_sql, job_config=update_config)
+    except Exception as update_err:
+        logger.warning(f"Failed to update last_used_at: {update_err}")
+
+    return row

--- a/pipeline/api/pundit_router.py
+++ b/pipeline/api/pundit_router.py
@@ -2,6 +2,7 @@
 Pundit Scorecard API — Public REST Endpoints (Issue #113, #198, #201)
 
 Endpoints:
+  GET /v1/me                                — Authenticated key info (tier, rate limits)
   GET /v1/pundits/                          — List all tracked pundits with summary scores
   GET /v1/pundits/{pundit_id}               — Pundit detail with accuracy breakdown by category
   GET /v1/pundits/{pundit_id}/predictions   — Paginated prediction history with resolution status
@@ -11,6 +12,9 @@ Endpoints:
   GET /v1/draft/{year}/results              — Draft resolution scoreboard for a given year
   GET /v1/leaderboard                       — Ranked pundits by weighted score / accuracy
   GET /v1/integrity/verify                  — Hash chain integrity check (tamper detection)
+
+All /v1/* routes require a valid X-API-Key header (except /v1/me which also requires it,
+but returns the key's own metadata).
 """
 
 import logging
@@ -21,13 +25,27 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from google.cloud.bigquery import DatasetReference, QueryJobConfig, ScalarQueryParameter
 
+from api.api_key_auth import verify_api_key
 from src.cryptographic_ledger import verify_chain_integrity
 from src.db_manager import DBManager
 from src.resolution_engine import get_pundit_accuracy_summary
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/v1", tags=["pundit-ledger"])
+# Rate limits by tier (requests per minute)
+TIER_RATE_LIMITS: Dict[str, int] = {
+    "free": 10,
+    "pro": 60,
+    "api_starter": 120,
+    "api_growth": 300,
+    "enterprise": 1000,
+}
+
+router = APIRouter(
+    prefix="/v1",
+    tags=["pundit-ledger"],
+    dependencies=[Depends(verify_api_key)],
+)
 
 LEDGER_TABLE = "gold_layer.prediction_ledger"
 RESOLUTIONS_TABLE = "gold_layer.prediction_resolutions"
@@ -56,6 +74,35 @@ def _parameterized_query(db: DBManager, sql: str, params: List[ScalarQueryParame
     )
     job = db.client.query(sql, job_config=job_config)
     return job.to_dataframe()
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/me — authenticated key metadata
+# ---------------------------------------------------------------------------
+
+
+@router.get("/me", summary="Authenticated API key info")
+def me(
+    key_info: Dict[str, Any] = Depends(verify_api_key),
+) -> Dict[str, Any]:
+    """
+    Returns the tier, rate limit, scopes, and last-used info for the
+    authenticated API key.  Useful for SDK clients to surface quota info.
+    """
+    tier = key_info.get("tier", "free")
+    rate_limit = TIER_RATE_LIMITS.get(tier, TIER_RATE_LIMITS["free"])
+    return {
+        "key_id": key_info.get("key_id"),
+        "name": key_info.get("name"),
+        "user_id": key_info.get("user_id"),
+        "tier": tier,
+        "status": key_info.get("status"),
+        "scopes": key_info.get("scopes") or [],
+        "rate_limit_per_minute": rate_limit,
+        "created_at": str(key_info.get("created_at")) if key_info.get("created_at") else None,
+        "last_used_at": str(key_info.get("last_used_at")) if key_info.get("last_used_at") else None,
+        "key_last_four": key_info.get("key_last_four"),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_api_key_auth.py
+++ b/pipeline/tests/test_api_key_auth.py
@@ -1,0 +1,186 @@
+"""
+Tests for API key authentication middleware (api/api_key_auth.py).
+Uses FastAPI TestClient with mocked DBManager and BigQuery client.
+No BigQuery connection required.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Patch DB initialisation before importing the app
+with patch("src.db_manager.DBManager._initialize_connection"):
+    from api.main import app
+    from api.api_key_auth import _hash_key, verify_api_key, get_db_for_auth
+    from api.pundit_router import get_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bq_row(
+    key_id="capk_live_test",
+    user_id="user_123",
+    tier="free",
+    status="active",
+    scopes=None,
+    name="Test Key",
+    created_at=None,
+    revoked_at=None,
+    last_used_at=None,
+    key_last_four="abcd",
+):
+    """Return a plain dict that behaves like a BigQuery Row (has .items())."""
+    return {
+        "key_id": key_id,
+        "user_id": user_id,
+        "tier": tier,
+        "status": status,
+        "scopes": scopes,
+        "name": name,
+        "created_at": created_at,
+        "revoked_at": revoked_at,
+        "last_used_at": last_used_at,
+        "key_last_four": key_last_four,
+    }
+
+
+def _mock_query_result(rows):
+    """Return a mock BQ job whose .result() yields the given rows."""
+    job = MagicMock()
+    job.result.return_value = rows
+    return job
+
+
+@pytest.fixture
+def mock_auth_db():
+    db = MagicMock()
+    db.project_id = "test-project"
+    db.dataset_id = "nfl_dead_money"
+    return db
+
+
+@pytest.fixture
+def mock_pundit_db():
+    db = MagicMock()
+    db.project_id = "test-project"
+    db.dataset_id = "nfl_dead_money"
+    return db
+
+
+@pytest.fixture
+def client(mock_auth_db, mock_pundit_db):
+    app.dependency_overrides[get_db_for_auth] = lambda: mock_auth_db
+    app.dependency_overrides[get_db] = lambda: mock_pundit_db
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _hash_key
+# ---------------------------------------------------------------------------
+
+
+class TestHashKey:
+    def test_returns_64_char_hex(self):
+        h = _hash_key("capk_live_abc123")
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_same_key_same_hash(self):
+        assert _hash_key("capk_live_abc") == _hash_key("capk_live_abc")
+
+    def test_different_keys_different_hashes(self):
+        assert _hash_key("capk_live_abc") != _hash_key("capk_live_xyz")
+
+    def test_pepper_changes_hash(self):
+        with patch.dict(os.environ, {"API_KEY_PEPPER": "pepper1"}):
+            h1 = _hash_key("mykey")
+        with patch.dict(os.environ, {"API_KEY_PEPPER": "pepper2"}):
+            h2 = _hash_key("mykey")
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — auth middleware via TestClient
+# ---------------------------------------------------------------------------
+
+
+class TestAuthMiddleware:
+    def test_missing_key_returns_401(self, client, mock_auth_db):
+        # No X-API-Key header — FastAPI will return 422 for missing required header
+        resp = client.get("/v1/leaderboard")
+        assert resp.status_code in (401, 422)
+
+    def test_invalid_key_returns_401(self, client, mock_auth_db):
+        mock_auth_db.client.query.return_value = _mock_query_result([])
+        resp = client.get("/v1/leaderboard", headers={"X-API-Key": "capk_live_invalid"})
+        assert resp.status_code == 401
+
+    def test_revoked_key_returns_403(self, client, mock_auth_db):
+        revoked_row = _make_bq_row(status="revoked")
+        mock_auth_db.client.query.return_value = _mock_query_result([revoked_row])
+        resp = client.get("/v1/leaderboard", headers={"X-API-Key": "capk_live_revoked"})
+        assert resp.status_code == 403
+
+    def test_valid_key_passes_through(self, client, mock_auth_db, mock_pundit_db):
+        import pandas as pd
+
+        active_row = _make_bq_row(status="active")
+        # first call = auth lookup; second = update last_used_at (fire-and-forget)
+        mock_auth_db.client.query.return_value = _mock_query_result([active_row])
+        mock_pundit_db.fetch_df.return_value = pd.DataFrame()
+        resp = client.get("/v1/leaderboard", headers={"X-API-Key": "capk_live_valid"})
+        # 200 or 500 (BQ mock), not 401/403
+        assert resp.status_code not in (401, 403)
+
+    def test_health_check_requires_no_key(self, client):
+        """/ health check must remain public."""
+        resp = client.get("/")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/me
+# ---------------------------------------------------------------------------
+
+
+class TestMeEndpoint:
+    def test_returns_key_metadata(self, client, mock_auth_db):
+        active_row = _make_bq_row(
+            key_id="capk_live_me_test",
+            tier="pro",
+            status="active",
+            key_last_four="1234",
+        )
+        mock_auth_db.client.query.return_value = _mock_query_result([active_row])
+        resp = client.get("/v1/me", headers={"X-API-Key": "capk_live_valid"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["key_id"] == "capk_live_me_test"
+        assert data["tier"] == "pro"
+        assert data["status"] == "active"
+        assert data["key_last_four"] == "1234"
+
+    def test_rate_limit_present(self, client, mock_auth_db):
+        active_row = _make_bq_row(tier="api_growth", status="active")
+        mock_auth_db.client.query.return_value = _mock_query_result([active_row])
+        resp = client.get("/v1/me", headers={"X-API-Key": "capk_live_valid"})
+        data = resp.json()
+        assert data["rate_limit_per_minute"] == 300
+
+    def test_free_tier_rate_limit(self, client, mock_auth_db):
+        active_row = _make_bq_row(tier="free", status="active")
+        mock_auth_db.client.query.return_value = _mock_query_result([active_row])
+        resp = client.get("/v1/me", headers={"X-API-Key": "capk_live_valid"})
+        data = resp.json()
+        assert data["rate_limit_per_minute"] == 10
+
+    def test_me_without_key_returns_401_or_422(self, client, mock_auth_db):
+        resp = client.get("/v1/me")
+        assert resp.status_code in (401, 422)

--- a/pipeline/tests/test_pundit_api.py
+++ b/pipeline/tests/test_pundit_api.py
@@ -13,10 +13,24 @@ from fastapi.testclient import TestClient
 # Patch DB before importing the app so startup doesn't attempt BQ connection
 with patch("src.db_manager.DBManager._initialize_connection"):
     from api.main import app
+    from api.api_key_auth import verify_api_key
     from api.pundit_router import get_db
 
 FAKE_HASH = "a" * 64
 FAKE_HASH2 = "b" * 64
+
+# Stub key info bypasses BigQuery lookup in tests
+_STUB_KEY_INFO = {
+    "key_id": "capk_live_test",
+    "user_id": "user_test",
+    "tier": "pro",
+    "status": "active",
+    "scopes": [],
+    "name": "Test Key",
+    "created_at": None,
+    "last_used_at": None,
+    "key_last_four": "test",
+}
 
 
 def _mock_bq_job(df):
@@ -39,7 +53,10 @@ def mock_db():
 
 @pytest.fixture
 def client(mock_db):
+    # Override both the pundit DB dependency and the auth dependency so tests
+    # don't need a real BigQuery connection or a valid API key.
     app.dependency_overrides[get_db] = lambda: mock_db
+    app.dependency_overrides[verify_api_key] = lambda: _STUB_KEY_INFO
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- Adds `pipeline/api/api_key_auth.py` with `verify_api_key` FastAPI dependency that SHA-256-hashes the incoming `X-API-Key` header (using `API_KEY_PEPPER` env var) and looks it up in BigQuery `monetization.api_keys`
- Returns `401` for missing/invalid keys; `403` for revoked keys
- Wires the dependency at the `APIRouter` level on `router = APIRouter(prefix="/v1", ...)` so all `/v1/*` routes are protected with a single declaration — `GET /` health check remains public
- Adds `GET /v1/me` endpoint that returns authenticated key's tier, rate-limit-per-minute, scopes, and last-used info
- Updates `test_pundit_api.py` to override `verify_api_key` dependency so existing tests keep passing
- Adds `test_api_key_auth.py` with 13 new tests: hash function unit tests, 401/403 middleware tests, `/v1/me` response shape tests

## Test plan

- [x] `pytest tests/test_api_key_auth.py` — 13 new tests, all pass
- [x] `pytest tests/test_pundit_api.py` — 36 existing tests, all pass
- [x] Full suite: 841 passed, 1 pre-existing BQ data failure (unrelated `content_hash` duplicate in integration test)
- [x] `ruff check` — clean

## Schema assumed (from issue #142)
`monetization.api_keys` with columns: `key_id`, `key_hash`, `key_last_four`, `user_id`, `tier`, `scopes`, `status`, `created_at`, `revoked_at`, `last_used_at`, `last_used_ip`, `name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)