### PR TITLE
fix(security): remove hardcoded revalidate bypass + restrict CORS origins (#424 #426)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# ============================================================
+# Environment variable template — copy to .env and fill in
+# DO NOT commit .env to version control
+# ============================================================
+
+# --- Next.js cache revalidation (issue #424) ----------------
+# Generate with: openssl rand -hex 32
+REVALIDATE_SECRET=
+
+# --- FastAPI CORS allowlist (issue #426) --------------------
+# Comma-separated list of allowed origins (no wildcards)
+ALLOWED_ORIGINS=https://cap-alpha.co

--- a/pipeline/api/main.py
+++ b/pipeline/api/main.py
@@ -34,9 +34,10 @@ app = FastAPI(
 
 from fastapi.middleware.cors import CORSMiddleware
 
+origins = os.getenv("ALLOWED_ORIGINS", "https://cap-alpha.co").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_methods=["GET"],
     allow_headers=["*"],
 )

--- a/web/app/api/revalidate/route.ts
+++ b/web/app/api/revalidate/route.ts
@@ -1,20 +1,19 @@
 import { revalidatePath } from 'next/cache';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
     try {
-        const body = await request.json();
+        const token = request.headers.get("x-revalidate-token");
 
-        // Very basic webhook auth to prevent public clearing
-        if (body.token !== process.env.MOTHERDUCK_TOKEN && body.token !== "local-dev-bypass") {
-            return NextResponse.json({ message: 'Invalid token' }, { status: 401 });
+        if (!token || token !== process.env.REVALIDATE_SECRET) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
         // Revalidate the entire dashboard and player routes since data refreshed
         revalidatePath('/dashboard');
         revalidatePath('/', 'layout');
 
-        console.log(`[Cache Revalidation] Triggered forcefully. Next.js will fetch new MotherDuck data.`);
+        console.log(`[Cache Revalidation] Triggered. Next.js will fetch fresh data.`);
         return NextResponse.json({ revalidated: true, now: Date.now() });
     } catch (err) {
         return NextResponse.json({ message: 'Error revalidating' }, { status: 500 });


### PR DESCRIPTION
## Summary

- **#424**: Replace static `"local-dev-bypass"` token in `/api/revalidate/route.ts` with a header-based check (`x-revalidate-token`) validated against `REVALIDATE_SECRET` env var. Eliminates the public bypass that worked in all environments.
- **#426**: Replace `allow_origins=["*"]` in `pipeline/api/main.py` with an explicit allowlist read from `ALLOWED_ORIGINS` env var (defaults to `https://cap-alpha.co`).
- Add `.env.example` documenting both new vars; `REVALIDATE_SECRET` notes to generate with `openssl rand -hex 32`.

## Test plan

- [ ] Set `REVALIDATE_SECRET=<value>` and POST `/api/revalidate` with matching `x-revalidate-token` header — should return 200
- [ ] POST without header or with wrong value — should return 401
- [ ] FastAPI: requests from `https://cap-alpha.co` pass CORS; requests from other origins are blocked
- [ ] Set `ALLOWED_ORIGINS=https://cap-alpha.co,http://localhost:3000` and confirm local dev still works
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)