### PR TITLE
fix(resolve): normalize 0-indexed SportsDataIO draft picks to 1-indexed

### DIFF
--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -240,6 +240,17 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         logger.warning("No draft data available for resolution.")
         return summary
 
+    # SportsDataIO stores the top ~22 first-round picks as 0-indexed
+    # (CollegeDraftRound=0, CollegeDraftPick=0 = #1 overall pick).
+    # Normalize to 1-indexed so all downstream comparisons are consistent.
+    zero_indexed_mask = (draft_data["draft_round"] == 0) & (
+        draft_data["draft_pick"] >= 0
+    )
+    draft_data.loc[zero_indexed_mask, "draft_round"] = 1
+    draft_data.loc[zero_indexed_mask, "draft_pick"] = (
+        draft_data.loc[zero_indexed_mask, "draft_pick"] + 1
+    )
+
     logger.info(
         f"Resolving {len(draft_preds)} draft_pick predictions "
         f"against {len(draft_data)} player draft records"
@@ -325,8 +336,8 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         actual_team = actual.get("draft_team")
         actual_name = actual.get("Name")
 
-        # Skip if pick data is missing or invalid (pick 0 = not yet assigned)
-        if not pd.notna(actual_pick) or int(actual_pick) == 0:
+        # Skip if pick data is missing (0-indexed picks already normalized to 1+ above)
+        if not pd.notna(actual_pick):
             logger.info(
                 f"  SKIP {phash[:12]}… — player found but pick not yet assigned: {actual_name}"
             )

--- a/pipeline/tests/test_resolve_daily.py
+++ b/pipeline/tests/test_resolve_daily.py
@@ -909,6 +909,59 @@ class TestResolveDraftPicks:
         assert summary["voided"] == 1
         mock_void.assert_called_once()
 
+    @patch("src.resolve_daily._load_draft_data")
+    @patch("src.resolve_daily.get_pending_predictions")
+    @patch("src.resolve_daily.resolve_binary")
+    def test_zero_indexed_picks_normalized(
+        self, mock_resolve, mock_pending, mock_load, mock_db
+    ):
+        """SportsDataIO 0-indexed picks (round=0, pick=0 = #1 overall) are normalized to 1-indexed."""
+        # Simulate SportsDataIO raw data: #1 overall stored as round=0, pick=0
+        zero_indexed_data = pd.DataFrame(
+            [
+                {
+                    "Name": "Fernando Mendoza",
+                    "name_lower": "fernando mendoza",
+                    "draft_year": 2025,
+                    "draft_round": 0,  # SportsDataIO 0-indexed
+                    "draft_pick": 0,  # SportsDataIO 0-indexed — means pick #1
+                    "draft_team": "CLE",
+                    "current_team": "CLE",
+                    "undrafted": False,
+                },
+                {
+                    "Name": "Arvell Reese",
+                    "name_lower": "arvell reese",
+                    "draft_year": 2025,
+                    "draft_round": 0,  # SportsDataIO 0-indexed
+                    "draft_pick": 2,  # SportsDataIO 0-indexed — means pick #3
+                    "draft_team": "NYG",
+                    "current_team": "NYG",
+                    "undrafted": False,
+                },
+            ]
+        )
+        preds = _make_pending_df(
+            "draft_pick",
+            [
+                {
+                    "claim": "Fernando Mendoza is the No. 1 overall pick in 2025",
+                    "season_year": 2025,
+                    "target_player_id": "Fernando Mendoza",
+                }
+            ],
+        )
+        mock_pending.return_value = preds
+        mock_load.return_value = zero_indexed_data
+
+        summary = resolve_draft_picks(mock_db, dry_run=False)
+
+        # Should resolve (not skip) because pick 0 is normalized to 1
+        assert summary["resolved"] == 1
+        assert summary["skipped"] == 0
+        call_kwargs = mock_resolve.call_args[1]
+        assert call_kwargs["correct"] is True
+
     @patch("src.resolve_daily.get_pending_predictions")
     def test_empty_predictions(self, mock_pending, mock_db):
         """Return 0 checked when there are no draft_pick predictions."""


### PR DESCRIPTION
## Summary

- SportsDataIO stores the top ~22 first-round picks as 0-indexed: `CollegeDraftRound=0, CollegeDraftPick=0` = #1 overall pick
- The resolver was treating `pick=0` as "not yet assigned" and skipping Fernando Mendoza (#1 overall), Arvell Reese (#3 overall), and all other top-22 picks
- Fixed by normalizing 0-indexed rows to 1-indexed immediately after loading draft data from BigQuery, then removing the now-redundant `pick==0` guard

## Changes

- `pipeline/src/resolve_daily.py`: Add normalization block after `_load_draft_data(db)` call; remove `or int(actual_pick) == 0` from skip condition
- `pipeline/tests/test_resolve_daily.py`: Add `test_zero_indexed_picks_normalized` regression test using raw 0-indexed mock data

## Test plan

- [x] `68 passed` — all existing tests pass plus new regression test
- [x] `test_zero_indexed_picks_normalized` — verifies pick=0 (raw) resolves correctly as pick #1 overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)