### PR TITLE
[Gate 0] Legal review gate — 21+ age restriction in ToS

### DIFF
--- a/web/app/legal/terms/page.tsx
+++ b/web/app/legal/terms/page.tsx
@@ -45,6 +45,11 @@ export default function TermsOfService() {
                             this application be construed as financial, legal, or professional
                             sports-betting advice.
                         </p>
+                        <p className="text-amber-400 font-semibold text-sm">
+                            Sports betting is regulated by individual states. You must be 21 or older
+                            (or the minimum legal age in your jurisdiction) to engage in sports wagering
+                            where permitted by law. Void where prohibited.
+                        </p>
                     </section>
 
                     <section className="space-y-3">


### PR DESCRIPTION
Closes #488

## Summary
- Adds explicit 21+ age restriction language to Terms of Service (section 1) per issue requirement: "any page mentioning sports betting adjacency should include 'Must be 21+ in applicable states' or equivalent"

## What's already done (not in this PR)
- Privacy Policy page (`/legal/privacy`) — already on main
- Acceptable Use Policy page (`/legal/acceptable-use`) — already on main
- Footer legal nav links (Terms, Privacy, Acceptable Use) — already on main
- FTC affiliate disclosure page — PR #516 (open, auto-merge enabled)
- Responsible gambling messaging + 1-800-GAMBLER + 21+ in footer — PR #515 (open, auto-merge enabled)

## Remaining acceptance criteria (non-code)
- Lawyer engagement via Priori Legal / UpCounsel / bar referral
- Written sign-off stored in 1Password
- Lawyer approval of FTC disclosure language (placeholder in #516)
- Lawyer approval of RG language (in #515)