### PR TITLE
feat(ops): GitHub App identity — replace Lars PAT with installation tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 > - **Never edit files in the main checkout.** A PreToolUse hook (`.claude/hooks/require-worktree.sh`) blocks Edit/Write/MultiEdit when CWD is the main repo. If you see that error, switch to a worktree.
 > - **Use `EnterWorktree` first**, or run `git worktree add .claude/worktrees/<name> -b <branch>` and `cd` into it before any edit.
 > - **Land PRs with `gh pr merge <n> --rebase --auto`** (rebase only — no squash, no merge commits). Squash and merge-commit are disabled at the repo level; `main` requires linear history.
-> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Identity is the **`nfl-dead-money-triage` GitHub App** (App ID 3545386, installed on `cap-alpha` org). Tokens are minted automatically by `scripts/gh-app-token.sh` — no PAT needed. PEM lives at `~/.ghconfig/triage-app.pem` on the dev machine (never committed).
+> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Identity is the **`nfl-dead-money-triage` GitHub App** (App ID 3545386, installed on `cap-alpha` org). Tokens are minted automatically by `scripts/gh-app-token.sh` — no PAT needed. The PEM is read from the path configured by `scripts/gh-app-token.sh` on the dev machine (never committed).
 > - **Why:** concurrent agents in the same checkout cause branch switches, vanishing edits, and merge conflicts. Worktrees give physical isolation; the merge queue serializes landings and re-runs CI on the combined state.
 >
 > Established 2026-04-07 after multi-agent coordination failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 > - **Never edit files in the main checkout.** A PreToolUse hook (`.claude/hooks/require-worktree.sh`) blocks Edit/Write/MultiEdit when CWD is the main repo. If you see that error, switch to a worktree.
 > - **Use `EnterWorktree` first**, or run `git worktree add .claude/worktrees/<name> -b <branch>` and `cd` into it before any edit.
 > - **Land PRs with `gh pr merge <n> --rebase --auto`** (rebase only — no squash, no merge commits). Squash and merge-commit are disabled at the repo level; `main` requires linear history.
-> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Lars Bakken (`kinghrothgar-dev`) is the default GitHub identity. Token stored in `.env.personas` (git-ignored).
+> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Identity is the **`nfl-dead-money-triage` GitHub App** (App ID 3545386, installed on `cap-alpha` org). Tokens are minted automatically by `scripts/gh-app-token.sh` — no PAT needed. PEM lives at `~/.ghconfig/triage-app.pem` on the dev machine (never committed).
 > - **Why:** concurrent agents in the same checkout cause branch switches, vanishing edits, and merge conflicts. Worktrees give physical isolation; the merge queue serializes landings and re-runs CI on the combined state.
 >
 > Established 2026-04-07 after multi-agent coordination failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 > - **Never edit files in the main checkout.** A PreToolUse hook (`.claude/hooks/require-worktree.sh`) blocks Edit/Write/MultiEdit when CWD is the main repo. If you see that error, switch to a worktree.
 > - **Use `EnterWorktree` first**, or run `git worktree add .claude/worktrees/<name> -b <branch>` and `cd` into it before any edit.
 > - **Land PRs with `gh pr merge <n> --rebase --auto`** (rebase only — no squash, no merge commits). Squash and merge-commit are disabled at the repo level; `main` requires linear history.
-> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Identity is the **`nfl-dead-money-triage` GitHub App** (App ID 3545386, installed on `cap-alpha` org). Tokens are minted automatically by `scripts/gh-app-token.sh` — no PAT needed. The PEM is read from the path configured by `scripts/gh-app-token.sh` on the dev machine (never committed).
+> - **All `gh` issue/PR/comment operations MUST use `scripts/gh-lars`** instead of bare `gh`. Identity is the **`cap-alpha-workflow-automation` GitHub App**. Tokens are minted automatically by `scripts/gh-app-token.sh` using `GH_APP_ID` and `GH_INSTALLATION_ID` from `.env.personas` (gitignored). PEM at `~/.ghconfig/triage-app.pem` on each dev machine (never committed).
 > - **Why:** concurrent agents in the same checkout cause branch switches, vanishing edits, and merge conflicts. Worktrees give physical isolation; the merge queue serializes landings and re-runs CI on the combined state.
 >
 > Established 2026-04-07 after multi-agent coordination failures.

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -69,11 +69,22 @@ response=$(curl -sf -X POST \
 }
 
 python3 - "$response" "$CACHE_FILE" <<'PYEOF'
-import json, os, sys
+import json, os, sys, tempfile
 response_str, cache_file = sys.argv[1], sys.argv[2]
 d = json.loads(response_str)
-with open(cache_file, "w") as f:
-    json.dump({"token": d["token"], "expires_at": d["expires_at"]}, f)
-os.chmod(cache_file, 0o600)
+cache_dir = os.path.dirname(cache_file) or "."
+os.makedirs(cache_dir, exist_ok=True)
+fd, temp_cache_file = tempfile.mkstemp(dir=cache_dir)
+try:
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"token": d["token"], "expires_at": d["expires_at"]}, f)
+    os.replace(temp_cache_file, cache_file)
+except Exception:
+    try:
+        os.unlink(temp_cache_file)
+    except FileNotFoundError:
+        pass
+    raise
 sys.stdout.write(d["token"])
 PYEOF

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -1,20 +1,33 @@
 #!/usr/bin/env bash
 # gh-app-token.sh — Mint or reuse a GitHub App installation token.
 #
-# Auth identity: the `nfl-dead-money-triage` GitHub App, owned by `ucalegon206`,
-# installed on the `cap-alpha` org (with access scoped to `cap-alpha-protocol`).
+# Required env vars:
+#   GH_APP_ID           — numeric GitHub App ID
+#   GH_INSTALLATION_ID  — installation ID for the target org (find via: gh api /app/installations)
+#   GH_APP_PEM          — path to the App's RSA private key (default: ~/.ghconfig/triage-app.pem)
+#
 # Installation tokens last 1 hour and are cached at $CACHE_FILE; we refresh
 # when <5 min remain.
 #
-# Output: the installation token on stdout (single line, no trailing newline-only output).
-# Errors: write to stderr with non-zero exit.
-#
-# Override defaults via env: GH_APP_ID, GH_INSTALLATION_ID, GH_APP_PEM.
+# Output: the installation token on stdout (single line, no trailing newline).
+# Errors: written to stderr with non-zero exit.
 
 set -euo pipefail
 
 APP_ID="${GH_APP_ID:-3545386}"
-INSTALLATION_ID="${GH_INSTALLATION_ID:-128138694}"
+
+if ! [[ "$APP_ID" =~ ^[0-9]+$ ]]; then
+    echo "gh-app-token: GH_APP_ID must be numeric, got: $APP_ID" >&2
+    exit 1
+fi
+
+if [[ -z "${GH_INSTALLATION_ID:-}" ]]; then
+    echo "gh-app-token: GH_INSTALLATION_ID must be set (numeric installation ID for the target org)." >&2
+    echo "  Find it with: GH_TOKEN=<jwt> gh api /app/installations" >&2
+    exit 1
+fi
+INSTALLATION_ID="${GH_INSTALLATION_ID}"
+
 PEM_PATH="${GH_APP_PEM:-${HOME}/.ghconfig/triage-app.pem}"
 CACHE_DIR="${HOME}/.cache/nfl-dead-money"
 CACHE_FILE="${CACHE_DIR}/gh-app-token.json"
@@ -55,7 +68,8 @@ b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
 header_b64=$(printf '{"typ":"JWT","alg":"RS256"}' | b64url)
 iat=$(date -u +%s)
 exp=$(( iat + 540 ))   # 9 min — GitHub caps at 10
-payload_b64=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$iat" "$exp" "$APP_ID" | b64url)
+# iss must be a numeric claim per GitHub App JWT spec — no quotes around APP_ID.
+payload_b64=$(printf '{"iat":%d,"exp":%d,"iss":%d}' "$iat" "$exp" "$APP_ID" | b64url)
 signing_input="${header_b64}.${payload_b64}"
 sig_b64=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$PEM_PATH" -binary | b64url)
 jwt="${signing_input}.${sig_b64}"
@@ -69,7 +83,7 @@ http_status=$(curl -sS -X POST \
     -w '%{http_code}' \
     "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens") || {
     rm -f "$response_file"
-    echo "gh-app-token: failed to exchange JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID)" >&2
+    echo "gh-app-token: curl failed when exchanging JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID)" >&2
     exit 1
 }
 

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 APP_ID="${GH_APP_ID:-3545386}"
 INSTALLATION_ID="${GH_INSTALLATION_ID:-128138694}"
-PEM_PATH="${GH_APP_PEM:-/Users/andrewsmith/portfolio/.ghconfig/triage-app.pem}"
+PEM_PATH="${GH_APP_PEM:-${HOME}/.ghconfig/triage-app.pem}"
 CACHE_DIR="${HOME}/.cache/nfl-dead-money"
 CACHE_FILE="${CACHE_DIR}/gh-app-token.json"
 

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -2,8 +2,9 @@
 # gh-app-token.sh — Mint or reuse a GitHub App installation token.
 #
 # Auth identity: the `nfl-dead-money-triage` GitHub App, owned by `ucalegon206`,
-# installed on `cap-alpha/cap-alpha-protocol`. Installation tokens last 1 hour
-# and are cached at $CACHE_FILE; we refresh when <5 min remain.
+# installed on the `cap-alpha` org (with access scoped to `cap-alpha-protocol`).
+# Installation tokens last 1 hour and are cached at $CACHE_FILE; we refresh
+# when <5 min remain.
 #
 # Output: the installation token on stdout (single line, no trailing newline-only output).
 # Errors: write to stderr with non-zero exit.

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -59,14 +59,29 @@ signing_input="${header_b64}.${payload_b64}"
 sig_b64=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$PEM_PATH" -binary | b64url)
 jwt="${signing_input}.${sig_b64}"
 
-response=$(curl -sf -X POST \
+response_file=$(mktemp)
+http_status=$(curl -sS -X POST \
     -H "Authorization: Bearer $jwt" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
+    -o "$response_file" \
+    -w '%{http_code}' \
     "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens") || {
+    rm -f "$response_file"
     echo "gh-app-token: failed to exchange JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID)" >&2
     exit 1
 }
+
+response=$(cat "$response_file")
+if [[ ! "$http_status" =~ ^2 ]]; then
+    echo "gh-app-token: failed to exchange JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID, HTTP $http_status)" >&2
+    if [[ -n "$response" ]]; then
+        printf '%s\n' "$response" >&2
+    fi
+    rm -f "$response_file"
+    exit 1
+fi
+rm -f "$response_file"
 
 python3 - "$response" "$CACHE_FILE" <<'PYEOF'
 import json, os, sys, tempfile

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -51,14 +51,18 @@ fi
 
 mkdir -p "$CACHE_DIR"
 
-# Try cache first.
+# Try cache first — only reuse if app_id + installation_id still match.
 if [[ -f "$CACHE_FILE" ]]; then
-    cached_token=$(python3 - "$CACHE_FILE" <<'PYEOF' 2>/dev/null || true
+    cached_token=$(python3 - "$CACHE_FILE" "$APP_ID" "$INSTALLATION_ID" <<'PYEOF' 2>/dev/null || true
 import json, sys
 from datetime import datetime, timezone
-cache_file = sys.argv[1]
+cache_file, expected_app_id, expected_install_id = sys.argv[1], sys.argv[2], sys.argv[3]
 try:
     d = json.load(open(cache_file))
+    if str(d.get("app_id")) != expected_app_id:
+        sys.exit(0)
+    if str(d.get("installation_id")) != expected_install_id:
+        sys.exit(0)
     exp = datetime.fromisoformat(d["expires_at"].replace("Z", "+00:00"))
     if (exp - datetime.now(timezone.utc)).total_seconds() > 300:
         print(d["token"])
@@ -114,9 +118,9 @@ if [[ ! "$http_status" =~ ^2 ]]; then
 fi
 rm -f "$response_file"
 
-python3 - "$response" "$CACHE_FILE" <<'PYEOF'
+python3 - "$response" "$CACHE_FILE" "$APP_ID" "$INSTALLATION_ID" <<'PYEOF'
 import json, os, sys, tempfile
-response_str, cache_file = sys.argv[1], sys.argv[2]
+response_str, cache_file, app_id, installation_id = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 d = json.loads(response_str)
 cache_dir = os.path.dirname(cache_file) or "."
 os.makedirs(cache_dir, exist_ok=True)
@@ -124,7 +128,12 @@ fd, temp_cache_file = tempfile.mkstemp(dir=cache_dir)
 try:
     os.fchmod(fd, 0o600)
     with os.fdopen(fd, "w") as f:
-        json.dump({"token": d["token"], "expires_at": d["expires_at"]}, f)
+        json.dump({
+            "token": d["token"],
+            "expires_at": d["expires_at"],
+            "app_id": app_id,
+            "installation_id": installation_id,
+        }, f)
     os.replace(temp_cache_file, cache_file)
 except Exception:
     try:

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# gh-app-token.sh — Mint or reuse a GitHub App installation token.
+#
+# Auth identity: the `nfl-dead-money-triage` GitHub App, owned by `ucalegon206`,
+# installed on `cap-alpha/cap-alpha-protocol`. Installation tokens last 1 hour
+# and are cached at $CACHE_FILE; we refresh when <5 min remain.
+#
+# Output: the installation token on stdout (single line, no trailing newline-only output).
+# Errors: write to stderr with non-zero exit.
+#
+# Override defaults via env: GH_APP_ID, GH_INSTALLATION_ID, GH_APP_PEM.
+
+set -euo pipefail
+
+APP_ID="${GH_APP_ID:-3545386}"
+INSTALLATION_ID="${GH_INSTALLATION_ID:-128138694}"
+PEM_PATH="${GH_APP_PEM:-/Users/andrewsmith/portfolio/.ghconfig/triage-app.pem}"
+CACHE_DIR="${HOME}/.cache/nfl-dead-money"
+CACHE_FILE="${CACHE_DIR}/gh-app-token.json"
+
+if [[ ! -f "$PEM_PATH" ]]; then
+    echo "gh-app-token: private key not found at $PEM_PATH" >&2
+    echo "  Set GH_APP_PEM env var or place the App's .pem at the default path." >&2
+    exit 1
+fi
+
+mkdir -p "$CACHE_DIR"
+
+# Try cache first.
+if [[ -f "$CACHE_FILE" ]]; then
+    cached_token=$(python3 - "$CACHE_FILE" <<'PYEOF' 2>/dev/null || true
+import json, sys
+from datetime import datetime, timezone
+cache_file = sys.argv[1]
+try:
+    d = json.load(open(cache_file))
+    exp = datetime.fromisoformat(d["expires_at"].replace("Z", "+00:00"))
+    if (exp - datetime.now(timezone.utc)).total_seconds() > 300:
+        print(d["token"])
+except Exception:
+    pass
+PYEOF
+    )
+    if [[ -n "${cached_token:-}" ]]; then
+        printf '%s' "$cached_token"
+        exit 0
+    fi
+fi
+
+# Cache miss or stale — mint a fresh JWT, exchange for an installation token.
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+header_b64=$(printf '{"typ":"JWT","alg":"RS256"}' | b64url)
+iat=$(date -u +%s)
+exp=$(( iat + 540 ))   # 9 min — GitHub caps at 10
+payload_b64=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$iat" "$exp" "$APP_ID" | b64url)
+signing_input="${header_b64}.${payload_b64}"
+sig_b64=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$PEM_PATH" -binary | b64url)
+jwt="${signing_input}.${sig_b64}"
+
+response=$(curl -sf -X POST \
+    -H "Authorization: Bearer $jwt" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens") || {
+    echo "gh-app-token: failed to exchange JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID)" >&2
+    exit 1
+}
+
+python3 - "$response" "$CACHE_FILE" <<'PYEOF'
+import json, os, sys
+response_str, cache_file = sys.argv[1], sys.argv[2]
+d = json.loads(response_str)
+with open(cache_file, "w") as f:
+    json.dump({"token": d["token"], "expires_at": d["expires_at"]}, f)
+os.chmod(cache_file, 0o600)
+sys.stdout.write(d["token"])
+PYEOF

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -86,17 +86,22 @@ sig_b64=$(printf '%s' "$signing_input" | openssl dgst -sha256 -sign "$PEM_PATH" 
 jwt="${signing_input}.${sig_b64}"
 
 response_file=$(mktemp)
-http_status=$(curl -sS -X POST \
-    -H "Authorization: Bearer $jwt" \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
+curl_config_file=$(mktemp)
+chmod 600 "$curl_config_file"
+cat >"$curl_config_file" <<EOF
+url = "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens"
+header = "Authorization: Bearer $jwt"
+header = "Accept: application/vnd.github+json"
+header = "X-GitHub-Api-Version: 2022-11-28"
+EOF
+http_status=$(curl -sS --config "$curl_config_file" -X POST \
     -o "$response_file" \
-    -w '%{http_code}' \
-    "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens") || {
-    rm -f "$response_file"
+    -w '%{http_code}') || {
+    rm -f "$response_file" "$curl_config_file"
     echo "gh-app-token: curl failed when exchanging JWT for installation token (App ID $APP_ID, install $INSTALLATION_ID)" >&2
     exit 1
 }
+rm -f "$curl_config_file"
 
 response=$(cat "$response_file")
 if [[ ! "$http_status" =~ ^2 ]]; then

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -14,7 +14,12 @@
 
 set -euo pipefail
 
-APP_ID="${GH_APP_ID:-3545386}"
+if [[ -z "${GH_APP_ID:-}" ]]; then
+    echo "gh-app-token: GH_APP_ID must be set (numeric GitHub App ID)." >&2
+    echo "  Set it in .env.personas or export GH_APP_ID." >&2
+    exit 1
+fi
+APP_ID="$GH_APP_ID"
 
 if ! [[ "$APP_ID" =~ ^[0-9]+$ ]]; then
     echo "gh-app-token: GH_APP_ID must be numeric, got: $APP_ID" >&2
@@ -22,8 +27,8 @@ if ! [[ "$APP_ID" =~ ^[0-9]+$ ]]; then
 fi
 
 if [[ -z "${GH_INSTALLATION_ID:-}" ]]; then
-    echo "gh-app-token: GH_INSTALLATION_ID must be set (numeric installation ID for the target org)." >&2
-    echo "  Find it with: GH_TOKEN=<jwt> gh api /app/installations" >&2
+    echo "gh-app-token: GH_INSTALLATION_ID must be set (numeric installation ID)." >&2
+    echo "  Set it in .env.personas or export GH_INSTALLATION_ID." >&2
     exit 1
 fi
 INSTALLATION_ID="${GH_INSTALLATION_ID}"

--- a/scripts/gh-app-token.sh
+++ b/scripts/gh-app-token.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # gh-app-token.sh — Mint or reuse a GitHub App installation token.
 #
-# Required env vars:
+# Required env vars (no defaults — set in .env.personas):
 #   GH_APP_ID           — numeric GitHub App ID
-#   GH_INSTALLATION_ID  — installation ID for the target org (find via: gh api /app/installations)
-#   GH_APP_PEM          — path to the App's RSA private key (default: ~/.ghconfig/triage-app.pem)
+#   GH_INSTALLATION_ID  — numeric installation ID (find via: gh api /app/installations)
+#
+# Optional env var:
+#   GH_APP_PEM          — path to RSA private key (default: ~/.ghconfig/triage-app.pem)
 #
 # Installation tokens last 1 hour and are cached at $CACHE_FILE; we refresh
 # when <5 min remain.
@@ -29,6 +31,10 @@ fi
 if [[ -z "${GH_INSTALLATION_ID:-}" ]]; then
     echo "gh-app-token: GH_INSTALLATION_ID must be set (numeric installation ID)." >&2
     echo "  Set it in .env.personas or export GH_INSTALLATION_ID." >&2
+    exit 1
+fi
+if ! [[ "$GH_INSTALLATION_ID" =~ ^[0-9]+$ ]]; then
+    echo "gh-app-token: GH_INSTALLATION_ID must be numeric, got: $GH_INSTALLATION_ID" >&2
     exit 1
 fi
 INSTALLATION_ID="${GH_INSTALLATION_ID}"

--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -12,11 +12,27 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve main repo root — works from worktrees too (git-common-dir points to main .git).
+MAIN_REPO="$(cd "$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir)/.." && pwd)"
 TOKEN_SCRIPT="${SCRIPT_DIR}/gh-app-token.sh"
+PERSONAS_FILE="${MAIN_REPO}/.env.personas"
+
+# Source .env.personas to pick up GH_INSTALLATION_ID (and Slack creds) if not
+# already set — lets agents call gh-lars without pre-sourcing the file themselves.
+if [[ -z "${GH_INSTALLATION_ID:-}" && -f "$PERSONAS_FILE" ]]; then
+    set -a; source "$PERSONAS_FILE"; set +a
+fi
 
 if [[ ! -x "$TOKEN_SCRIPT" ]]; then
     echo "gh-lars: token script not found or not executable: $TOKEN_SCRIPT" >&2
     exit 1
 fi
 
-GH_TOKEN="$("$TOKEN_SCRIPT")" exec gh "$@"
+# Explicitly capture + check token — bash set -e doesn't fire on $() failures.
+GH_TOKEN="$("$TOKEN_SCRIPT")"
+if [[ -z "$GH_TOKEN" ]]; then
+    echo "gh-lars: gh-app-token.sh returned empty token" >&2
+    exit 1
+fi
+export GH_TOKEN
+exec gh "$@"

--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -17,9 +17,10 @@ MAIN_REPO="$(cd "$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir)/.." && pwd)"
 TOKEN_SCRIPT="${SCRIPT_DIR}/gh-app-token.sh"
 PERSONAS_FILE="${MAIN_REPO}/.env.personas"
 
-# Source .env.personas to pick up GH_INSTALLATION_ID (and Slack creds) if not
-# already set — lets agents call gh-lars without pre-sourcing the file themselves.
-if [[ -z "${GH_INSTALLATION_ID:-}" && -f "$PERSONAS_FILE" ]]; then
+# Source .env.personas to pick up required GitHub App settings (and Slack creds)
+# when either GH_APP_ID or GH_INSTALLATION_ID is not already set — lets agents
+# call gh-lars without pre-sourcing the file themselves.
+if [[ -f "$PERSONAS_FILE" ]] && [[ -z "${GH_APP_ID:-}" || -z "${GH_INSTALLATION_ID:-}" ]]; then
     set -a; source "$PERSONAS_FILE"; set +a
 fi
 

--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# gh-lars — gh CLI wrapper authenticated as the nfl-dead-money-triage GitHub App.
+#
+# Replaces the previous LARS_TOKEN PAT approach with installation tokens minted
+# by scripts/gh-app-token.sh. Tokens last 1 hour and are cached automatically.
+#
+# Usage: identical to `gh` — just call `gh-lars <gh-args>`
+#
+# Rate limits: GitHub App installation tokens get 5,000 req/hr per installation,
+# vs ~1,000/hr for PATs (and much lower for new accounts). No more abuse flags.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOKEN_SCRIPT="${SCRIPT_DIR}/gh-app-token.sh"
+
+if [[ ! -x "$TOKEN_SCRIPT" ]]; then
+    echo "gh-lars: token script not found or not executable: $TOKEN_SCRIPT" >&2
+    exit 1
+fi
+
+GH_TOKEN="$("$TOKEN_SCRIPT")" exec gh "$@"

--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# gh-lars — gh CLI wrapper authenticated as the nfl-dead-money-triage GitHub App.
+# gh-lars — gh CLI wrapper authenticated as the cap-alpha-workflow-automation GitHub App.
 #
 # Replaces the previous LARS_TOKEN PAT approach with installation tokens minted
 # by scripts/gh-app-token.sh. Tokens last 1 hour and are cached automatically.


### PR DESCRIPTION
## Summary

- `scripts/gh-app-token.sh`: mints/caches GitHub App installation tokens. JWT signed RS256 with local PEM (never committed). Tokens cached at `~/.cache/nfl-dead-money/gh-app-token.json`, refreshed when <5 min remain.
- `scripts/gh-lars`: thin `gh` wrapper — mints token via App, sets `GH_TOKEN`, execs `gh`. Drop-in for all callers.
- `CLAUDE.md`: identity section updated — App auth, PAT refs removed.
- `.env.personas` (gitignored): revoked LARS_TOKEN removed, Slack creds preserved.

**Why App over PAT:** 5,000 req/hr vs ~1,000 for PATs; new accounts get flagged at ~30 rapid API calls; Apps are GitHub's sanctioned automation path.

**Pending:** one-time update to `GH_INSTALLATION_ID` default in `gh-app-token.sh` once App installed on `cap-alpha` org (in progress).

## Test plan

- [ ] `scripts/gh-app-token.sh` mints a token (40-char string, no error)
- [ ] `GH_TOKEN=$(scripts/gh-app-token.sh) gh api rate_limit` returns 5000 req/hr limit
- [ ] `scripts/gh-lars issue list` returns cap-alpha/cap-alpha-protocol issues
- [ ] Second call within 1h uses cached token (no new JWT minted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)