### PR TITLE
feat(ops): triage-agent scripts — autonomous hourly issue/PR dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down shell-pipeline venv test lint lint-fix test-e2e pipeline-scrape pipeline-train pipeline-nlp pipeline-validate pipeline-factcheck web-logs setup check resolve-draft resolve-draft-dry prune-worktrees agent-identity
+.PHONY: up down shell-pipeline venv test lint lint-fix test-e2e pipeline-scrape pipeline-train pipeline-nlp pipeline-validate pipeline-factcheck web-logs setup check resolve-draft resolve-draft-dry setup-triage-agent uninstall-triage-agent agent-identity prune-worktrees
 
 PYTHON ?= python3
 VENV := .venv
@@ -15,6 +15,18 @@ DOCKER := docker compose --env-file docker_env.txt
 setup: venv
 	git config core.hooksPath .githooks
 	@echo "Done. Venv at $(VENV)/, git hooks configured."
+
+setup-triage-agent:
+	bash scripts/setup-triage-agent.sh
+
+uninstall-triage-agent:
+	bash scripts/uninstall-triage-agent.sh
+
+agent-identity:
+	bash scripts/configure_agent_identity.sh
+
+prune-worktrees:
+	bash scripts/prune_worktrees.sh
 
 venv:
 	$(PYTHON) -m venv $(VENV)

--- a/scripts/dispatch-claude.sh
+++ b/scripts/dispatch-claude.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# dispatch-claude.sh — thin wrapper around `claude -p` that logs token spend
+# Usage: dispatch-claude.sh --model <model> --prompt-file <file> --worktree <path> [--env KEY=VAL ...]
+# Outputs Claude's response to stdout; appends usage delta to .claude/usage_log.jsonl
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+USAGE_LOG="${REPO_ROOT}/.claude/usage_log.jsonl"
+CLAUDE_BIN="${CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+LOG_LABEL=""
+MODEL=""
+PROMPT_FILE=""
+WORKTREE=""
+ENV_VARS=()
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)      MODEL="$2";       shift 2 ;;
+        --prompt-file) PROMPT_FILE="$2"; shift 2 ;;
+        --worktree)   WORKTREE="$2";    shift 2 ;;
+        --label)      LOG_LABEL="$2";   shift 2 ;;
+        --env)        ENV_VARS+=("$2"); shift 2 ;;
+        *)            EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+[[ -z "$MODEL" ]]       && { echo "ERROR: --model required" >&2; exit 1; }
+[[ -z "$PROMPT_FILE" ]] && { echo "ERROR: --prompt-file required" >&2; exit 1; }
+[[ -z "$WORKTREE" ]]    && { echo "ERROR: --worktree required" >&2; exit 1; }
+[[ ! -f "$PROMPT_FILE" ]] && { echo "ERROR: prompt file not found: $PROMPT_FILE" >&2; exit 1; }
+[[ ! -d "$WORKTREE" ]]    && { echo "ERROR: worktree not found: $WORKTREE" >&2; exit 1; }
+[[ ! -x "$CLAUDE_BIN" ]]  && { echo "ERROR: claude not found at $CLAUDE_BIN" >&2; exit 1; }
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+START_TS="$(ts)"
+
+# Build env prefix for subagent environment
+ENV_PREFIX=()
+for kv in "${ENV_VARS[@]}"; do
+    ENV_PREFIX+=(env "$kv")
+done
+
+# Invoke claude -p (non-interactive) with stream-json output so we can parse usage
+TMPOUT="$(mktemp)"
+trap 'rm -f "$TMPOUT"' EXIT
+
+set +e
+"${ENV_PREFIX[@]:-env}" "$CLAUDE_BIN" \
+    -p \
+    --model "$MODEL" \
+    --add-dir "$WORKTREE" \
+    --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
+    --append-system-prompt-file "$PROMPT_FILE" \
+    --allow-dangerously-skip-permissions \
+    --output-format stream-json \
+    "${EXTRA_ARGS[@]}" \
+    "$(cat "$PROMPT_FILE")" \
+    2>&1 | tee "$TMPOUT"
+EXIT_CODE=$?
+set -e
+
+# Parse token usage from stream-json output
+INPUT_TOKENS=0
+OUTPUT_TOKENS=0
+if command -v python3 &>/dev/null; then
+    read -r INPUT_TOKENS OUTPUT_TOKENS < <(python3 - "$TMPOUT" <<'PYEOF'
+import sys, json
+
+inp_total = 0
+out_total = 0
+try:
+    with open(sys.argv[1]) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            usage = obj.get("usage") or (obj.get("message") or {}).get("usage") or {}
+            inp_total += usage.get("input_tokens", 0)
+            out_total += usage.get("output_tokens", 0)
+except Exception:
+    pass
+print(inp_total, out_total)
+PYEOF
+    )
+fi
+
+# Append delta to usage log
+mkdir -p "$(dirname "$USAGE_LOG")"
+printf '{"ts":"%s","model":"%s","label":"%s","input_tokens":%d,"output_tokens":%d,"exit_code":%d}\n' \
+    "$START_TS" "$MODEL" "$LOG_LABEL" "$INPUT_TOKENS" "$OUTPUT_TOKENS" "$EXIT_CODE" \
+    >> "$USAGE_LOG"
+
+exit "$EXIT_CODE"

--- a/scripts/launchagents/com.capalpha.triage-agent.plist
+++ b/scripts/launchagents/com.capalpha.triage-agent.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.capalpha.triage-agent</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>REPO_ROOT_PLACEHOLDER/scripts/triage-agent.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>REPO_ROOT_PLACEHOLDER</string>
+
+    <!-- Run every hour -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>StandardOutPath</key>
+    <string>HOME_PLACEHOLDER/Library/Logs/com.capalpha.triage-agent.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>HOME_PLACEHOLDER/Library/Logs/com.capalpha.triage-agent.log</string>
+
+    <!-- Keep alive only on crash, not on clean exit -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>HOME_PLACEHOLDER</string>
+        <key>CLAUDE_BIN</key>
+        <string>/opt/homebrew/bin/claude</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/prompts/ci-investigate.md
+++ b/scripts/prompts/ci-investigate.md
@@ -1,0 +1,13 @@
+You are a Sonnet coding agent diagnosing a CI failure on a GitHub PR.
+
+PR_NUMBER and FAILING_CHECK are set in the environment.
+
+## Your task
+
+1. Read CLAUDE.md before touching anything.
+2. Fetch the CI logs: `scripts/gh-lars run list --workflow "${FAILING_CHECK}" --branch $(scripts/gh-lars pr view ${PR_NUMBER} --json headRefName --jq .headRefName) --limit 1 --json databaseId --jq '.[0].databaseId'` then `scripts/gh-lars run view <run-id> --log-failed`.
+3. Diagnose the root cause from the logs.
+4. Check out the PR branch: `scripts/gh-lars pr checkout ${PR_NUMBER}`.
+5. Apply the minimal fix. Run `make check` to verify locally.
+6. Commit and push: `git commit -am "fix: resolve CI failure on PR #${PR_NUMBER}" && git push`.
+7. If you cannot determine a fix after 2 attempts, post a comment explaining the failure: `scripts/gh-lars pr comment ${PR_NUMBER} --body "CI triage: <diagnosis>. Needs human review."`.

--- a/scripts/prompts/copilot-fix.md
+++ b/scripts/prompts/copilot-fix.md
@@ -1,0 +1,17 @@
+You are a Sonnet coding agent fixing unresolved Copilot/reviewer threads on a GitHub PR.
+
+The PR number is in PR_NUMBER. Unresolved thread details (id, comment body, file, line) are in THREAD_JSON.
+
+## Your task
+
+1. Read CLAUDE.md before touching anything.
+2. Check out the PR branch: `scripts/gh-lars pr checkout ${PR_NUMBER}`.
+3. For each unresolved thread in THREAD_JSON, read the relevant file and apply the requested change.
+4. Run `make check`. Fix all failures.
+5. Commit: `git commit -am "fix: address review threads on PR #${PR_NUMBER}"`.
+6. Push: `git push`.
+7. Resolve each thread via GraphQL — for each thread ID in THREAD_JSON:
+   ```bash
+   scripts/gh-lars api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{id isResolved}}}' -f id="<thread_id>"
+   ```
+8. Do not merge the PR yourself — the original auto-merge queue handles it.

--- a/scripts/prompts/issue-work.md
+++ b/scripts/prompts/issue-work.md
@@ -1,0 +1,17 @@
+You are a Sonnet coding agent implementing a GitHub issue for the NFL Dead Money / Pundit Prediction Ledger project.
+
+You are operating in a fresh git worktree. The issue number, title, and body are in the environment variables ISSUE_NUMBER, ISSUE_TITLE, and ISSUE_BODY.
+
+## Your task
+
+1. Read CLAUDE.md thoroughly before touching anything.
+2. Implement the acceptance criteria in ISSUE_BODY. Work autonomously — no asking for clarification.
+3. Write or update tests for your change if appropriate.
+4. Run `make check` (lint + unit tests). Fix all failures before proceeding.
+5. Commit your changes: `git add -A && git commit -m "feat: implement #${ISSUE_NUMBER} — ${ISSUE_TITLE}"`.
+6. Push the branch: `git push -u origin HEAD`.
+7. Open a PR via `scripts/gh-lars pr create --title "[Gate N] <title>" --body "Closes #${ISSUE_NUMBER}\n\n<summary>"`.
+8. Queue the PR: `scripts/gh-lars pr merge <pr-number> --rebase --auto`.
+9. Release the issue lock: `ALLOW_MAIN_CHECKOUT=1 .agent/claim.sh release issue:${ISSUE_NUMBER} triage-agent`.
+
+Do not gold-plate. Implement exactly what the acceptance criteria say.

--- a/scripts/prompts/lint-fix.md
+++ b/scripts/prompts/lint-fix.md
@@ -1,0 +1,12 @@
+You are a Haiku agent fixing lint failures on a GitHub PR branch. Answer ONLY from tool output — do not invent information.
+
+PR_NUMBER is set in the environment.
+
+## Your task (answer ONLY from tool output)
+
+1. Check out the branch: `scripts/gh-lars pr checkout ${PR_NUMBER}`.
+2. Run `make lint-fix` to auto-fix all lint issues.
+3. Check if anything changed: `git diff --stat`.
+4. If changes exist: `git commit -am "chore: auto-fix lint on PR #${PR_NUMBER}" && git push`.
+5. If nothing changed, exit 0 — lint was already clean.
+6. Do not open a new PR. Do not merge anything.

--- a/scripts/setup-triage-agent.sh
+++ b/scripts/setup-triage-agent.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# setup-triage-agent.sh — idempotent setup for com.capalpha.triage-agent launchd job.
+# Safe to run multiple times.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# git --git-common-dir points at the main .git regardless of worktree; parent is the main checkout
+_GIT_COMMON="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+MAIN_ROOT="$(cd "${_GIT_COMMON}/.." 2>/dev/null && pwd || echo "$REPO_ROOT")"
+# .env.personas is always in the main checkout, not the worktree
+PERSONAS="${MAIN_ROOT}/.env.personas"
+PLIST_TEMPLATE="${REPO_ROOT}/scripts/launchagents/com.capalpha.triage-agent.plist"
+PLIST_DEST="${HOME}/Library/LaunchAgents/com.capalpha.triage-agent.plist"
+CLAUDE_BIN="/opt/homebrew/bin/claude"
+LOG_PATH="${HOME}/Library/Logs/com.capalpha.triage-agent.log"
+LOG_LABEL="com.capalpha.triage-agent"
+
+err() { echo "ERROR: $*" >&2; exit 1; }
+ok()  { echo "  OK: $*"; }
+
+echo "=== Setting up Autonomous Triage Agent ==="
+
+# 1. Validate claude exists
+[[ -x "$CLAUDE_BIN" ]] || err "claude not found at $CLAUDE_BIN. Install via: brew install anthropic/tap/claude"
+ok "claude CLI found at $CLAUDE_BIN ($(\"$CLAUDE_BIN\" --version 2>/dev/null | head -1 || echo 'version unknown'))"
+
+# 2. Validate .env.personas
+[[ -f "$PERSONAS" ]] || err ".env.personas not found at $PERSONAS. Create it with GH_APP_ID, GH_INSTALLATION_ID, and SLACK_WEBHOOK_URL."
+# Accept either GitHub App identity (GH_APP_ID) or legacy PAT (LARS_TOKEN)
+if ! grep -q "^GH_APP_ID=" "$PERSONAS" && ! grep -q "^LARS_TOKEN=" "$PERSONAS"; then
+    err ".env.personas missing GitHub identity — need GH_APP_ID (App auth) or LARS_TOKEN (PAT auth)"
+fi
+grep -q "^SLACK_WEBHOOK_URL=" "$PERSONAS" || { echo "  WARN: SLACK_WEBHOOK_URL not set — Slack alerts disabled"; }
+ok ".env.personas validated"
+
+# 3. Validate plist template exists
+[[ -f "$PLIST_TEMPLATE" ]] || err "plist template not found at $PLIST_TEMPLATE"
+
+# 4. Substitute paths and write plist
+# REPO_ROOT_PLACEHOLDER → main checkout (not worktree) so launchd uses the stable path
+mkdir -p "${HOME}/Library/LaunchAgents"
+sed \
+    -e "s|REPO_ROOT_PLACEHOLDER|${MAIN_ROOT}|g" \
+    -e "s|HOME_PLACEHOLDER|${HOME}|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+ok "plist written to $PLIST_DEST"
+
+# 5. Reload launchd job (idempotent: unload first, ignore error if not loaded)
+launchctl unload "$PLIST_DEST" 2>/dev/null || true
+launchctl load "$PLIST_DEST"
+ok "launchd job loaded"
+
+# 6. Verify job is registered
+if launchctl list | grep -q "$LOG_LABEL"; then
+    ok "launchctl confirmed: $LOG_LABEL is registered"
+else
+    err "launchctl did not register $LOG_LABEL — check plist syntax"
+fi
+
+# 7. Dry-run to verify the script works end-to-end
+echo ""
+echo "--- Running --dry-run ---"
+bash "${REPO_ROOT}/scripts/triage-agent.sh" --dry-run
+echo "--- End dry-run ---"
+echo ""
+
+# 8. Print next-run time and log path
+NEXT_RUN=$(date -v+1H "+%Y-%m-%d %H:%M %Z" 2>/dev/null || date --date="+1 hour" "+%Y-%m-%d %H:%M %Z" 2>/dev/null || echo "in ~1 hour")
+echo "=== Setup complete ==="
+echo "  Next scheduled run : $NEXT_RUN"
+echo "  Log file           : $LOG_PATH"
+echo "  Disable with       : make uninstall-triage-agent"
+echo ""
+echo "Tip: tail -f $LOG_PATH"

--- a/scripts/triage-agent.sh
+++ b/scripts/triage-agent.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+# triage-agent.sh — Autonomous hourly triage: dispatch issues, fix PR threads, fix lint, investigate CI.
+# Invoked by launchd (com.capalpha.triage-agent) every hour.
+#
+# Flags:
+#   --dry-run   Print what would be dispatched; do not invoke claude or claim locks.
+
+set -euo pipefail
+
+PERSONAS_FILE="$(dirname "${BASH_SOURCE[0]}")/../.env.personas"
+if [ -f "$PERSONAS_FILE" ]; then
+    # shellcheck disable=SC1090
+    set -a; source "$PERSONAS_FILE"; set +a
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENT_DIR="${REPO_ROOT}/.agent"
+GH_LARS="${REPO_ROOT}/scripts/gh-lars"
+DISPATCH="${REPO_ROOT}/scripts/dispatch-claude.sh"
+PROMPTS_DIR="${REPO_ROOT}/scripts/prompts"
+NOTIFICATIONS="${REPO_ROOT}/.claude/notifications.md"
+USAGE_LOG="${REPO_ROOT}/.claude/usage_log.jsonl"
+GATE_FILE="${REPO_ROOT}/.claude/current_gate.txt"
+CLAUDE_BIN="${CLAUDE_BIN:-/opt/homebrew/bin/claude}"
+AGENT_ID="triage-agent-$(hostname -s)-$$"
+
+# Concurrency cap: max parallel subagents per run
+CONCURRENCY_CAP=4
+# Claude Max throttle window: 50M output tokens per 5h; pause at 80%
+QUOTA_OUTPUT_LIMIT=$(( 50000000 * 80 / 100 ))   # 40M output tokens per 5h
+QUOTA_WINDOW_HOURS=5
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+ts()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "[$(ts)] $*"; }
+
+# ── Quota awareness ───────────────────────────────────────────────────────────
+
+check_quota() {
+    [[ ! -f "$USAGE_LOG" ]] && return 0
+
+    local cutoff_ts
+    cutoff_ts=$(python3 -c "
+from datetime import datetime, timezone, timedelta
+cutoff = datetime.now(timezone.utc) - timedelta(hours=${QUOTA_WINDOW_HOURS})
+print(cutoff.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+
+    local recent_output_tokens
+    recent_output_tokens=$(python3 - "$USAGE_LOG" "$cutoff_ts" <<'PYEOF'
+import sys, json
+from datetime import datetime, timezone
+
+log_path = sys.argv[1]
+cutoff_str = sys.argv[2]
+cutoff = datetime.fromisoformat(cutoff_str.rstrip("Z")).replace(tzinfo=timezone.utc)
+
+total = 0
+try:
+    with open(log_path) as f:
+        for line in f:
+            try:
+                obj = json.loads(line.strip())
+                ts_str = obj.get("ts", "")
+                ts = datetime.fromisoformat(ts_str.rstrip("Z")).replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    total += obj.get("output_tokens", 0)
+            except Exception:
+                pass
+except FileNotFoundError:
+    pass
+print(total)
+PYEOF
+    )
+
+    if (( recent_output_tokens >= QUOTA_OUTPUT_LIMIT )); then
+        log "QUOTA EXCEEDED: ${recent_output_tokens} output tokens in last ${QUOTA_WINDOW_HOURS}h (limit: ${QUOTA_OUTPUT_LIMIT}). Pausing run."
+        slack_alert "Triage agent quota pause: ${recent_output_tokens} output tokens in last ${QUOTA_WINDOW_HOURS}h. Next run in 1h."
+        return 1
+    fi
+
+    log "Quota OK: ${recent_output_tokens} output tokens in last ${QUOTA_WINDOW_HOURS}h (limit: ${QUOTA_OUTPUT_LIMIT})"
+    return 0
+}
+
+# ── Slack escalation ─────────────────────────────────────────────────────────
+
+slack_alert() {
+    local message="$1"
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+        local payload
+        payload=$(printf '{"channel":"%s","text":"%s"}' \
+            "${SLACK_CHANNEL:-#pundit-ledger-nfl-dead-money-cap-alpha-protocol}" \
+            "$message")
+        curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' --data "$payload" > /dev/null || true
+    fi
+}
+
+notify() {
+    local issue_number="$1" title="$2" why_blocked="$3" question="$4"
+    mkdir -p "$(dirname "$NOTIFICATIONS")"
+    {
+        echo ""
+        echo "## [$(ts)] Needs clarification: Issue #${issue_number} — ${title}"
+        echo "**Why blocked:** ${why_blocked}"
+        echo "**Question:** ${question}"
+    } >> "$NOTIFICATIONS"
+    log "ESCALATE issue #${issue_number}: ${why_blocked}"
+    slack_alert "Needs your input: Issue #${issue_number} — ${title}\n>${question}"
+}
+
+# ── Claim helper ─────────────────────────────────────────────────────────────
+
+is_claimed() {
+    grep -q "^issue:${1}" "${AGENT_DIR}/current.md" 2>/dev/null
+}
+
+is_pr_claimed() {
+    grep -q "^pr:${1}" "${AGENT_DIR}/current.md" 2>/dev/null
+}
+
+claim_resource() {
+    local resource="$1"
+    ALLOW_MAIN_CHECKOUT=1 "${AGENT_DIR}/claim.sh" claim "$resource" "$AGENT_ID" 2>/dev/null
+}
+
+# ── Autonomy classifier (salvaged from original script) ───────────────────────
+
+BLOCK_REASON=""
+BLOCK_QUESTION=""
+
+can_work_autonomously() {
+    local body="$1"
+    local labels="$2"
+
+    local ambiguous_phrases=(
+        "TBD" "TODO: clarify" "open question" "discussion needed"
+        "what should" "which approach" "unclear" "not sure" "to be determined"
+        "needs design" "needs discussion" "RFC"
+    )
+
+    local has_criteria=false
+    if echo "$body" | grep -qi "acceptance criteria\|should\|must\|requirement\|implement\|add\|fix\|update\|create"; then
+        has_criteria=true
+    fi
+
+    for phrase in "${ambiguous_phrases[@]}"; do
+        if echo "$body" | grep -qi "$phrase"; then
+            BLOCK_REASON="Issue body contains ambiguous phrase: '${phrase}'"
+            BLOCK_QUESTION="Is the scope clear enough to proceed? What exact output should this produce?"
+            return 1
+        fi
+    done
+
+    local body_len=${#body}
+    if [ "$body_len" -lt 50 ]; then
+        BLOCK_REASON="Issue body too short (${body_len} chars)"
+        BLOCK_QUESTION="What are the acceptance criteria?"
+        return 1
+    fi
+
+    if echo "$labels" | grep -qi "question\|discussion\|needs-design\|wontfix\|invalid"; then
+        BLOCK_REASON="Label indicates human input needed (${labels})"
+        BLOCK_QUESTION="Can you clarify the expected implementation?"
+        return 1
+    fi
+
+    if [ "$has_criteria" = "false" ]; then
+        BLOCK_REASON="Cannot identify acceptance criteria"
+        BLOCK_QUESTION="What should 'done' look like?"
+        return 1
+    fi
+
+    return 0
+}
+
+# ── Concurrency tracker ───────────────────────────────────────────────────────
+
+declare -a BACKGROUND_PIDS=()
+
+wait_if_at_cap() {
+    while (( ${#BACKGROUND_PIDS[@]} >= CONCURRENCY_CAP )); do
+        # Wait for any one job to finish
+        local new_pids=()
+        for pid in "${BACKGROUND_PIDS[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                new_pids+=("$pid")
+            fi
+        done
+        BACKGROUND_PIDS=("${new_pids[@]:-}")
+        if (( ${#BACKGROUND_PIDS[@]} >= CONCURRENCY_CAP )); then
+            sleep 2
+        fi
+    done
+}
+
+wait_all() {
+    for pid in "${BACKGROUND_PIDS[@]:-}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+}
+
+spawn_background() {
+    wait_if_at_cap
+    "$@" &
+    BACKGROUND_PIDS+=($!)
+}
+
+# ── Gate filter ───────────────────────────────────────────────────────────────
+
+current_gate() {
+    if [[ -f "$GATE_FILE" ]]; then
+        tr -d '[:space:]' < "$GATE_FILE"
+    else
+        echo "0"
+    fi
+}
+
+issue_gate() {
+    local title="$1"
+    # Match [Gate N] or [Gate N / WO-NNN]
+    if [[ "$title" =~ \[Gate[[:space:]]+([0-9]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        echo "-1"   # Not a gated issue — skip
+    fi
+}
+
+# ── Issue dispatch ────────────────────────────────────────────────────────────
+
+dispatch_issue() {
+    local number="$1" title="$2" body="$3"
+    local branch="feat/${number}-auto"
+    local worktree_path="${REPO_ROOT}/.claude/worktrees/auto-issue-${number}"
+
+    if $DRY_RUN; then
+        log "would dispatch: issue #${number} via Sonnet → ${worktree_path}"
+        return
+    fi
+
+    log "Dispatching issue #${number}: ${title}"
+
+    # Remove stale worktree if present without a live branch
+    if [[ -d "$worktree_path" ]]; then
+        log "  Worktree already exists at ${worktree_path}, skipping"
+        return
+    fi
+
+    git -C "$REPO_ROOT" worktree add "$worktree_path" -b "$branch" 2>/dev/null || {
+        log "  Branch conflict for #${number}, skipping"
+        return
+    }
+
+    spawn_background "$DISPATCH" \
+        --model "claude-sonnet-4-6" \
+        --prompt-file "${PROMPTS_DIR}/issue-work.md" \
+        --worktree "$worktree_path" \
+        --label "issue-${number}" \
+        --env "ISSUE_NUMBER=${number}" \
+        --env "ISSUE_TITLE=${title}" \
+        --env "ISSUE_BODY=${body}"
+}
+
+triage_issues() {
+    local gate
+    gate="$(current_gate)"
+    log "Current gate: ${gate}"
+
+    local issues
+    issues=$("$GH_LARS" issue list \
+        --state open \
+        --limit 50 \
+        --json number,title,body,labels,assignees \
+        2>/dev/null) || {
+        log "WARNING: Could not fetch issues (gh rate-limited or auth failure). Skipping issue triage."
+        return 0
+    }
+
+    local issue_count
+    issue_count=$(python3 -c "import sys,json; print(len(json.load(sys.stdin)))" <<< "$issues" 2>/dev/null || echo 0)
+    log "Found ${issue_count} open issues"
+
+    while IFS=$'\t' read -r number title labels body; do
+        [[ -z "$number" ]] && continue
+
+        local ig
+        ig=$(issue_gate "$title")
+        if (( ig < 0 )); then
+            log "  #${number} not gated, skipping"
+            continue
+        fi
+        if (( ig > gate )); then
+            log "  #${number} gate ${ig} > current ${gate}, skipping"
+            continue
+        fi
+
+        if is_claimed "$number"; then
+            log "  #${number} already claimed, skipping"
+            continue
+        fi
+
+        BLOCK_REASON=""
+        BLOCK_QUESTION=""
+        if can_work_autonomously "$body" "$labels"; then
+            if $DRY_RUN; then
+                log "would dispatch: issue #${number} '${title}'"
+            else
+                if claim_resource "issue:${number}"; then
+                    dispatch_issue "$number" "$title" "$body"
+                else
+                    log "  Could not claim issue:${number} (race), skipping"
+                fi
+            fi
+        else
+            notify "$number" "$title" "$BLOCK_REASON" "$BLOCK_QUESTION"
+        fi
+
+    done < <(python3 - <<PYEOF
+import sys, json
+data = json.loads("""$(echo "$issues" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")""")
+for issue in data:
+    number = issue.get("number","")
+    title  = (issue.get("title","") or "").replace("\t"," ")
+    body   = (issue.get("body","") or "").replace("\t"," ").replace("\n"," ")[:2000]
+    labels = ", ".join(l["name"] for l in (issue.get("labels") or []))
+    print(f"{number}\t{title}\t{labels}\t{body}")
+PYEOF
+    )
+}
+
+# ── PR triage ─────────────────────────────────────────────────────────────────
+
+dispatch_pr_copilot() {
+    local pr_number="$1" thread_json="$2"
+    local worktree_path="${REPO_ROOT}/.claude/worktrees/auto-pr-copilot-${pr_number}"
+
+    if $DRY_RUN; then
+        log "would dispatch: PR #${pr_number} copilot-fix via Sonnet"
+        return
+    fi
+
+    log "Dispatching Copilot fix for PR #${pr_number}"
+    [[ -d "$worktree_path" ]] && { log "  Copilot worktree already exists, skipping"; return; }
+
+    git -C "$REPO_ROOT" worktree add "$worktree_path" 2>/dev/null || {
+        log "  Could not create worktree for copilot fix on PR #${pr_number}"
+        return
+    }
+
+    spawn_background "$DISPATCH" \
+        --model "claude-sonnet-4-6" \
+        --prompt-file "${PROMPTS_DIR}/copilot-fix.md" \
+        --worktree "$worktree_path" \
+        --label "pr-copilot-${pr_number}" \
+        --env "PR_NUMBER=${pr_number}" \
+        --env "THREAD_JSON=${thread_json}"
+}
+
+dispatch_pr_lint() {
+    local pr_number="$1"
+    local worktree_path="${REPO_ROOT}/.claude/worktrees/auto-pr-lint-${pr_number}"
+
+    if $DRY_RUN; then
+        log "would dispatch: PR #${pr_number} lint-fix via Haiku"
+        return
+    fi
+
+    log "Dispatching lint fix for PR #${pr_number}"
+    [[ -d "$worktree_path" ]] && { log "  Lint worktree already exists, skipping"; return; }
+
+    git -C "$REPO_ROOT" worktree add "$worktree_path" 2>/dev/null || {
+        log "  Could not create worktree for lint fix on PR #${pr_number}"
+        return
+    }
+
+    spawn_background "$DISPATCH" \
+        --model "claude-haiku-4-5-20251001" \
+        --prompt-file "${PROMPTS_DIR}/lint-fix.md" \
+        --worktree "$worktree_path" \
+        --label "pr-lint-${pr_number}" \
+        --env "PR_NUMBER=${pr_number}"
+}
+
+dispatch_pr_ci() {
+    local pr_number="$1" failing_check="$2"
+    local worktree_path="${REPO_ROOT}/.claude/worktrees/auto-pr-ci-${pr_number}"
+
+    if $DRY_RUN; then
+        log "would dispatch: PR #${pr_number} ci-investigate (${failing_check}) via Sonnet"
+        return
+    fi
+
+    log "Dispatching CI investigation for PR #${pr_number} (${failing_check})"
+    [[ -d "$worktree_path" ]] && { log "  CI worktree already exists, skipping"; return; }
+
+    git -C "$REPO_ROOT" worktree add "$worktree_path" 2>/dev/null || {
+        log "  Could not create worktree for CI investigate on PR #${pr_number}"
+        return
+    }
+
+    spawn_background "$DISPATCH" \
+        --model "claude-sonnet-4-6" \
+        --prompt-file "${PROMPTS_DIR}/ci-investigate.md" \
+        --worktree "$worktree_path" \
+        --label "pr-ci-${pr_number}" \
+        --env "PR_NUMBER=${pr_number}" \
+        --env "FAILING_CHECK=${failing_check}"
+}
+
+triage_prs() {
+    local prs
+    prs=$("$GH_LARS" pr list \
+        --state open \
+        --limit 30 \
+        --json number,title,headRefName,statusCheckRollup,reviewThreads \
+        2>/dev/null) || {
+        log "WARNING: Could not fetch PRs (gh rate-limited or auth failure). Skipping PR triage."
+        return 0
+    }
+
+    local pr_count
+    pr_count=$(python3 -c "import sys,json; print(len(json.load(sys.stdin)))" <<< "$prs" 2>/dev/null || echo 0)
+    log "Found ${pr_count} open PRs"
+
+    # Process each PR via python — output tab-separated action lines
+    while IFS=$'\t' read -r action pr_number extra; do
+        [[ -z "$pr_number" ]] && continue
+
+        case "$action" in
+            COPILOT)
+                if ! is_pr_claimed "${pr_number}-copilot"; then
+                    claim_resource "pr:${pr_number}-copilot" || true
+                    dispatch_pr_copilot "$pr_number" "$extra"
+                fi
+                ;;
+            LINT)
+                if ! is_pr_claimed "${pr_number}-lint"; then
+                    claim_resource "pr:${pr_number}-lint" || true
+                    dispatch_pr_lint "$pr_number"
+                fi
+                ;;
+            CI)
+                if ! is_pr_claimed "${pr_number}-ci"; then
+                    claim_resource "pr:${pr_number}-ci" || true
+                    dispatch_pr_ci "$pr_number" "$extra"
+                fi
+                ;;
+        esac
+
+    done < <(python3 - <<PYEOF
+import sys, json
+
+data = json.loads("""$(echo "$prs" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)))")""")
+
+for pr in data:
+    number = pr.get("number","")
+
+    # Copilot threads
+    threads = pr.get("reviewThreads") or []
+    unresolved = [t for t in threads if not t.get("isResolved", True)]
+    if unresolved:
+        thread_json = json.dumps(unresolved).replace('"', '\\"')
+        print(f"COPILOT\t{number}\t{thread_json}")
+        continue  # prioritize copilot fix; lint/CI can wait
+
+    # CI status
+    checks = pr.get("statusCheckRollup") or []
+    lint_failing = False
+    ci_failing_name = ""
+    for check in checks:
+        name = (check.get("name") or check.get("context") or "").lower()
+        conclusion = (check.get("conclusion") or check.get("state") or "").upper()
+        if conclusion in ("FAILURE", "TIMED_OUT", "ERROR"):
+            if "lint" in name or "ruff" in name or "format" in name:
+                lint_failing = True
+            else:
+                ci_failing_name = check.get("name") or check.get("context") or "unknown"
+
+    if lint_failing:
+        print(f"LINT\t{number}\t")
+    elif ci_failing_name:
+        print(f"CI\t{number}\t{ci_failing_name}")
+PYEOF
+    )
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+main() {
+    log "=== Triage agent v2 starting === (dry-run: ${DRY_RUN})"
+    log "Repo: ${REPO_ROOT}"
+
+    # Rate-limit guard: if gh-lars returns 403/429, we skip gracefully (done inside triage_* fns)
+    # Quota check
+    if ! $DRY_RUN; then
+        check_quota || exit 0
+    fi
+
+    triage_issues
+    triage_prs
+
+    wait_all
+    log "=== Triage agent v2 complete ==="
+}
+
+main "$@"

--- a/scripts/uninstall-triage-agent.sh
+++ b/scripts/uninstall-triage-agent.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# uninstall-triage-agent.sh — remove launchd job and optionally the plist.
+
+set -euo pipefail
+
+PLIST_DEST="${HOME}/Library/LaunchAgents/com.capalpha.triage-agent.plist"
+LOG_LABEL="com.capalpha.triage-agent"
+
+echo "=== Uninstalling Autonomous Triage Agent ==="
+
+launchctl unload "$PLIST_DEST" 2>/dev/null && echo "  Unloaded: $LOG_LABEL" || echo "  Not loaded (already unloaded or never installed)"
+
+if [[ -f "$PLIST_DEST" ]]; then
+    rm "$PLIST_DEST"
+    echo "  Removed plist: $PLIST_DEST"
+fi
+
+echo "=== Done. Re-install with: make setup-triage-agent ==="


### PR DESCRIPTION
## Summary

- Adds `scripts/triage-agent.sh` — the autonomous hourly triage script invoked by launchd. Polls open issues and PRs, dispatches Sonnet/Haiku subagents for issue work, Copilot thread fixes, lint fixes, and CI investigation.
- Adds `scripts/dispatch-claude.sh` — thin `claude -p` wrapper that logs token spend to `.claude/usage_log.jsonl`.
- Adds `scripts/setup-triage-agent.sh` — idempotent launchd setup: validates deps, writes plist from template, loads job, runs `--dry-run`.
- Adds `scripts/uninstall-triage-agent.sh` — removes launchd job and plist cleanly.
- Adds `scripts/configure_agent_identity.sh` — sets worktree git author to `Claude Code (agent)` so commits are attributed to Claude.
- Adds `scripts/prune_worktrees.sh` — prunes merged stale worktrees (run weekly or before `/go`).
- Adds `scripts/launchagents/com.capalpha.triage-agent.plist` — plist template with `REPO_ROOT_PLACEHOLDER`/`HOME_PLACEHOLDER` substituted at install time.
- Adds `scripts/prompts/` — four subagent prompt files: `issue-work.md`, `copilot-fix.md`, `lint-fix.md`, `ci-investigate.md`.
- Updates `Makefile`: adds `setup-triage-agent`, `uninstall-triage-agent`, `agent-identity`, `prune-worktrees` targets.
- Updates `CLAUDE.md`: corrects `--squash` → `--rebase` in PR landing instructions; adds `gh-lars` identity note; adds agent commit identity and worktree hygiene sections.

**Fixes:** launchd `com.capalpha.triage-agent` exit 127 — `scripts/triage-agent.sh` did not exist on `main`. Files cherry-picked from `feat/triage-agent-v2` (c8e1ab7), omitting unrelated v2-branch changes.

**Depends on:** PR #471 (`scripts/gh-lars` App token upgrade) — now merged.

## Test plan

- [ ] `bash scripts/triage-agent.sh --dry-run` exits 0 and prints sensible log lines
- [ ] `make setup-triage-agent` completes: writes plist, loads launchd job
- [ ] `launchctl list | grep capalpha` shows the job registered
- [ ] `launchctl kickstart -k gui/501/com.capalpha.triage-agent` triggers a run; log at `~/Library/Logs/com.capalpha.triage-agent.log` shows exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)