### PR TITLE
fix(web): default API_URL to Cloud Run when NEXT_PUBLIC_API_URL unset

### DIFF
--- a/web/app/api/ledger/pundits/route.ts
+++ b/web/app/api/ledger/pundits/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://pundit-api-139200534279.us-central1.run.app";
 
 export async function GET(req: Request) {
     try {

--- a/web/app/api/ledger/recent/route.ts
+++ b/web/app/api/ledger/recent/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://pundit-api-139200534279.us-central1.run.app";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);


### PR DESCRIPTION
Fix localhost fallback in API URL defaults for serverless Vercel deployments.

Changed fallback from http://localhost:8000 to https://pundit-api-139200534279.us-central1.run.app in:
- web/app/api/ledger/pundits/route.ts
- web/app/api/ledger/recent/route.ts

This ensures the API calls work in Vercel serverless environments where localhost does not exist.