### PR TITLE
fix(security): parameterize BigQuery queries — prevent SQL injection (#425)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,6 +3,7 @@
 # Pre-commit hook: lint + unit tests via local venv
 #
 # Runs ruff (format + lint) and pytest. No Docker required.
+#
 # Bootstrap: make setup
 
 set -e

--- a/pipeline/src/db_manager.py
+++ b/pipeline/src/db_manager.py
@@ -125,17 +125,28 @@ class DBManager:
 
         return query, (bind_params if bind_params else None)
 
-    def execute(self, query: str, params: Optional[Dict[str, Any]] = None):
-        """Executes a SQL query on BigQuery."""
+    def execute(
+        self,
+        query: str,
+        params: Optional[Dict[str, Any]] = None,
+        query_parameters: Optional[list] = None,
+    ):
+        """Executes a SQL query on BigQuery.
+
+        Args:
+            query: SQL query string. Use @param_name placeholders for safe parameterization.
+            params: Dict of DataFrames (uploaded as temp tables).
+            query_parameters: List of bigquery.ScalarQueryParameter / ArrayQueryParameter
+                              for safe @param substitution. Use this for any external or
+                              data-derived values to prevent SQL injection.
+        """
         try:
             processed_query, bind_params = self._handle_dataframe_params(query, params)
 
-            # BigQuery parameterization is slightly different (uses @param) but we just use format for simplicity here if bind_params passed non-DF constants.
-            # Warning: BigQuery python SDK expects parameters via QueryJobConfig, if complex params are passed we'd setup a JobConfig here.
-            # For this pipeline, usually params are purely DataFrames {"df": df} which we intercepted above!
-
             dataset_ref = bigquery.DatasetReference(self.project_id, self.dataset_id)
             job_config = bigquery.QueryJobConfig(default_dataset=dataset_ref)
+            if query_parameters:
+                job_config.query_parameters = query_parameters
             job = self.client.query(processed_query, job_config=job_config)
             job.result()  # Wait for query to complete to catch errors and prevent premature temp table deletion
             return BQResultProxy(job)
@@ -144,13 +155,26 @@ class DBManager:
             raise
 
     def fetch_df(
-        self, query: str, params: Optional[Dict[str, Any]] = None
+        self,
+        query: str,
+        params: Optional[Dict[str, Any]] = None,
+        query_parameters: Optional[list] = None,
     ) -> pd.DataFrame:
-        """Executes a query and returns a Pandas DataFrame."""
+        """Executes a query and returns a Pandas DataFrame.
+
+        Args:
+            query: SQL query string. Use @param_name placeholders for safe parameterization.
+            params: Dict of DataFrames (uploaded as temp tables).
+            query_parameters: List of bigquery.ScalarQueryParameter / ArrayQueryParameter
+                              for safe @param substitution. Use this for any external or
+                              data-derived values to prevent SQL injection.
+        """
         try:
             processed_query, bind_params = self._handle_dataframe_params(query, params)
             dataset_ref = bigquery.DatasetReference(self.project_id, self.dataset_id)
             job_config = bigquery.QueryJobConfig(default_dataset=dataset_ref)
+            if query_parameters:
+                job_config.query_parameters = query_parameters
             job = self.client.query(processed_query, job_config=job_config)
             return job.to_dataframe()
         except Exception as e:

--- a/pipeline/src/generate_sentiment_features.py
+++ b/pipeline/src/generate_sentiment_features.py
@@ -7,6 +7,7 @@ import urllib.error
 import urllib.request
 
 import pandas as pd
+from google.cloud import bigquery
 from tqdm import tqdm
 
 # Add pipeline root to path
@@ -90,8 +91,16 @@ def main():
             logger.warning(f"Wikipedia hover failed for {player}: {e}")
 
         # 1. Fetch Recent News/Media Baseline
-        media_query = f"SELECT raw_text FROM bronze_layer.raw_media_sentiment WHERE player_name = '{player}' ORDER BY ingested_at DESC LIMIT 1"
-        media_df = db.fetch_df(media_query)
+        media_query = (
+            "SELECT raw_text FROM bronze_layer.raw_media_sentiment"
+            " WHERE player_name = @player_name ORDER BY ingested_at DESC LIMIT 1"
+        )
+        media_df = db.fetch_df(
+            media_query,
+            query_parameters=[
+                bigquery.ScalarQueryParameter("player_name", "STRING", player)
+            ],
+        )
         media_text = (
             media_df["raw_text"].iloc[0]
             if not media_df.empty
@@ -99,8 +108,17 @@ def main():
         )
 
         # 2. Fetch Aggregated Injury History
-        injury_query = f"SELECT report_primary_injury, practice_status, report_status FROM bronze_layer.nflverse_injuries WHERE full_name = '{player}' AND report_primary_injury IS NOT NULL LIMIT 50"
-        injury_df = db.fetch_df(injury_query)
+        injury_query = (
+            "SELECT report_primary_injury, practice_status, report_status"
+            " FROM bronze_layer.nflverse_injuries"
+            " WHERE full_name = @player_name AND report_primary_injury IS NOT NULL LIMIT 50"
+        )
+        injury_df = db.fetch_df(
+            injury_query,
+            query_parameters=[
+                bigquery.ScalarQueryParameter("player_name", "STRING", player)
+            ],
+        )
         injury_text = "No severe injuries reported."
         if not injury_df.empty:
             injury_logs = injury_df.to_dict("records")

--- a/pipeline/src/resolution_engine.py
+++ b/pipeline/src/resolution_engine.py
@@ -96,6 +96,8 @@ def record_resolution(result: ResolutionResult, db: Optional[DBManager] = None) 
         project_id = os.environ.get("GCP_PROJECT_ID")
         now = datetime.now(timezone.utc).isoformat()
 
+        # Numeric/boolean literals are safe to inline because they come from Python
+        # dataclass fields (floats and bools), not from external/data-derived strings.
         brier = f"{result.brier_score}" if result.brier_score is not None else "NULL"
         binary = (
             "TRUE"
@@ -108,40 +110,57 @@ def record_resolution(result: ResolutionResult, db: Optional[DBManager] = None) 
             f"{result.weighted_score}" if result.weighted_score is not None else "NULL"
         )
 
-        def _q(s: Optional[str]) -> str:
-            if s is None:
-                return "NULL"
-            return "'" + s.replace("'", "\\'") + "'"
-
+        # All string values from external/data-derived sources go through @params.
         merge_sql = f"""
             MERGE `{project_id}.{RESOLUTIONS_TABLE}` T
-            USING (SELECT '{result.prediction_hash}' AS prediction_hash) S
+            USING (SELECT @prediction_hash AS prediction_hash) S
             ON T.prediction_hash = S.prediction_hash
             WHEN MATCHED THEN UPDATE SET
-                resolution_status     = '{result.resolution_status}',
-                resolved_at           = '{now}',
-                resolver              = '{result.resolver}',
+                resolution_status     = @resolution_status,
+                resolved_at           = @resolved_at,
+                resolver              = @resolver,
                 brier_score           = {brier},
                 binary_correct        = {binary},
                 timeliness_weight     = {result.timeliness_weight},
                 weighted_score        = {weighted},
-                outcome_source        = {_q(result.outcome_source)},
-                outcome_reference_id  = {_q(result.outcome_reference_id)},
-                outcome_notes         = {_q(result.outcome_notes)},
-                updated_at            = '{now}'
+                outcome_source        = @outcome_source,
+                outcome_reference_id  = @outcome_reference_id,
+                outcome_notes         = @outcome_notes,
+                updated_at            = @updated_at
             WHEN NOT MATCHED THEN INSERT (
                 prediction_hash, resolution_status, resolved_at, resolver,
                 brier_score, binary_correct, timeliness_weight, weighted_score,
                 outcome_source, outcome_reference_id, outcome_notes,
                 created_at, updated_at
             ) VALUES (
-                '{result.prediction_hash}', '{result.resolution_status}', '{now}', '{result.resolver}',
+                @prediction_hash, @resolution_status, @resolved_at, @resolver,
                 {brier}, {binary}, {result.timeliness_weight}, {weighted},
-                {_q(result.outcome_source)}, {_q(result.outcome_reference_id)}, {_q(result.outcome_notes)},
-                '{now}', '{now}'
+                @outcome_source, @outcome_reference_id, @outcome_notes,
+                @created_at, @created_at
             )
         """
-        db.execute(merge_sql)
+        query_parameters = [
+            bigquery.ScalarQueryParameter(
+                "prediction_hash", "STRING", result.prediction_hash
+            ),
+            bigquery.ScalarQueryParameter(
+                "resolution_status", "STRING", result.resolution_status
+            ),
+            bigquery.ScalarQueryParameter("resolved_at", "STRING", now),
+            bigquery.ScalarQueryParameter("resolver", "STRING", result.resolver),
+            bigquery.ScalarQueryParameter(
+                "outcome_source", "STRING", result.outcome_source
+            ),
+            bigquery.ScalarQueryParameter(
+                "outcome_reference_id", "STRING", result.outcome_reference_id
+            ),
+            bigquery.ScalarQueryParameter(
+                "outcome_notes", "STRING", result.outcome_notes
+            ),
+            bigquery.ScalarQueryParameter("updated_at", "STRING", now),
+            bigquery.ScalarQueryParameter("created_at", "STRING", now),
+        ]
+        db.execute(merge_sql, query_parameters=query_parameters)
         logger.info(
             f"Recorded resolution for {result.prediction_hash[:16]}…: "
             f"{result.resolution_status} (resolver={result.resolver})"
@@ -276,7 +295,7 @@ def get_pending_predictions(
 
     try:
         project_id = os.environ.get("GCP_PROJECT_ID")
-        sport_filter = f"AND COALESCE(l.sport, 'NFL') = '{sport}'" if sport else ""
+        sport_filter = "AND COALESCE(l.sport, 'NFL') = @sport" if sport else ""
         query = f"""
             SELECT
                 l.prediction_hash,
@@ -296,7 +315,10 @@ def get_pending_predictions(
               {sport_filter}
             ORDER BY l.ingestion_timestamp ASC
         """
-        return db.fetch_df(query)
+        query_parameters = (
+            [bigquery.ScalarQueryParameter("sport", "STRING", sport)] if sport else []
+        )
+        return db.fetch_df(query, query_parameters=query_parameters)
     finally:
         if close_db:
             db.close()
@@ -322,7 +344,7 @@ def get_pundit_accuracy_summary(
         project_id = os.environ.get("GCP_PROJECT_ID")
         where_clauses = []
         if sport:
-            where_clauses.append(f"COALESCE(l.sport, 'NFL') = '{sport}'")
+            where_clauses.append("COALESCE(l.sport, 'NFL') = @sport")
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
         quality_join = ""
@@ -332,7 +354,6 @@ def get_pundit_accuracy_summary(
                 f"ON l.prediction_hash = q.prediction_hash "
                 f"AND q.quality_score >= {float(min_quality)}"
             )
-
         query = f"""
             SELECT
                 l.pundit_id,
@@ -355,7 +376,10 @@ def get_pundit_accuracy_summary(
             GROUP BY l.pundit_id, l.pundit_name, sport
             ORDER BY avg_weighted_score DESC NULLS LAST
         """
-        return db.fetch_df(query)
+        query_parameters = (
+            [bigquery.ScalarQueryParameter("sport", "STRING", sport)] if sport else []
+        )
+        return db.fetch_df(query, query_parameters=query_parameters)
     finally:
         if close_db:
             db.close()

--- a/pipeline/src/resolution_engine.py
+++ b/pipeline/src/resolution_engine.py
@@ -94,7 +94,10 @@ def record_resolution(result: ResolutionResult, db: Optional[DBManager] = None) 
 
     try:
         project_id = os.environ.get("GCP_PROJECT_ID")
-        now = datetime.now(timezone.utc).isoformat()
+        # Keep now as a timezone-aware datetime so it can be bound as a TIMESTAMP
+        # parameter.  Binding ISO strings as STRING to TIMESTAMP columns causes
+        # BigQuery type-mismatch errors during the MERGE.
+        now = datetime.now(timezone.utc)
 
         # Numeric/boolean literals are safe to inline because they come from Python
         # dataclass fields (floats and bools), not from external/data-derived strings.
@@ -146,7 +149,7 @@ def record_resolution(result: ResolutionResult, db: Optional[DBManager] = None) 
             bigquery.ScalarQueryParameter(
                 "resolution_status", "STRING", result.resolution_status
             ),
-            bigquery.ScalarQueryParameter("resolved_at", "STRING", now),
+            bigquery.ScalarQueryParameter("resolved_at", "TIMESTAMP", now),
             bigquery.ScalarQueryParameter("resolver", "STRING", result.resolver),
             bigquery.ScalarQueryParameter(
                 "outcome_source", "STRING", result.outcome_source
@@ -157,8 +160,8 @@ def record_resolution(result: ResolutionResult, db: Optional[DBManager] = None) 
             bigquery.ScalarQueryParameter(
                 "outcome_notes", "STRING", result.outcome_notes
             ),
-            bigquery.ScalarQueryParameter("updated_at", "STRING", now),
-            bigquery.ScalarQueryParameter("created_at", "STRING", now),
+            bigquery.ScalarQueryParameter("updated_at", "TIMESTAMP", now),
+            bigquery.ScalarQueryParameter("created_at", "TIMESTAMP", now),
         ]
         db.execute(merge_sql, query_parameters=query_parameters)
         logger.info(

--- a/pipeline/tests/test_resolution_engine.py
+++ b/pipeline/tests/test_resolution_engine.py
@@ -146,8 +146,10 @@ class TestRecordResolution:
             resolver="manual",
         )
         record_resolution(result, db=mock_db)
-        call_sql = mock_db.execute.call_args[0][0]
-        assert FAKE_HASH in call_sql
+        # Values are now passed as query_parameters (not inlined in SQL) to prevent SQL injection.
+        call_kwargs = mock_db.execute.call_args[1]
+        param_values = {p.name: p.value for p in call_kwargs["query_parameters"]}
+        assert param_values["prediction_hash"] == FAKE_HASH
 
     def test_void_uses_null_scores(self, mock_db):
         result = ResolutionResult(
@@ -157,8 +159,10 @@ class TestRecordResolution:
             outcome_notes="Player never played",
         )
         record_resolution(result, db=mock_db)
-        call_sql = mock_db.execute.call_args[0][0]
-        assert "VOID" in call_sql
+        # Values are now passed as query_parameters (not inlined in SQL) to prevent SQL injection.
+        call_kwargs = mock_db.execute.call_args[1]
+        param_values = {p.name: p.value for p in call_kwargs["query_parameters"]}
+        assert param_values["resolution_status"] == "VOID"
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_sport_field.py
+++ b/pipeline/tests/test_sport_field.py
@@ -478,27 +478,33 @@ class TestResolutionEngineSportFilter:
     def test_get_pending_with_nfl_filter(self):
         db = self._make_mock_db()
         get_pending_predictions(sport="NFL", db=db)
-        query = db.fetch_df.call_args[0][0]
-        assert "NFL" in query
+        # Sport value is now passed as a query_parameter to prevent SQL injection.
+        call_kwargs = db.fetch_df.call_args[1]
+        param_values = {p.name: p.value for p in call_kwargs["query_parameters"]}
+        assert param_values["sport"] == "NFL"
 
     def test_get_pending_with_mlb_filter(self):
         db = self._make_mock_db()
         get_pending_predictions(sport="MLB", db=db)
-        query = db.fetch_df.call_args[0][0]
-        assert "MLB" in query
+        # Sport value is now passed as a query_parameter to prevent SQL injection.
+        call_kwargs = db.fetch_df.call_args[1]
+        param_values = {p.name: p.value for p in call_kwargs["query_parameters"]}
+        assert param_values["sport"] == "MLB"
 
     def test_get_accuracy_summary_no_sport_filter(self):
         db = self._make_mock_db()
         get_pundit_accuracy_summary(db=db)
-        query = db.fetch_df.call_args[0][0]
-        # No WHERE clause when sport not specified
-        assert "MLB" not in query and "NBA" not in query
+        # No query_parameters when sport is not specified.
+        call_kwargs = db.fetch_df.call_args[1]
+        assert not call_kwargs.get("query_parameters")
 
     def test_get_accuracy_summary_with_nfl_filter(self):
         db = self._make_mock_db()
         get_pundit_accuracy_summary(sport="NFL", db=db)
-        query = db.fetch_df.call_args[0][0]
-        assert "NFL" in query
+        # Sport value is now passed as a query_parameter to prevent SQL injection.
+        call_kwargs = db.fetch_df.call_args[1]
+        param_values = {p.name: p.value for p in call_kwargs["query_parameters"]}
+        assert param_values["sport"] == "NFL"
 
     def test_get_accuracy_summary_returns_sport_column(self):
         """Verifies sport is in the SELECT clause of the summary query."""

--- a/web/app/api/ledger/recent/route.ts
+++ b/web/app/api/ledger/recent/route.ts
@@ -12,6 +12,7 @@ export async function GET(req: Request) {
 
     const { searchParams } = new URL(req.url);
     const parsed = parseInt(searchParams.get("limit") ?? "");
+    // Guard against NaN (e.g. ?limit=foo) — fall back to default before clamping.
     const limit = Number.isFinite(parsed) ? Math.min(parsed, 100) : 20;
     const sport = searchParams.get("sport");
     const punditId = searchParams.get("pundit_id");


### PR DESCRIPTION
## Summary
- Fixes High security finding: f-string SQL interpolation of external/data-derived values in `generate_sentiment_features.py` and `resolution_engine.py` was exploitable via bronze-layer data poisoning
- Added `query_parameters` kwarg to `DBManager.execute` and `fetch_df` supporting `bigquery.ScalarQueryParameter` lists with `@param` syntax
- Replaced all 5 injection points with parameterized queries: `player_name` lookups (2), sport filter in pending/summary queries (2), and all string fields in the MERGE upsert (1)
- Updated 5 test assertions that checked for literal values in SQL strings to check `query_parameters` instead

## Test plan
- [x] `make test` — 520 passed, 24 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` — all clean
- [x] Pre-commit hook passed

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)