### PR TITLE
fix(web): API proxy routes — field mapping, 502 on error, NaN guards

### DIFF
--- a/web/app/api/draft/[year]/route.ts
+++ b/web/app/api/draft/[year]/route.ts
@@ -1,16 +1,8 @@
 import { NextResponse } from "next/server";
-import { BigQuery } from "@google-cloud/bigquery";
 
-const bigquery = new BigQuery({
-    projectId: process.env.GCP_PROJECT_ID || "cap-alpha-protocol",
-    credentials:
-        process.env.GCP_CLIENT_EMAIL && process.env.GCP_PRIVATE_KEY
-            ? {
-                  client_email: process.env.GCP_CLIENT_EMAIL,
-                  private_key: process.env.GCP_PRIVATE_KEY.replace(/\\n/g, "\n"),
-              }
-            : undefined,
-});
+const API_URL =
+    process.env.NEXT_PUBLIC_API_URL ||
+    "https://pundit-ledger-api-wvhvx2muna-uc.a.run.app";
 
 interface Prediction {
     prediction_hash: string;
@@ -37,12 +29,13 @@ export async function GET(
     req: Request,
     { params }: { params: { year: string } }
 ): Promise<NextResponse<DraftData>> {
-    const year = parseInt(params.year, 10);
+    const parsed = parseInt(params.year, 10);
+    const year = Number.isFinite(parsed) ? parsed : NaN;
 
     if (isNaN(year) || year < 1900 || year > 2100) {
         return NextResponse.json(
             {
-                draft_year: year,
+                draft_year: year || 0,
                 total_predictions: 0,
                 resolved: 0,
                 pending: 0,
@@ -53,52 +46,54 @@ export async function GET(
     }
 
     try {
-        const projectId = process.env.GCP_PROJECT_ID || "cap-alpha-protocol";
-
-        const query = `
-            SELECT
-                l.prediction_hash,
-                l.pundit_id,
-                l.pundit_name,
-                l.extracted_claim,
-                l.target_player_name,
-                l.target_team,
-                l.source_url,
-                COALESCE(r.resolution_status, 'PENDING') AS status,
-                r.binary_correct,
-                r.outcome_notes
-            FROM \`${projectId}.gold_layer.prediction_ledger\` l
-            LEFT JOIN \`${projectId}.gold_layer.prediction_resolutions\` r
-                ON l.prediction_hash = r.prediction_hash
-            WHERE l.claim_category = 'draft_pick'
-              AND COALESCE(l.season_year, EXTRACT(YEAR FROM l.ingestion_timestamp)) = @year
-            ORDER BY l.ingestion_timestamp DESC
-            LIMIT 1000
-        `;
-
-        const [job] = await bigquery.createQueryJob({
-            query,
-            params: { year },
-            jobTimeoutMs: 15000,
+        const res = await fetch(`${API_URL}/v1/draft/${year}`, {
+            headers: {
+                Accept: "application/json",
+            },
         });
-        const [rows] = await job.getQueryResults({ timeoutMs: 15000 });
 
-        const predictions = rows as Prediction[];
+        if (!res.ok) {
+            console.error(
+                `[Draft API] Backend returned ${res.status}`,
+                await res.text()
+            );
+            return NextResponse.json(
+                {
+                    draft_year: year,
+                    total_predictions: 0,
+                    resolved: 0,
+                    pending: 0,
+                    predictions: [],
+                },
+                { status: 502 }
+            );
+        }
 
-        const resolved = predictions.filter(
-            (p) => p.status !== "PENDING"
-        ).length;
-        const pending = predictions.filter((p) => p.status === "PENDING").length;
-
+        const data = await res.json();
+        // Backend may return resolution_status; normalise to status for UI
+        const predictions = (data.predictions || []).map(
+            (p: Record<string, unknown>) => ({
+                ...p,
+                status:
+                    (p.status as string) ??
+                    (p.resolution_status as string) ??
+                    "PENDING",
+            })
+        );
         return NextResponse.json({
             draft_year: year,
-            total_predictions: predictions.length,
-            resolved,
-            pending,
+            total_predictions: data.total ?? data.total_predictions ?? 0,
+            resolved: data.resolved ?? 0,
+            pending: data.pending ?? 0,
             predictions,
         });
     } catch (err) {
-        console.error("[Draft API] BigQuery error:", err);
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.error("[Draft API] Backend fetch error:", {
+            error: errorMsg,
+            backendUrl: API_URL,
+            year,
+        });
         return NextResponse.json(
             {
                 draft_year: year,
@@ -107,7 +102,7 @@ export async function GET(
                 pending: 0,
                 predictions: [],
             },
-            { status: 500 }
+            { status: 502 }
         );
     }
 }

--- a/web/app/api/ledger/pundits/route.ts
+++ b/web/app/api/ledger/pundits/route.ts
@@ -1,28 +1,49 @@
 import { NextResponse } from "next/server";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://pundit-ledger-api-wvhvx2muna-uc.a.run.app";
+const API_URL =
+    process.env.NEXT_PUBLIC_API_URL ||
+    "https://pundit-ledger-api-wvhvx2muna-uc.a.run.app";
 
 export async function GET(req: Request) {
     try {
         const res = await fetch(`${API_URL}/v1/pundits/`, {
             headers: {
-                "Accept": "application/json",
+                Accept: "application/json",
             },
         });
 
         if (!res.ok) {
-            console.error(`[Ledger API] Backend returned ${res.status}`, await res.text());
-            return NextResponse.json({ pundits: [] });
+            console.error(
+                `[Ledger API] Backend returned ${res.status}`,
+                await res.text()
+            );
+            return NextResponse.json({ pundits: [] }, { status: 502 });
         }
 
         const data = await res.json();
-        return NextResponse.json({ pundits: data.pundits || [] });
+        // Backend returns resolved_count / correct_count — map to UI field names
+        const mapped = (data.pundits || []).map((p: Record<string, unknown>) => ({
+            ...p,
+            resolved_predictions:
+                (p.resolved_count as number) ??
+                (p.resolved_predictions as number) ??
+                0,
+            correct_predictions:
+                (p.correct_count as number) ??
+                (p.correct_predictions as number) ??
+                0,
+            incorrect_predictions:
+                (p.incorrect_count as number) ??
+                (p.incorrect_predictions as number) ??
+                0,
+        }));
+        return NextResponse.json({ pundits: mapped });
     } catch (err) {
         const errorMsg = err instanceof Error ? err.message : String(err);
         console.error("[Ledger API] Backend fetch error:", {
             error: errorMsg,
             backendUrl: API_URL,
         });
-        return NextResponse.json({ pundits: [] });
+        return NextResponse.json({ pundits: [] }, { status: 502 });
     }
 }

--- a/web/app/api/ledger/recent/route.ts
+++ b/web/app/api/ledger/recent/route.ts
@@ -1,21 +1,30 @@
 import { NextResponse } from "next/server";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://pundit-ledger-api-wvhvx2muna-uc.a.run.app";
+const API_URL =
+    process.env.NEXT_PUBLIC_API_URL ||
+    "https://pundit-ledger-api-wvhvx2muna-uc.a.run.app";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
-    const limit = Math.min(parseInt(searchParams.get("limit") || "20"), 100);
+    const parsed = parseInt(searchParams.get("limit") ?? "");
+    const limit = Number.isFinite(parsed) ? Math.min(parsed, 100) : 20;
 
     try {
-        const res = await fetch(`${API_URL}/v1/predictions/recent?limit=${limit}`, {
-            headers: {
-                "Accept": "application/json",
-            },
-        });
+        const res = await fetch(
+            `${API_URL}/v1/predictions/recent?limit=${limit}`,
+            {
+                headers: {
+                    Accept: "application/json",
+                },
+            }
+        );
 
         if (!res.ok) {
-            console.error(`[Ledger Recent API] Backend returned ${res.status}`, await res.text());
-            return NextResponse.json({ predictions: [] });
+            console.error(
+                `[Ledger Recent API] Backend returned ${res.status}`,
+                await res.text()
+            );
+            return NextResponse.json({ predictions: [] }, { status: 502 });
         }
 
         const data = await res.json();
@@ -26,6 +35,6 @@ export async function GET(req: Request) {
             error: errorMsg,
             backendUrl: API_URL,
         });
-        return NextResponse.json({ predictions: [] });
+        return NextResponse.json({ predictions: [] }, { status: 502 });
     }
 }


### PR DESCRIPTION
## Summary

Split from PR #400 per reviewer feedback — web route changes only.

- **Bug 5 (/api/ledger/pundits field names)**: backend returns `resolved_count` / `correct_count` but UI expects `resolved_predictions` / `correct_predictions` — add mapping layer in route handler
- **Bug 6 (error → 200)**: on backend failure, return `{ status: 502 }` instead of `200` with empty body, for both `/api/ledger/pundits` and `/api/ledger/recent`
- **Bug 7 (parseInt NaN guard)**: use `Number.isFinite(parsed)` check on `limit` parameter in `/api/ledger/recent` to avoid `NaN` propagating to backend URL
- **Bug 8 (resolution_status → status)**: map `resolution_status` to `status` in `/api/draft/[year]` predictions
- **Bug 9 (draft_year NaN)**: guard `parseInt(params.year)` with `Number.isFinite` fallback in `/api/draft/[year]`
- Replace BigQuery-direct implementation in `/api/draft/[year]` with Python backend proxy (consistent with main branch pattern from #263)

## Test plan

- [x] `make lint` — ruff clean (Python side unaffected; TypeScript checked via pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)