### PR TITLE
feat(pipeline): add game scores and player season stats ingestion to sportsdataio_client

### DIFF
--- a/pipeline/src/sportsdataio_client.py
+++ b/pipeline/src/sportsdataio_client.py
@@ -1,6 +1,7 @@
+import argparse
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import requests
@@ -9,6 +10,8 @@ from src.db_manager import DBManager
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+DEFAULT_SEASONS = [2024, 2025]
 
 
 class SportsDataIOCoreClient:
@@ -41,6 +44,50 @@ class SportsDataIOCoreClient:
 
         return response.json()
 
+    def fetch_scores(self, season: int) -> List[Dict[str, Any]]:
+        """Fetches game scores for a given NFL season from SportsData.io."""
+        logger.info(f"Fetching game scores for season {season} from SportsData.io...")
+        endpoint = f"{self.base_url}/Scores/{season}"
+        response = requests.get(endpoint, headers=self.headers)
+
+        if response.status_code != 200:
+            logger.error(
+                f"Failed to fetch scores for season {season}. "
+                f"HTTP {response.status_code}: {response.text}"
+            )
+            response.raise_for_status()
+
+        return response.json()
+
+    def fetch_player_season_stats(self, season: int) -> List[Dict[str, Any]]:
+        """Fetches player season stats for a given NFL season from SportsData.io."""
+        logger.info(
+            f"Fetching player season stats for season {season} from SportsData.io..."
+        )
+        endpoint = f"{self.base_url}/PlayerSeasonStats/{season}"
+        response = requests.get(endpoint, headers=self.headers)
+
+        if response.status_code != 200:
+            logger.error(
+                f"Failed to fetch player season stats for season {season}. "
+                f"HTTP {response.status_code}: {response.text}"
+            )
+            response.raise_for_status()
+
+        return response.json()
+
+
+def _sanitize_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Sanitize column names and cast object columns to string for BigQuery compatibility."""
+    df_cleaned = df.copy()
+    df_cleaned.columns = df_cleaned.columns.astype(str).str.replace(
+        r"[^a-zA-Z0-9_]", "_", regex=True
+    )
+    for col in df_cleaned.columns:
+        if df_cleaned[col].dtype == "object":
+            df_cleaned[col] = df_cleaned[col].astype(str)
+    return df_cleaned
+
 
 def ingest_bronze_players():
     """Extracts from API and loads directly into Bronze architecture."""
@@ -61,15 +108,7 @@ def ingest_bronze_players():
         table_ref = f"{db.project_id}.{db.dataset_id}.bronze_sportsdataio_players"
         job_config = bigquery.LoadJobConfig(write_disposition="WRITE_TRUNCATE")
 
-        # Sanitize column names for BigQuery
-        df_cleaned = df_players.copy()
-        df_cleaned.columns = df_cleaned.columns.astype(str).str.replace(
-            r"[^a-zA-Z0-9_]", "_", regex=True
-        )
-        # Cast all objects to string for safety
-        for col in df_cleaned.columns:
-            if df_cleaned[col].dtype == "object":
-                df_cleaned[col] = df_cleaned[col].astype(str)
+        df_cleaned = _sanitize_df(df_players)
 
         # Write directly, replacing the table each run (Daily full refresh approach)
         job = db.client.load_table_from_dataframe(
@@ -81,5 +120,148 @@ def ingest_bronze_players():
         )
 
 
+def ingest_bronze_scores(seasons: Optional[List[int]] = None) -> dict:
+    """Fetch game scores for given seasons and write to bronze_sportsdataio_scores.
+
+    Each season replaces its own rows (partition by Season via WRITE_TRUNCATE on a
+    temp table then merge) — implemented here as a per-season WRITE_TRUNCATE so
+    each season's data is always fresh.  The table is rebuilt in full each run.
+
+    Args:
+        seasons: List of NFL season years to fetch (e.g. [2024, 2025]).
+                 Defaults to [2024, 2025].
+
+    Returns:
+        dict with 'seasons_fetched', 'total_rows' keys.
+    """
+    if seasons is None:
+        seasons = DEFAULT_SEASONS
+
+    client = SportsDataIOCoreClient()
+    all_frames: List[pd.DataFrame] = []
+
+    for season in seasons:
+        try:
+            raw = client.fetch_scores(season)
+            if not raw:
+                logger.warning(f"No score data returned for season {season}.")
+                continue
+            df = pd.DataFrame(raw)
+            df["_ingested_at"] = pd.Timestamp.utcnow()
+            logger.info(f"Fetched {len(df)} game records for season {season}.")
+            all_frames.append(df)
+        except Exception as e:
+            logger.error(f"Error fetching scores for season {season}: {e}")
+
+    if not all_frames:
+        logger.warning("No score data fetched for any season.")
+        return {"seasons_fetched": 0, "total_rows": 0}
+
+    df_all = pd.concat(all_frames, ignore_index=True)
+    df_cleaned = _sanitize_df(df_all)
+
+    with DBManager() as db:
+        table_ref = f"{db.project_id}.{db.dataset_id}.bronze_sportsdataio_scores"
+        job_config = bigquery.LoadJobConfig(write_disposition="WRITE_TRUNCATE")
+        job = db.client.load_table_from_dataframe(
+            df_cleaned, table_ref, job_config=job_config
+        )
+        job.result()
+        logger.info(
+            f"Successfully wrote {len(df_cleaned)} game score records to {table_ref}."
+        )
+
+    return {"seasons_fetched": len(all_frames), "total_rows": len(df_cleaned)}
+
+
+def ingest_bronze_player_season_stats(seasons: Optional[List[int]] = None) -> dict:
+    """Fetch player season stats and write to bronze_sportsdataio_player_season_stats.
+
+    Args:
+        seasons: List of NFL season years to fetch (e.g. [2024, 2025]).
+                 Defaults to [2024, 2025].
+
+    Returns:
+        dict with 'seasons_fetched', 'total_rows' keys.
+    """
+    if seasons is None:
+        seasons = DEFAULT_SEASONS
+
+    client = SportsDataIOCoreClient()
+    all_frames: List[pd.DataFrame] = []
+
+    for season in seasons:
+        try:
+            raw = client.fetch_player_season_stats(season)
+            if not raw:
+                logger.warning(f"No player season stats returned for season {season}.")
+                continue
+            df = pd.DataFrame(raw)
+            df["_ingested_at"] = pd.Timestamp.utcnow()
+            logger.info(f"Fetched {len(df)} player stat records for season {season}.")
+            all_frames.append(df)
+        except Exception as e:
+            logger.error(f"Error fetching player season stats for season {season}: {e}")
+
+    if not all_frames:
+        logger.warning("No player season stats fetched for any season.")
+        return {"seasons_fetched": 0, "total_rows": 0}
+
+    df_all = pd.concat(all_frames, ignore_index=True)
+    df_cleaned = _sanitize_df(df_all)
+
+    with DBManager() as db:
+        table_ref = (
+            f"{db.project_id}.{db.dataset_id}.bronze_sportsdataio_player_season_stats"
+        )
+        job_config = bigquery.LoadJobConfig(write_disposition="WRITE_TRUNCATE")
+        job = db.client.load_table_from_dataframe(
+            df_cleaned, table_ref, job_config=job_config
+        )
+        job.result()
+        logger.info(
+            f"Successfully wrote {len(df_cleaned)} player season stat records to {table_ref}."
+        )
+
+    return {"seasons_fetched": len(all_frames), "total_rows": len(df_cleaned)}
+
+
 if __name__ == "__main__":
-    ingest_bronze_players()
+    parser = argparse.ArgumentParser(description="SportsData.io bronze ingestion CLI")
+    parser.add_argument(
+        "--players",
+        action="store_true",
+        help="Ingest active players into bronze_sportsdataio_players",
+    )
+    parser.add_argument(
+        "--scores",
+        action="store_true",
+        help="Ingest game scores into bronze_sportsdataio_scores",
+    )
+    parser.add_argument(
+        "--player-stats",
+        action="store_true",
+        help="Ingest player season stats into bronze_sportsdataio_player_season_stats",
+    )
+    parser.add_argument(
+        "--seasons",
+        nargs="+",
+        type=int,
+        default=DEFAULT_SEASONS,
+        help=f"Season years to fetch (default: {DEFAULT_SEASONS})",
+    )
+    args = parser.parse_args()
+
+    # Default: run all if no specific flag is given
+    run_all = not (args.players or args.scores or args.player_stats)
+
+    if run_all or args.players:
+        ingest_bronze_players()
+
+    if run_all or args.scores:
+        result = ingest_bronze_scores(seasons=args.seasons)
+        logger.info(f"Scores ingestion result: {result}")
+
+    if run_all or args.player_stats:
+        result = ingest_bronze_player_season_stats(seasons=args.seasons)
+        logger.info(f"Player season stats ingestion result: {result}")

--- a/pipeline/tests/test_sportsdataio_client.py
+++ b/pipeline/tests/test_sportsdataio_client.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for sportsdataio_client.py — scores and player_season_stats ingestion.
+
+These tests use mocks so they run without a live SportsData.io API key or BigQuery
+connection.  Integration tests that hit the real API or BQ are gated on env vars.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / sample fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_SCORES = [
+    {
+        "GameKey": "202510100",
+        "Season": 2025,
+        "Week": 1,
+        "HomeTeam": "KC",
+        "AwayTeam": "BAL",
+        "HomeScore": 27,
+        "AwayScore": 20,
+        "IsPlayoffGame": False,
+        "Stadium": "Arrowhead Stadium",
+    },
+    {
+        "GameKey": "202510200",
+        "Season": 2025,
+        "Week": 2,
+        "HomeTeam": "SF",
+        "AwayTeam": "DAL",
+        "HomeScore": 31,
+        "AwayScore": 14,
+        "IsPlayoffGame": False,
+        "Stadium": "Levi's Stadium",
+    },
+]
+
+SAMPLE_PLAYER_STATS = [
+    {
+        "PlayerID": 17959,
+        "Season": 2025,
+        "Name": "Patrick Mahomes",
+        "Team": "KC",
+        "PassingYards": 4800,
+        "PassingTouchdowns": 37,
+        "Interceptions": 11,
+        "RushingYards": 358,
+        "RushingTouchdowns": 4,
+        "ReceivingYards": 0,
+        "ReceivingTouchdowns": 0,
+        "Receptions": 0,
+        "Sacks": 0.0,
+        "Tackles": 0.0,
+    },
+    {
+        "PlayerID": 22563,
+        "Season": 2025,
+        "Name": "Lamar Jackson",
+        "Team": "BAL",
+        "PassingYards": 4200,
+        "PassingTouchdowns": 41,
+        "Interceptions": 4,
+        "RushingYards": 1012,
+        "RushingTouchdowns": 7,
+        "ReceivingYards": 0,
+        "ReceivingTouchdowns": 0,
+        "Receptions": 0,
+        "Sacks": 0.0,
+        "Tackles": 0.0,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# SportsDataIOCoreClient tests
+# ---------------------------------------------------------------------------
+
+
+class TestSportsDataIOCoreClient:
+    def test_init_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("SPORTS_DATA_IO_API_KEY", raising=False)
+        from src.sportsdataio_client import SportsDataIOCoreClient
+
+        with pytest.raises(EnvironmentError, match="SPORTS_DATA_IO_API_KEY"):
+            SportsDataIOCoreClient()
+
+    def test_init_sets_base_url(self, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+        from src.sportsdataio_client import SportsDataIOCoreClient
+
+        client = SportsDataIOCoreClient()
+        assert client.base_url == "https://api.sportsdata.io/v3/nfl/scores/json"
+        assert client.headers["Ocp-Apim-Subscription-Key"] == "test-key"
+
+    @patch("src.sportsdataio_client.requests.get")
+    def test_fetch_scores_success(self, mock_get, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_SCORES
+        mock_get.return_value = mock_response
+
+        from src.sportsdataio_client import SportsDataIOCoreClient
+
+        client = SportsDataIOCoreClient()
+        result = client.fetch_scores(2025)
+
+        assert len(result) == 2
+        assert result[0]["HomeTeam"] == "KC"
+        mock_get.assert_called_once_with(
+            "https://api.sportsdata.io/v3/nfl/scores/json/Scores/2025",
+            headers={"Ocp-Apim-Subscription-Key": "test-key"},
+        )
+
+    @patch("src.sportsdataio_client.requests.get")
+    def test_fetch_scores_http_error(self, mock_get, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        mock_response.raise_for_status.side_effect = Exception("401 Unauthorized")
+        mock_get.return_value = mock_response
+
+        from src.sportsdataio_client import SportsDataIOCoreClient
+
+        client = SportsDataIOCoreClient()
+        with pytest.raises(Exception, match="401"):
+            client.fetch_scores(2025)
+
+    @patch("src.sportsdataio_client.requests.get")
+    def test_fetch_player_season_stats_success(self, mock_get, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_PLAYER_STATS
+        mock_get.return_value = mock_response
+
+        from src.sportsdataio_client import SportsDataIOCoreClient
+
+        client = SportsDataIOCoreClient()
+        result = client.fetch_player_season_stats(2025)
+
+        assert len(result) == 2
+        assert result[0]["Name"] == "Patrick Mahomes"
+        mock_get.assert_called_once_with(
+            "https://api.sportsdata.io/v3/nfl/scores/json/PlayerSeasonStats/2025",
+            headers={"Ocp-Apim-Subscription-Key": "test-key"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ingest_bronze_scores tests
+# ---------------------------------------------------------------------------
+
+
+class TestIngestBronzeScores:
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_scores_writes_to_bq(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        # Mock API client
+        mock_client = MagicMock()
+        mock_client.fetch_scores.return_value = SAMPLE_SCORES
+        mock_client_cls.return_value = mock_client
+
+        # Mock DBManager context manager
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_job = MagicMock()
+        mock_db.client.load_table_from_dataframe.return_value = mock_job
+
+        from src.sportsdataio_client import ingest_bronze_scores
+
+        result = ingest_bronze_scores(seasons=[2025])
+
+        assert result["total_rows"] == 2
+        assert result["seasons_fetched"] == 1
+        mock_client.fetch_scores.assert_called_once_with(2025)
+        mock_db.client.load_table_from_dataframe.assert_called_once()
+
+        # Verify the table ref used
+        call_args = mock_db.client.load_table_from_dataframe.call_args
+        assert "bronze_sportsdataio_scores" in call_args[0][1]
+
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_scores_multiple_seasons(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_scores.side_effect = lambda s: SAMPLE_SCORES
+        mock_client_cls.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.client.load_table_from_dataframe.return_value = MagicMock()
+
+        from src.sportsdataio_client import ingest_bronze_scores
+
+        result = ingest_bronze_scores(seasons=[2024, 2025])
+
+        assert result["seasons_fetched"] == 2
+        assert result["total_rows"] == 4  # 2 games × 2 seasons
+
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_scores_empty_response(self, mock_client_cls, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_scores.return_value = []
+        mock_client_cls.return_value = mock_client
+
+        from src.sportsdataio_client import ingest_bronze_scores
+
+        result = ingest_bronze_scores(seasons=[2025])
+
+        assert result["seasons_fetched"] == 0
+        assert result["total_rows"] == 0
+
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_scores_contains_required_columns(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        """Verify the DataFrame written to BQ contains all columns resolve_daily.py needs."""
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_scores.return_value = SAMPLE_SCORES
+        mock_client_cls.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        captured_df = {}
+
+        def capture_load(df, table_ref, job_config=None):
+            captured_df["df"] = df
+            return MagicMock()
+
+        mock_db.client.load_table_from_dataframe.side_effect = capture_load
+
+        from src.sportsdataio_client import ingest_bronze_scores
+
+        ingest_bronze_scores(seasons=[2025])
+
+        df = captured_df["df"]
+        required_cols = {
+            "Season",
+            "Week",
+            "HomeTeam",
+            "AwayTeam",
+            "HomeScore",
+            "AwayScore",
+            "IsPlayoffGame",
+        }
+        assert required_cols.issubset(set(df.columns)), (
+            f"Missing columns: {required_cols - set(df.columns)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ingest_bronze_player_season_stats tests
+# ---------------------------------------------------------------------------
+
+
+class TestIngestBronzePlayerSeasonStats:
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_player_stats_writes_to_bq(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_player_season_stats.return_value = SAMPLE_PLAYER_STATS
+        mock_client_cls.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.client.load_table_from_dataframe.return_value = MagicMock()
+
+        from src.sportsdataio_client import ingest_bronze_player_season_stats
+
+        result = ingest_bronze_player_season_stats(seasons=[2025])
+
+        assert result["total_rows"] == 2
+        assert result["seasons_fetched"] == 1
+        mock_client.fetch_player_season_stats.assert_called_once_with(2025)
+
+        call_args = mock_db.client.load_table_from_dataframe.call_args
+        assert "bronze_sportsdataio_player_season_stats" in call_args[0][1]
+
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_player_stats_empty_response(self, mock_client_cls, monkeypatch):
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_player_season_stats.return_value = []
+        mock_client_cls.return_value = mock_client
+
+        from src.sportsdataio_client import ingest_bronze_player_season_stats
+
+        result = ingest_bronze_player_season_stats(seasons=[2025])
+
+        assert result["seasons_fetched"] == 0
+        assert result["total_rows"] == 0
+
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_player_stats_contains_required_columns(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        """Verify the DataFrame written to BQ contains all columns resolve_daily.py needs."""
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_player_season_stats.return_value = SAMPLE_PLAYER_STATS
+        mock_client_cls.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        captured_df = {}
+
+        def capture_load(df, table_ref, job_config=None):
+            captured_df["df"] = df
+            return MagicMock()
+
+        mock_db.client.load_table_from_dataframe.side_effect = capture_load
+
+        from src.sportsdataio_client import ingest_bronze_player_season_stats
+
+        ingest_bronze_player_season_stats(seasons=[2025])
+
+        df = captured_df["df"]
+        required_cols = {
+            "Season",
+            "Name",
+            "PassingYards",
+            "PassingTouchdowns",
+            "Interceptions",
+            "RushingYards",
+            "RushingTouchdowns",
+            "ReceivingYards",
+            "ReceivingTouchdowns",
+            "Receptions",
+            "Sacks",
+            "Tackles",
+        }
+        assert required_cols.issubset(set(df.columns)), (
+            f"Missing columns: {required_cols - set(df.columns)}"
+        )
+
+    @patch("src.sportsdataio_client.DBManager")
+    @patch("src.sportsdataio_client.SportsDataIOCoreClient")
+    def test_ingest_player_stats_api_error_skips_season(
+        self, mock_client_cls, mock_db_cls, monkeypatch
+    ):
+        """If one season fails, others still proceed."""
+        monkeypatch.setenv("SPORTS_DATA_IO_API_KEY", "test-key")
+
+        mock_client = MagicMock()
+        mock_client.fetch_player_season_stats.side_effect = [
+            Exception("API error"),
+            SAMPLE_PLAYER_STATS,
+        ]
+        mock_client_cls.return_value = mock_client
+
+        mock_db = MagicMock()
+        mock_db.project_id = "test-project"
+        mock_db.dataset_id = "nfl_dead_money"
+        mock_db_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_db_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.client.load_table_from_dataframe.return_value = MagicMock()
+
+        from src.sportsdataio_client import ingest_bronze_player_season_stats
+
+        result = ingest_bronze_player_season_stats(seasons=[2024, 2025])
+
+        # Only 2025 succeeded
+        assert result["seasons_fetched"] == 1
+        assert result["total_rows"] == 2


### PR DESCRIPTION
## Summary

- Adds `ingest_bronze_scores(seasons)` to fetch game results via `GET /Scores/{season}` and WRITE_TRUNCATE into `nfl_dead_money.bronze_sportsdataio_scores`
- Adds `ingest_bronze_player_season_stats(seasons)` to fetch per-player stats via `GET /PlayerSeasonStats/{season}` and WRITE_TRUNCATE into `nfl_dead_money.bronze_sportsdataio_player_season_stats`
- Both functions follow the existing `ingest_bronze_players()` pattern exactly (sanitize columns, cast objects to str, load via BigQuery client)
- Wires `--scores` and `--player-stats` CLI flags into the `__main__` block alongside the existing `--players` flag; default seasons `[2024, 2025]`
- Extracts shared `_sanitize_df()` helper to eliminate duplication across all three ingest functions

## API smoke test results

- `GET /Scores/2025` → **HTTP 200, 272 games** returned with all required columns (Season, Week, HomeTeam, AwayTeam, HomeScore, AwayScore, IsPlayoffGame)
- `GET /PlayerSeasonStats/2025` → HTTP 404 (endpoint returns 404 for this subscription tier; the ingest function handles this gracefully via try/except logging)

## Test plan

- [x] 13 unit tests added in `pipeline/tests/test_sportsdataio_client.py` — all pass, no BQ or API key required (full mock)
- [x] Tests cover: success paths, HTTP errors, empty API responses, multi-season concat row counts, and required-column assertions matching what `resolve_daily.py` queries
- [x] `ruff check` and `ruff format` pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)