### PR TITLE
chore(deps): enable Dependabot + apply safe npm audit fixes (#495)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "pip"
+    directory: "/pipeline"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -462,9 +462,9 @@
             }
         },
         "node_modules/@clerk/themes/node_modules/@clerk/shared": {
-            "version": "3.47.2",
-            "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-            "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+            "version": "3.47.5",
+            "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+            "integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -1715,19 +1715,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@google-cloud/bigquery/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@google-cloud/common": {
@@ -5888,19 +5875,6 @@
             },
             "peerDependencies": {
                 "webpack": ">=4.40.0"
-            }
-        },
-        "node_modules/@sentry/webpack-plugin/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -10845,9 +10819,9 @@
             }
         },
         "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -11336,9 +11310,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -11476,9 +11450,9 @@
             }
         },
         "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -12353,9 +12327,9 @@
             }
         },
         "node_modules/drizzle-orm": {
-            "version": "0.45.1",
-            "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
-            "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
+            "version": "0.45.2",
+            "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+            "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@aws-sdk/client-rds-data": ">=3",
@@ -13934,19 +13908,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/gaxios/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/gcp-metadata": {
@@ -16016,9 +15977,9 @@
             }
         },
         "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -17358,9 +17319,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.13",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+            "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -17982,9 +17943,9 @@
             }
         },
         "node_modules/readdirp/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "license": "MIT",
             "engines": {
                 "node": ">=8.6"
@@ -19334,13 +19295,12 @@
             }
         },
         "node_modules/svix": {
-            "version": "1.88.0",
-            "resolved": "https://registry.npmjs.org/svix/-/svix-1.88.0.tgz",
-            "integrity": "sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==",
+            "version": "1.92.2",
+            "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+            "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
             "license": "MIT",
             "dependencies": {
-                "standardwebhooks": "1.0.0",
-                "uuid": "^10.0.0"
+                "standardwebhooks": "1.0.0"
             }
         },
         "node_modules/swr": {
@@ -19467,19 +19427,6 @@
             },
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/teeny-request/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/terser": {
@@ -20665,9 +20612,10 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for weekly automated dependency PRs (npm, pip, GitHub Actions)
- Runs `npm audit fix --production` (non-breaking): fixes 1 CRITICAL + 4 other vulnerabilities
- Runs `pip-audit --local`: **no known vulnerabilities** in pipeline Python deps
- Documents all remaining HIGH/CRITICAL findings that need breaking-change upgrades

## Audit findings

### npm — Fixed in this PR
| Package | Severity | Fix applied |
|---|---|---|
| `@clerk/shared` | CRITICAL (GHSA-vqx2-fgx2-5wq9) | Patched |
| `drizzle-orm` | HIGH (GHSA-gpj5-g38j-94v9) | Patched |
| `picomatch` x2 | HIGH | Patched |
| `brace-expansion` | MODERATE | Patched |

### npm — Remaining HIGH (require --force / breaking changes)
| Package | CVEs | Follow-up needed |
|---|---|---|
| `@clerk/nextjs`/`clerk-react` | GHSA-w24r-5266-9c3c | Clerk Core 3 migration |
| `next` | 5 CVEs incl. DoS, HTTP smuggling | Next.js major upgrade |
| `@sentry/nextjs` | rollup path traversal | Sentry SDK major |
| `tar` | 6 CVEs (via duckdb) | duckdb-async upgrade |
| `playwright` | GHSA-7mvr-c777-76hp | test-only, low impact |

### pip
No vulnerabilities found (`pip-audit --local`).

## Test plan
- [ ] CI passes (no logic changes, only package-lock.json + new config file)
- [ ] Verify Dependabot appears as enabled in repo Settings → Security → Dependabot

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)