### PR TITLE
feat(pipeline): add launchd-driven daily pipeline script

### DIFF
--- a/pipeline/scripts/run_daily_pipeline.sh
+++ b/pipeline/scripts/run_daily_pipeline.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Daily Pundit Prediction Ledger Pipeline
+# Invoked by launchd (com.punditledger.pipeline) at 6:00 AM local time.
+# Logs to /tmp/pundit_pipeline.log (appended each run).
+#
+# Stages:
+#   1. media_ingestor     — ingest new articles from RSS feeds
+#   2. assertion_extractor — extract predictions via local Ollama (qwen2.5:32b)
+#   3. resolve_daily      — resolve PENDING predictions against outcomes
+
+set -euo pipefail
+
+REPO_ROOT="/Users/andrewsmith/portfolio/nfl-dead-money"
+PIPELINE_DIR="${REPO_ROOT}/pipeline"
+PYTHON="${REPO_ROOT}/.venv/bin/python"
+ENV_FILE="${REPO_ROOT}/.env"
+LOG_FILE="/tmp/pundit_pipeline.log"
+
+echo "=== Pundit Pipeline run started at $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "${LOG_FILE}"
+
+# Load environment variables from .env (BigQuery credentials, API keys, etc.)
+if [[ -f "${ENV_FILE}" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "${ENV_FILE}"
+    set +a
+else
+    echo "WARNING: ${ENV_FILE} not found; continuing without it" >> "${LOG_FILE}"
+fi
+
+# All pipeline modules use relative imports from within pipeline/
+cd "${PIPELINE_DIR}"
+
+run_stage() {
+    local stage="$1"
+    shift
+    echo "--- [$(date -u +%H:%M:%SZ)] Stage: ${stage} ---" >> "${LOG_FILE}"
+    if "${PYTHON}" "$@" >> "${LOG_FILE}" 2>&1; then
+        echo "--- [$(date -u +%H:%M:%SZ)] ${stage} OK ---" >> "${LOG_FILE}"
+    else
+        local rc=$?
+        echo "--- [$(date -u +%H:%M:%SZ)] ${stage} FAILED (exit ${rc}) ---" >> "${LOG_FILE}"
+        # Exit so launchd records a non-zero exit and throttle kicks in
+        exit "${rc}"
+    fi
+}
+
+run_stage "media_ingestor"      -m src.media_ingestor
+run_stage "assertion_extractor" -m src.assertion_extractor --limit 500
+run_stage "resolve_daily"       -m src.resolve_daily
+
+echo "=== Pundit Pipeline completed successfully at $(date -u +%Y-%m-%dT%H:%M:%SZ) ===" >> "${LOG_FILE}"


### PR DESCRIPTION
## Summary

- Adds `pipeline/scripts/run_daily_pipeline.sh` — shell entrypoint for the macOS launchd daily pipeline agent
- Runs the three Pundit Prediction Ledger pipeline stages in sequence using the local venv and Ollama (qwen2.5:32b): `media_ingestor` → `assertion_extractor --limit 500` → `resolve_daily`
- Logs each stage with timestamps to `/tmp/pundit_pipeline.log`; exits non-zero on first failure so launchd throttling applies
- The companion `~/Library/LaunchAgents/com.punditledger.pipeline.plist` (outside the repo) triggers this script daily at 06:00 local time

## Why launchd, not GitHub Actions cron

`assertion_extractor` requires local Ollama (qwen2.5:32b running on the M4 Pro) — it cannot run on GitHub-hosted runners.

## Test plan

- [ ] Verify `launchctl list | grep pundit` shows `com.punditledger.pipeline` loaded
- [ ] Run `bash pipeline/scripts/run_daily_pipeline.sh` manually and confirm `/tmp/pundit_pipeline.log` shows all three stages completing
- [ ] Check `launchctl start com.punditledger.pipeline` triggers the job on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)