### PR TITLE
fix(ops): gh-lars — fix MAIN_REPO path resolution from main checkout

### DIFF
--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -12,8 +12,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Resolve main repo root — works from worktrees too (git-common-dir points to main .git).
-MAIN_REPO="$(cd "$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir)/.." && pwd)"
+# Resolve main repo root — works from both main checkout and worktrees.
+# --git-common-dir returns relative path from main checkout, absolute from worktrees.
+# Normalise by cd-ing from SCRIPT_DIR so relative paths are anchored correctly.
+_GIT_COMMON="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+# If absolute (worktree case), use directly; if relative, resolve from SCRIPT_DIR.
+case "$_GIT_COMMON" in
+    /*) MAIN_REPO="$(cd "$_GIT_COMMON/.." && pwd)" ;;
+    *)  MAIN_REPO="$(cd "$SCRIPT_DIR/$_GIT_COMMON/.." && pwd)" ;;
+esac
 TOKEN_SCRIPT="${SCRIPT_DIR}/gh-app-token.sh"
 PERSONAS_FILE="${MAIN_REPO}/.env.personas"
 


### PR DESCRIPTION
## Summary

`git rev-parse --git-common-dir` returns a **relative** path (`../.git`) from the main checkout but an **absolute** path from worktrees. The original `cd "$(git rev-parse --git-common-dir)/.."` resolved relative to cwd, not to `SCRIPT_DIR`, causing `no such file or directory` errors when `gh-lars` was invoked from anywhere other than the `scripts/` directory itself.

Fix: detect whether the path is absolute or relative, resolve accordingly — anchoring relative paths to `SCRIPT_DIR`.

**Verified:**
- `bash scripts/gh-lars issue list --limit 3` works from main checkout root
- `bash scripts/gh-lars issue list --limit 3` works from `scripts/` directory  
- `bash scripts/gh-lars issue list --limit 3` works from a worktree

This fix is required for `scripts/triage-agent.sh` to successfully fetch issues/PRs from the launchd job (which runs from the main repo root as working directory).

## Test plan

- [x] Verified locally from main checkout + worktree
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)