### PR TITLE
[Gate 0] Responsible-gambling messaging visible site-wide (1-800-GAMBLER + resources)

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from "@/components/providers";
 import OnboardingModal from "@/components/onboarding-modal";
 import { AuthInterstitial } from "@/components/auth-interstitial";
 import { Navbar } from "@/components/navbar";
+import Footer from "@/components/footer";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -42,6 +43,7 @@ export default function RootLayout({
                     <main className="flex-grow">
                         {children}
                     </main>
+                    <Footer />
                 </Providers>
             </body>
         </html>

--- a/web/app/legal/responsible-gambling/page.tsx
+++ b/web/app/legal/responsible-gambling/page.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Phone, Heart, AlertTriangle, ExternalLink } from "lucide-react";
+
+export const metadata: Metadata = {
+    title: "Responsible Gambling | Pundit Ledger",
+    description: "Responsible gambling resources, helplines, and information. If you or someone you know has a gambling problem, call 1-800-GAMBLER.",
+};
+
+const HELPLINES = [
+    {
+        name: "National Problem Gambling Helpline",
+        number: "1-800-GAMBLER (1-800-426-2537)",
+        tel: "18004262537",
+        description: "24/7 confidential support — call, text, or chat",
+        url: "https://www.ncpgambling.org/help-treatment/national-helpline/",
+        national: true,
+    },
+    {
+        name: "National Council on Problem Gambling (NCPG)",
+        number: null,
+        tel: null,
+        description: "Resources, self-assessment tools, and treatment locator",
+        url: "https://www.ncpgambling.org/",
+        national: true,
+    },
+    {
+        name: "Gamblers Anonymous",
+        number: null,
+        tel: null,
+        description: "Fellowship of men and women who share experience and support",
+        url: "https://www.gamblersanonymous.org/",
+        national: true,
+    },
+    {
+        name: "Substance Abuse and Mental Health Services Administration (SAMHSA)",
+        number: "1-800-662-4357",
+        tel: "18006624357",
+        description: "National helpline for mental health and substance use disorders",
+        url: "https://www.samhsa.gov/",
+        national: true,
+    },
+];
+
+const WARNING_SIGNS = [
+    "Spending more money or time on gambling than intended",
+    "Chasing losses — gambling to win back money you've lost",
+    "Gambling interfering with work, relationships, or responsibilities",
+    "Borrowing money or selling possessions to fund gambling",
+    "Feeling restless or irritable when trying to stop gambling",
+    "Lying to family or friends about gambling activity",
+    "Using gambling to escape problems or relieve distress",
+];
+
+export default function ResponsibleGamblingPage() {
+    return (
+        <main className="min-h-[100dvh] bg-black text-white px-6 py-16">
+            <div className="max-w-3xl mx-auto">
+                <Link
+                    href="/"
+                    className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-300 transition-colors mb-10"
+                >
+                    <ArrowLeft className="w-4 h-4" />
+                    Back to Pundit Ledger
+                </Link>
+
+                <div className="flex items-center gap-3 mb-2">
+                    <Heart className="w-7 h-7 text-amber-400 shrink-0" />
+                    <h1 className="text-3xl font-extrabold tracking-tight">Responsible Gambling</h1>
+                </div>
+                <p className="text-sm text-zinc-500 mb-10">Last Updated: April 29, 2026</p>
+
+                {/* Emergency helpline — prominent placement */}
+                <div className="bg-amber-950/50 border border-amber-700/50 rounded-xl p-6 mb-10">
+                    <div className="flex items-start gap-3">
+                        <Phone className="w-6 h-6 text-amber-400 shrink-0 mt-0.5" />
+                        <div>
+                            <p className="text-amber-200 font-bold text-lg leading-snug">
+                                If you or someone you know has a gambling problem, call{" "}
+                                <a href="tel:18004262537" className="underline hover:text-white transition-colors">
+                                    1-800-GAMBLER
+                                </a>
+                            </p>
+                            <p className="text-amber-300/70 text-sm mt-1">
+                                1-800-426-2537 · Available 24/7 · Confidential
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Age eligibility */}
+                <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 mb-10 flex items-start gap-3">
+                    <AlertTriangle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+                    <p className="text-zinc-300 text-sm">
+                        <span className="font-bold text-white">Age Requirement:</span> Must be 21 or older to participate in sports
+                        betting where permitted. Void where prohibited by law. Laws governing sports betting vary by state and
+                        jurisdiction — it is your responsibility to ensure compliance with local regulations.
+                    </p>
+                </div>
+
+                {/* About this site */}
+                <section className="mb-10">
+                    <h2 className="text-xl font-bold mb-3">About This Site</h2>
+                    <p className="text-zinc-400 text-sm leading-relaxed">
+                        Pundit Ledger is an entertainment and analytics platform that tracks sports pundits&apos; prediction
+                        accuracy. This site contains affiliate links to sportsbook platforms. We are committed to responsible
+                        gambling practices and require all users to be of legal gambling age in their jurisdiction.
+                    </p>
+                    <p className="text-zinc-400 text-sm leading-relaxed mt-3">
+                        Gambling should be entertaining, not a way to make money or escape personal problems. If gambling
+                        stops being fun, please reach out for help.
+                    </p>
+                </section>
+
+                {/* Warning signs */}
+                <section className="mb-10">
+                    <h2 className="text-xl font-bold mb-4">Warning Signs of Problem Gambling</h2>
+                    <ul className="space-y-2">
+                        {WARNING_SIGNS.map((sign, i) => (
+                            <li key={i} className="flex items-start gap-2 text-zinc-400 text-sm">
+                                <span className="text-amber-500 mt-1 shrink-0">•</span>
+                                {sign}
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+
+                {/* Helplines & resources */}
+                <section className="mb-10">
+                    <h2 className="text-xl font-bold mb-4">Helplines &amp; Resources</h2>
+                    <div className="space-y-4">
+                        {HELPLINES.map((resource, i) => (
+                            <div key={i} className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+                                <div className="flex items-start justify-between gap-2">
+                                    <div>
+                                        <p className="font-semibold text-white text-sm">{resource.name}</p>
+                                        {resource.number && (
+                                            <a
+                                                href={`tel:${resource.tel}`}
+                                                className="text-amber-400 font-mono text-sm hover:text-amber-200 transition-colors"
+                                            >
+                                                {resource.number}
+                                            </a>
+                                        )}
+                                        <p className="text-zinc-500 text-xs mt-1">{resource.description}</p>
+                                    </div>
+                                    {resource.url && (
+                                        <a
+                                            href={resource.url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="shrink-0 text-zinc-500 hover:text-zinc-300 transition-colors"
+                                            aria-label={`Visit ${resource.name} website`}
+                                        >
+                                            <ExternalLink className="w-4 h-4" />
+                                        </a>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                {/* Self-exclusion */}
+                <section className="mb-10">
+                    <h2 className="text-xl font-bold mb-3">Self-Exclusion</h2>
+                    <p className="text-zinc-400 text-sm leading-relaxed">
+                        All licensed sportsbooks offer self-exclusion programs. If you feel you need a break from
+                        gambling, contact the sportsbook directly or use your state&apos;s self-exclusion registry.
+                        Most states maintain a statewide self-exclusion list that covers all licensed operators in that
+                        state.
+                    </p>
+                </section>
+
+                {/* Affiliate disclosure */}
+                <section className="mb-10 bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+                    <h2 className="text-lg font-bold mb-2">Affiliate Disclosure</h2>
+                    <p className="text-zinc-400 text-sm leading-relaxed">
+                        Pundit Ledger may earn commissions through affiliate links to sportsbook platforms. These
+                        partnerships do not influence our editorial content or prediction accuracy scoring. We only link
+                        to regulated, licensed operators. All affiliate partners require that we display responsible
+                        gambling messaging and maintain compliance with their program terms.
+                    </p>
+                </section>
+
+                <div className="flex flex-wrap gap-3 text-xs text-zinc-600">
+                    <Link href="/legal/terms" className="hover:text-zinc-400 transition-colors">Terms of Service</Link>
+                    <span>·</span>
+                    <Link href="/legal/privacy" className="hover:text-zinc-400 transition-colors">Privacy Policy</Link>
+                    <span>·</span>
+                    <Link href="/legal/acceptable-use" className="hover:text-zinc-400 transition-colors">Acceptable Use</Link>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/web/app/share/player/[slug]/page.tsx
+++ b/web/app/share/player/[slug]/page.tsx
@@ -79,6 +79,16 @@ export default async function SharePlayerPage({ params }: Props) {
           View full profile →
         </a>
       </p>
+
+      {/* Responsible gambling — required for affiliate compliance */}
+      <div className="mt-6 w-full max-w-2xl bg-amber-950/40 border border-amber-900/30 rounded-lg px-4 py-3 text-center">
+        <p className="text-amber-200/80 text-xs leading-snug">
+          <span className="font-semibold">Gambling problem? Call </span>
+          <a href="tel:18004262537" className="underline hover:text-amber-100">1-800-GAMBLER</a>
+          <span className="text-amber-300/60"> · Must be 21+ · </span>
+          <a href="/legal/responsible-gambling" className="underline hover:text-amber-100">Resources</a>
+        </p>
+      </div>
     </main>
   );
 }

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -4,33 +4,56 @@ import { DebugReset } from './debug-reset';
 
 const Footer = () => {
     return (
-        <footer className="w-full py-8 px-4 border-t border-slate-800 bg-slate-950 mt-auto">
-            <div className="max-w-7xl mx-auto flex flex-col items-center justify-center space-y-4">
-                <p className="text-slate-400 text-sm text-center max-w-2xl leading-relaxed">
-                    <span className="font-bold text-slate-300">NOTICE:</span> For simulation and entertainment purposes only.
-                    The data and predictions provided by the Cap Alpha Protocol are probabilistic simulations and should not be
-                    construed as financial, legal, or professional sports management advice.
-                </p>
-                <div className="flex items-center gap-4 text-slate-500 text-xs">
-                    <Link href="/legal/terms" className="hover:text-slate-300 transition-colors">Terms</Link>
-                    <Link href="/legal/privacy" className="hover:text-slate-300 transition-colors">Privacy</Link>
-                    <Link href="/legal/acceptable-use" className="hover:text-slate-300 transition-colors">Acceptable Use</Link>
-                </div>
-                <div className="flex items-center space-x-2 text-slate-500 text-xs">
-                    <span>&copy; {new Date().getFullYear()} Andrew Smith</span>
-                    <span className="h-1 w-1 bg-slate-700 rounded-full"></span>
-                    <span>All Rights Reserved</span>
-                    <span className="h-1 w-1 bg-slate-700 rounded-full"></span>
-                    <a
-                        href={`https://github.com/ucalegon206/cap-alpha-protocol/commit/${process.env.NEXT_PUBLIC_COMMIT_SHA}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-mono text-slate-600 hover:text-emerald-500 transition-colors"
+        <footer className="w-full border-t border-slate-800 bg-slate-950 mt-auto">
+            {/* Responsible Gambling Banner */}
+            <div className="w-full bg-amber-950/60 border-b border-amber-900/40 px-4 py-3">
+                <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-center gap-2 text-center">
+                    <p className="text-amber-200 text-xs sm:text-sm font-medium leading-snug">
+                        <span className="font-bold">If you or someone you know has a gambling problem, call </span>
+                        <a href="tel:18004262537" className="font-bold underline hover:text-amber-100 transition-colors">1-800-GAMBLER</a>
+                        <span className="text-amber-300/80"> (1-800-426-2537)</span>
+                        <span className="mx-2 hidden sm:inline">·</span>
+                        <br className="sm:hidden" />
+                        <span className="text-amber-300/80">Must be 21+ to participate in sports betting. Void where prohibited.</span>
+                    </p>
+                    <Link
+                        href="/legal/responsible-gambling"
+                        className="shrink-0 text-xs text-amber-400 underline hover:text-amber-200 transition-colors"
                     >
-                        v{process.env.NEXT_PUBLIC_COMMIT_SHA?.substring(0, 7) || 'local'}
-                    </a>
-                    <span className="h-1 w-1 bg-slate-700 rounded-full mx-2 hidden sm:inline-block"></span>
-                    <DebugReset />
+                        Resources
+                    </Link>
+                </div>
+            </div>
+
+            <div className="py-8 px-4">
+                <div className="max-w-7xl mx-auto flex flex-col items-center justify-center space-y-4">
+                    <p className="text-slate-400 text-sm text-center max-w-2xl leading-relaxed">
+                        <span className="font-bold text-slate-300">NOTICE:</span> For simulation and entertainment purposes only.
+                        The data and predictions provided by the Cap Alpha Protocol are probabilistic simulations and should not be
+                        construed as financial, legal, or professional sports management advice.
+                    </p>
+                    <div className="flex flex-wrap items-center justify-center gap-4 text-slate-500 text-xs">
+                        <Link href="/legal/terms" className="hover:text-slate-300 transition-colors">Terms</Link>
+                        <Link href="/legal/privacy" className="hover:text-slate-300 transition-colors">Privacy</Link>
+                        <Link href="/legal/acceptable-use" className="hover:text-slate-300 transition-colors">Acceptable Use</Link>
+                        <Link href="/legal/responsible-gambling" className="hover:text-amber-400 transition-colors text-amber-600">Responsible Gambling</Link>
+                    </div>
+                    <div className="flex items-center space-x-2 text-slate-500 text-xs">
+                        <span>&copy; {new Date().getFullYear()} Andrew Smith</span>
+                        <span className="h-1 w-1 bg-slate-700 rounded-full"></span>
+                        <span>All Rights Reserved</span>
+                        <span className="h-1 w-1 bg-slate-700 rounded-full"></span>
+                        <a
+                            href={`https://github.com/ucalegon206/cap-alpha-protocol/commit/${process.env.NEXT_PUBLIC_COMMIT_SHA}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-mono text-slate-600 hover:text-emerald-500 transition-colors"
+                        >
+                            v{process.env.NEXT_PUBLIC_COMMIT_SHA?.substring(0, 7) || 'local'}
+                        </a>
+                        <span className="h-1 w-1 bg-slate-700 rounded-full mx-2 hidden sm:inline-block"></span>
+                        <DebugReset />
+                    </div>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
Closes #490

## Summary
- Footer on every page now includes prominent 1-800-GAMBLER banner with age eligibility language ("Must be 21+, void where prohibited")
- New `/legal/responsible-gambling` page with helplines (NCPG, Gamblers Anonymous, SAMHSA), warning signs, self-exclusion info, and affiliate disclosure
- Share/infographic pages include inline RG messaging
- Footer links updated to include Responsible Gambling link

## What changed
- `web/components/footer.tsx`: Added amber RG banner above main footer content; added Responsible Gambling link in nav links
- `web/app/layout.tsx`: Imported and rendered `<Footer />` so messaging appears on every page
- `web/app/legal/responsible-gambling/page.tsx`: New dedicated RG resources page
- `web/app/share/player/[slug]/page.tsx`: Added RG banner below shareable player cards

All 966 unit tests pass.