### PR TITLE
feat(ci): add cryptographic ledger chain validator step (#475)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,17 @@ jobs:
           --ignore=pipeline/tests/test_api_vegas.py
       env:
         PYTHONPATH: ${{ github.workspace }}/pipeline
-    
 
-    
+    - name: Validate cryptographic ledger chain integrity
+      # Explicitly targets chain-hash unit tests (no BigQuery required — mocked).
+      # Runs with -x to fail fast on the first broken chain invariant.
+      # Blocks merge if any chain hash computation or verification logic is broken.
+      run: |
+        pytest pipeline/tests/test_cryptographic_ledger.py -x -v --tb=short \
+          -k "not Integration"
+      env:
+        PYTHONPATH: ${{ github.workspace }}/pipeline
+
     - name: Upload coverage reports
       if: always()
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Summary

- Adds an explicit **Validate cryptographic ledger chain integrity** step to the `Run Data Quality Tests` job in `.github/workflows/tests.yml`
- Targets `pipeline/tests/test_cryptographic_ledger.py` with `-x` (fail-fast) and `-k "not Integration"` to skip BigQuery integration tests — runs with zero GCP credentials
- Blocks merge if any chain hash computation or `verify_chain_integrity()` invariant is broken
- The existing test file already has full coverage of `compute_chain_hash`, `verify_chain_integrity`, and tamper detection — this step makes that validation explicit and prominent in CI

## What already exists

- `pipeline/src/cryptographic_ledger.py` — `verify_chain_integrity()` walks the full ledger chronologically and re-derives each `chain_hash` using `compute_chain_hash(prediction_hash, previous_chain_hash)`. Returns `{"verified": bool, "total_records": int, "first_break_at": str|None}`.
- `pipeline/tests/test_cryptographic_ledger.py` — `TestVerifyChainIntegrity` class with `test_empty_ledger_is_verified`, `test_valid_chain_passes`, and `test_tampered_record_fails` — all mocked, no BQ needed.

## Test plan

- [ ] CI passes on this PR (the new step runs after the existing pytest step)
- [ ] Confirm both Python matrix versions (3.10, 3.11) pass the ledger step
- [ ] Verify the step appears clearly labeled in the Actions log

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)