### PR TITLE
feat(web): add security headers — HSTS, CSP, X-Frame-Options (#493)

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -28,29 +28,80 @@ const nextConfig = {
         ignoreDuringBuilds: true,
     },
     async headers() {
+        // Content-Security-Policy:
+        //   - default-src 'self'                      block unlisted origins by default
+        //   - script-src: Clerk (auth UI), Stripe (checkout), Sentry replay SDK
+        //   - style-src: 'unsafe-inline' required by Clerk/Tailwind CSS-in-JS
+        //   - font-src: Google Fonts static assets
+        //   - connect-src: API backend, Clerk API, Sentry ingest, Stripe API
+        //   - img-src: ESPN logos (remotePatterns), Clerk avatar CDN, data URIs
+        //   - frame-src: Stripe 3DS/checkout iframes
+        //   - worker-src: blob: for Sentry replay worker
+        const csp = [
+            "default-src 'self'",
+            // Scripts — Clerk injects its own <script> tags; Stripe needs js.stripe.com
+            "script-src 'self' 'unsafe-inline' https://clerk.cap-alpha.co https://*.clerk.accounts.dev https://js.stripe.com https://browser.sentry-cdn.com https://js.sentry-cdn.com https://*.sentry.io",
+            // Styles — Tailwind + Clerk require inline styles at runtime
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+            // Fonts — Google Fonts static files
+            "font-src 'self' https://fonts.gstatic.com",
+            // Connections — API backend, Clerk, Sentry ingest, Stripe
+            "connect-src 'self' https://clerk.cap-alpha.co https://*.clerk.accounts.dev https://api.clerk.dev https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.stripe.com https://generativelanguage.googleapis.com https://pundit-ledger-api-wvhvx2muna-uc.a.run.app",
+            // Images — ESPN team logos, Clerk user avatars, data URIs for OG images
+            "img-src 'self' data: blob: https://a.espncdn.com https://img.clerk.com https://*.clerk.com",
+            // Frames — Stripe 3DS and checkout iframes
+            "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",
+            // Workers — Sentry replay uses a blob: worker
+            "worker-src 'self' blob:",
+            // Media — no external audio/video sources needed
+            "media-src 'none'",
+            // Object — no Flash/plugin embeds
+            "object-src 'none'",
+            // Base — prevent base-tag hijacking
+            "base-uri 'self'",
+            // Form submissions — only to self
+            "form-action 'self'",
+            // Frame ancestors — replaces X-Frame-Options for CSP-aware browsers
+            "frame-ancestors 'self'",
+        ].join('; ');
+
         return [
             {
                 source: '/(.*)',
                 headers: [
                     {
                         key: 'Content-Security-Policy',
-                        value: "worker-src 'self' blob:;",
+                        value: csp,
                     },
+                    // HSTS: 2-year max-age, include all subdomains, eligible for preload list
                     {
                         key: 'Strict-Transport-Security',
                         value: 'max-age=63072000; includeSubDomains; preload',
                     },
+                    // Prevent MIME-type sniffing attacks
                     {
                         key: 'X-Content-Type-Options',
                         value: 'nosniff',
                     },
+                    // Keep X-Frame-Options for older browsers (CSP frame-ancestors covers modern ones)
                     {
                         key: 'X-Frame-Options',
-                        value: 'DENY',
+                        value: 'SAMEORIGIN',
                     },
+                    // Limit referrer info to origin only on cross-origin requests
                     {
                         key: 'Referrer-Policy',
                         value: 'strict-origin-when-cross-origin',
+                    },
+                    // Disable browser features not used by this app
+                    {
+                        key: 'Permissions-Policy',
+                        value: 'camera=(), microphone=(), geolocation=(), payment=(self "https://js.stripe.com"), usb=(), bluetooth=()',
+                    },
+                    // Enable DNS prefetching for performance (safe, no privacy leak from self-hosted app)
+                    {
+                        key: 'X-DNS-Prefetch-Control',
+                        value: 'on',
                     },
                 ],
             },


### PR DESCRIPTION
Closes #493

## What

Replaces the single `worker-src 'self' blob:` CSP stub in `web/next.config.js` with a full set of HTTP security headers targeting **A+ on Mozilla Observatory**.

## Headers added / updated

| Header | Value |
|---|---|
| `Content-Security-Policy` | Full policy (see below) |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `X-Frame-Options` | `SAMEORIGIN` (was `DENY`) |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | camera, mic, geolocation disabled; payment scoped to Stripe |
| `X-DNS-Prefetch-Control` | `on` |

## CSP domains discovered (audit of `web/app/`)

- **Clerk**: `clerk.cap-alpha.co`, `*.clerk.accounts.dev`, `api.clerk.dev`, `img.clerk.com`
- **Stripe**: `js.stripe.com`, `hooks.stripe.com`, `api.stripe.com`
- **Sentry**: `browser.sentry-cdn.com`, `js.sentry-cdn.com`, `*.ingest.sentry.io`, `*.ingest.us.sentry.io`
- **Google Fonts**: `fonts.googleapis.com` (CSS), `fonts.gstatic.com` (woff2)
- **ESPN**: `a.espncdn.com` (team logos — already in `images.remotePatterns`)
- **App API**: `pundit-ledger-api-wvhvx2muna-uc.a.run.app`

## Notes

- `unsafe-inline` remains on `script-src` because Clerk injects inline scripts at runtime. Removing it would require a nonce-based setup wired through Clerk's middleware, which is a separate follow-up.
- `frame-ancestors 'self'` in CSP handles modern browsers; `X-Frame-Options: SAMEORIGIN` is kept for IE/old Safari fallback.
- `Permissions-Policy` explicitly scopes `payment` to `self` + `js.stripe.com` for Stripe checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)