### PR TITLE
[Gate 0] FTC affiliate disclosure — footer + per-page disclosure on all affiliate links

### DIFF
--- a/web/app/legal/disclosure/page.tsx
+++ b/web/app/legal/disclosure/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
     description: "FTC-compliant affiliate disclosure for Cap Alpha / Pundit Ledger.",
 };
 
-export default function AffiliateDisclosure() {
+export default function DisclosurePage() {
     return (
         <main className="min-h-[100dvh] bg-black text-white px-6 py-16">
             <div className="max-w-3xl mx-auto">

--- a/web/app/legal/disclosure/page.tsx
+++ b/web/app/legal/disclosure/page.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, DollarSign } from "lucide-react";
+
+export const metadata: Metadata = {
+    title: "Affiliate Disclosure | Pundit Ledger",
+    description: "FTC-compliant affiliate disclosure for Cap Alpha / Pundit Ledger.",
+};
+
+export default function AffiliateDisclosure() {
+    return (
+        <main className="min-h-[100dvh] bg-black text-white px-6 py-16">
+            <div className="max-w-3xl mx-auto">
+                <Link
+                    href="/"
+                    className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-zinc-300 transition-colors mb-10"
+                >
+                    <ArrowLeft className="w-4 h-4" />
+                    Back to home
+                </Link>
+
+                <div className="flex items-center gap-3 mb-4">
+                    <DollarSign className="w-7 h-7 text-emerald-500" />
+                    <h1 className="text-3xl font-extrabold tracking-tight">Affiliate Disclosure</h1>
+                </div>
+                <p className="text-zinc-500 text-sm mb-10">Last Updated: April 29, 2026</p>
+
+                <div className="space-y-8 text-zinc-300 leading-relaxed">
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">FTC Disclosure</h2>
+                        <p>
+                            In accordance with the Federal Trade Commission&apos;s guidelines on endorsements and
+                            testimonials (<a href="https://www.ftc.gov/business-guidance/resources/ftc-endorsement-guides-what-people-are-asking" target="_blank" rel="noopener noreferrer" className="text-emerald-500 underline hover:text-emerald-400">16 CFR Part 255</a>),
+                            Cap Alpha / Pundit Ledger discloses the following: this site contains affiliate links.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">What Are Affiliate Links?</h2>
+                        <p>
+                            Some links on this site are affiliate links, meaning Cap Alpha may earn a commission
+                            if you click through and sign up or make a purchase — at no additional cost to you.
+                            These partnerships help us keep the service running and free to use.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">Which Partners?</h2>
+                        <p className="mb-3">
+                            We currently have or may have affiliate relationships with the following sportsbook
+                            and daily-fantasy operators:
+                        </p>
+                        <ul className="list-disc list-inside space-y-1 text-zinc-400 ml-2">
+                            <li>DraftKings</li>
+                            <li>FanDuel</li>
+                            <li>PrizePicks</li>
+                            <li>Underdog Fantasy</li>
+                        </ul>
+                        <p className="mt-3 text-zinc-400 text-sm">
+                            This list may not be exhaustive. Any link labeled &quot;affiliate link&quot; or accompanied
+                            by an affiliate disclosure badge earns us a commission.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">Our Editorial Independence</h2>
+                        <p>
+                            Affiliate relationships do not influence our analysis, predictions, or editorial
+                            content. We do not accept payment in exchange for favorable coverage of any
+                            sportsbook or fantasy platform. All opinions are our own.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">Responsible Gambling</h2>
+                        <p>
+                            Sports betting and daily-fantasy contests involve risk and are not suitable for
+                            everyone. Never wager more than you can afford to lose. If you or someone you
+                            know has a gambling problem, call the National Problem Gambling Helpline at{' '}
+                            <span className="text-white font-semibold">1-800-522-4700</span>.
+                        </p>
+                    </section>
+
+                    <section>
+                        <h2 className="text-xl font-bold text-white mb-3">Questions?</h2>
+                        <p>
+                            If you have any questions about this disclosure, please contact us. You can also
+                            review our{' '}
+                            <Link href="/legal/privacy" className="text-emerald-500 underline hover:text-emerald-400">
+                                Privacy Policy
+                            </Link>{' '}
+                            and{' '}
+                            <Link href="/legal/terms" className="text-emerald-500 underline hover:text-emerald-400">
+                                Terms of Service
+                            </Link>.
+                        </p>
+                    </section>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/web/components/affiliate-disclosure.tsx
+++ b/web/components/affiliate-disclosure.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Link from "next/link";
+
+/**
+ * Inline FTC disclosure — place above or adjacent to any sportsbook affiliate link.
+ * Required by FTC Endorsement Guides (16 CFR Part 255).
+ */
+export function AffiliateDisclosure() {
+    return (
+        <p className="text-xs text-zinc-500 leading-relaxed">
+            <span className="font-semibold text-zinc-400">Affiliate link:</span>{" "}
+            Cap Alpha may earn a commission if you sign up through this link, at no additional cost to you.{" "}
+            <Link href="/legal/disclosure" className="underline hover:text-emerald-500 transition-colors">
+                Learn more
+            </Link>
+        </p>
+    );
+}

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -32,11 +32,19 @@ const Footer = () => {
                         The data and predictions provided by the Cap Alpha Protocol are probabilistic simulations and should not be
                         construed as financial, legal, or professional sports management advice.
                     </p>
+                    <p className="text-slate-500 text-xs text-center max-w-2xl leading-relaxed">
+                        Some links on this site are affiliate links. Cap Alpha may earn a commission when you sign up through
+                        these links, at no additional cost to you.{' '}
+                        <Link href="/legal/disclosure" className="underline hover:text-emerald-500 transition-colors">
+                            Affiliate Disclosure
+                        </Link>
+                    </p>
                     <div className="flex flex-wrap items-center justify-center gap-4 text-slate-500 text-xs">
                         <Link href="/legal/terms" className="hover:text-slate-300 transition-colors">Terms</Link>
                         <Link href="/legal/privacy" className="hover:text-slate-300 transition-colors">Privacy</Link>
                         <Link href="/legal/acceptable-use" className="hover:text-slate-300 transition-colors">Acceptable Use</Link>
                         <Link href="/legal/responsible-gambling" className="hover:text-amber-400 transition-colors text-amber-600">Responsible Gambling</Link>
+                        <Link href="/legal/disclosure" className="hover:text-slate-300 transition-colors">Affiliate Disclosure</Link>
                     </div>
                     <div className="flex items-center space-x-2 text-slate-500 text-xs">
                         <span>&copy; {new Date().getFullYear()} Andrew Smith</span>


### PR DESCRIPTION
Closes #485

## Summary
- Adds FTC-compliant affiliate disclosure paragraph to the site-wide footer (`web/components/footer.tsx`) with a link to the full disclosure page — visible on every page including mobile
- Creates `/legal/disclosure` page (`web/app/legal/disclosure/page.tsx`) covering: what affiliate links are, which partners (DraftKings, FanDuel, PrizePicks, Underdog), editorial independence, responsible gambling helpline, and links back to Terms/Privacy
- Adds reusable `AffiliateDisclosure` inline component (`web/components/affiliate-disclosure.tsx`) for placement above/adjacent to individual affiliate links when the link placement strategy issue lands

## Notes
- Disclosure language is placeholder pending sports/entertainment lawyer review (acceptance criterion #3); the page is structured to make that review easy
- `CODEBASE.md` staleness warning is expected — new pages/components added; no structural entry points changed