### PR TITLE
fix(ingest): repair 3 broken RSS feed sources

### DIFF
--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -64,10 +64,13 @@ sources:
         match_authors: ["Matt Bowen"]
 
   - id: theringer_nfl
-    name: "The Ringer NFL"
+    name: "The Ringer NFL Show"
     sport: "NFL"
     type: rss
-    url: "https://www.theringer.com/rss/nfl/index.xml"
+    # Updated 2026-04-27: theringer.com/rss/nfl/index.xml returned 404 (article RSS
+    # discontinued). Replaced with Megaphone podcast feed for The Ringer NFL Show,
+    # which publishes daily NFL analysis episodes.
+    url: "https://feeds.megaphone.fm/the-ringer-nfl-show"
     enabled: true
     pundits:
       - id: bill_simmons
@@ -76,6 +79,9 @@ sources:
       - id: kevin_clark
         name: "Kevin Clark"
         match_authors: ["Kevin Clark"]
+      - id: sheil_kapadia
+        name: "Sheil Kapadia"
+        match_authors: ["Sheil Kapadia"]
 
   - id: theathletic_nfl
     name: "The Athletic NFL"
@@ -116,8 +122,12 @@ sources:
     sport: "NFL"
     type: rss
     scrape_full_text: true
+    # Disabled 2026-04-27: nfl.com/rss/rsslanding now returns text/html (React SPA),
+    # not XML. NFL.com has no public RSS endpoint as of this date. Re-enable if NFL
+    # restores an RSS feed. Consider replacing with Yahoo Sports NFL or CBS Sports NFL
+    # for Ian Rapoport / Tom Pelissero coverage.
     url: "https://www.nfl.com/rss/rsslanding?searchString=home"
-    enabled: true
+    enabled: false
     pundits:
       - id: ian_rapoport
         name: "Ian Rapoport"


### PR DESCRIPTION
## Summary

- **theringer_nfl**: Replaced dead article RSS (`theringer.com/rss/nfl/index.xml`, 404) with working Megaphone podcast feed (`feeds.megaphone.fm/the-ringer-nfl-show`). Verified: HTTP 200, feedparser bozo=False, 1535 entries. Adds Sheil Kapadia (current host) to pundits list.
- **nfl_official**: Disabled. `nfl.com/rss/rsslanding` now returns `text/html` (React SPA redirect), causing "not well-formed (invalid token)" parse errors. No public XML RSS endpoint exists on NFL.com as of 2026-04-27. Comment explains situation and suggests Yahoo/CBS Sports as coverage alternatives for Rapoport/Pelissero.
- **si_nfl**: Already disabled in this branch (Arena Group / Authentic Brands collapse Jan 2024 killed SI's RSS feeds).

## Verification

Tested with feedparser directly:
- `theringer_nfl` new URL: `status=200, bozo=False, entries=1535` ✓
- `nfl_official` old URL: `status=301, bozo=True, bozo_exception="not well-formed (invalid token)"` — matches reported error ✓

## Test plan

- [ ] Dry-run ingest (`make up` + `python -m src.media_ingestor --dry-run --source theringer_nfl`) confirms items fetched with no XML errors
- [ ] Dry-run for `nfl_official` and `si_nfl` skips gracefully (disabled sources)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)