### PR TITLE
feat(security): per-IP rate limiting for public API routes (#478)

### DIFF
--- a/web/lib/__tests__/rate-limit.test.ts
+++ b/web/lib/__tests__/rate-limit.test.ts
@@ -31,8 +31,10 @@ vi.mock("@upstash/redis", () => ({
 
 import {
     checkRateLimit,
+    checkIpRateLimit,
     buildRateLimitHeaders,
     TIER_RATE_LIMITS,
+    ANONYMOUS_RATE_LIMIT,
 } from "../rate-limit";
 
 // ── Tier limit constants ──────────────────────────────────────────────────────
@@ -244,5 +246,109 @@ describe("buildRateLimitHeaders", () => {
         for (const val of Object.values(headers)) {
             expect(typeof val).toBe("string");
         }
+    });
+});
+
+// ── ANONYMOUS_RATE_LIMIT constant ─────────────────────────────────────────────
+
+describe("ANONYMOUS_RATE_LIMIT", () => {
+    it("is a positive number", () => {
+        expect(ANONYMOUS_RATE_LIMIT).toBeGreaterThan(0);
+    });
+
+    it("equals 100 req/min (matches free tier per-IP scraping protection)", () => {
+        expect(ANONYMOUS_RATE_LIMIT).toBe(100);
+    });
+
+    it("matches free tier limit (anonymous = unauthenticated free)", () => {
+        expect(ANONYMOUS_RATE_LIMIT).toBe(TIER_RATE_LIMITS.free);
+    });
+});
+
+// ── checkIpRateLimit — fail-open (no Upstash) ────────────────────────────────
+// These run before the "with Upstash" block to avoid premature singleton setup.
+
+describe("checkIpRateLimit — fail-open when UPSTASH env vars are absent", () => {
+    it("returns success=true", async () => {
+        const result = await checkIpRateLimit("1.2.3.4");
+        expect(result.success).toBe(true);
+    });
+
+    it("reports limit equal to ANONYMOUS_RATE_LIMIT", async () => {
+        const result = await checkIpRateLimit("1.2.3.4");
+        expect(result.limit).toBe(ANONYMOUS_RATE_LIMIT);
+        expect(result.remaining).toBe(ANONYMOUS_RATE_LIMIT);
+    });
+
+    it("returns a reset timestamp ~60 s in the future", async () => {
+        const before = Math.floor(Date.now() / 1000);
+        const result = await checkIpRateLimit("1.2.3.4");
+        expect(result.reset).toBeGreaterThanOrEqual(before + 59);
+        expect(result.reset).toBeLessThanOrEqual(before + 61);
+    });
+
+    it("does not set retryAfter when allowing", async () => {
+        const result = await checkIpRateLimit("1.2.3.4");
+        expect(result.retryAfter).toBeUndefined();
+    });
+
+    it("handles comma-separated forwarded IPs by taking the first", async () => {
+        // Should not throw even with multi-IP strings
+        const result = await checkIpRateLimit("10.0.0.1, 10.0.0.2");
+        expect(result.success).toBe(true);
+    });
+
+    it("handles IPv6 addresses with brackets", async () => {
+        const result = await checkIpRateLimit("[::1]");
+        expect(result.success).toBe(true);
+    });
+});
+
+// ── checkIpRateLimit — with Upstash ──────────────────────────────────────────
+
+describe("checkIpRateLimit — with Upstash", () => {
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    beforeAll(() => {
+        process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io";
+        process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+        mockLimit.mockReset();
+    });
+
+    afterAll(() => {
+        process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+        process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    });
+
+    it("returns success=true when under the limit", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) + 60) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: true,
+            limit: 100,
+            remaining: 80,
+            reset: resetMs,
+        });
+
+        const result = await checkIpRateLimit("5.6.7.8");
+        expect(result.success).toBe(true);
+        expect(result.remaining).toBe(80);
+        expect(result.retryAfter).toBeUndefined();
+    });
+
+    it("returns success=false with retryAfter when the limit is exceeded", async () => {
+        const resetMs = (Math.floor(Date.now() / 1000) + 45) * 1000;
+        mockLimit.mockResolvedValueOnce({
+            success: false,
+            limit: 100,
+            remaining: 0,
+            reset: resetMs,
+        });
+
+        const result = await checkIpRateLimit("5.6.7.8");
+        expect(result.success).toBe(false);
+        expect(result.remaining).toBe(0);
+        expect(result.retryAfter).toBeGreaterThan(0);
+        expect(result.retryAfter).toBeLessThanOrEqual(45);
     });
 });

--- a/web/lib/rate-limit.ts
+++ b/web/lib/rate-limit.ts
@@ -5,7 +5,8 @@
  * Gracefully degrades (fail-open) when UPSTASH_REDIS_REST_URL is not
  * configured, so the API remains available before Upstash is provisioned.
  *
- * Issue: #144
+ * Issue: #144 (API-key tier limits)
+ * Issue: #478 (anonymous IP rate limits for public routes)
  */
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
@@ -30,10 +31,17 @@ export const TIER_RATE_LIMITS: Record<Tier, number> = {
     enterprise: 1_000_000, // effectively unlimited
 };
 
+/**
+ * Per-minute request limit for anonymous/unauthenticated callers on public routes.
+ * Applied per source IP. Intentionally conservative to deter scraping.
+ */
+export const ANONYMOUS_RATE_LIMIT = 100;
+
 // Module-level cache — only populated when UPSTASH env vars are present.
 // Re-checked on every call when env vars are absent (fail-open path).
 let _redis: Redis | null = null;
 const _limiters = new Map<Tier, Ratelimit>();
+let _ipLimiter: Ratelimit | null = null;
 
 function getRedis(): Redis | null {
     if (_redis !== null) return _redis;
@@ -67,6 +75,22 @@ function getLimiter(tier: Tier): Ratelimit | null {
     return limiter;
 }
 
+function getIpLimiter(): Ratelimit | null {
+    const redis = getRedis();
+    if (!redis) return null;
+
+    if (_ipLimiter) return _ipLimiter;
+
+    _ipLimiter = new Ratelimit({
+        redis,
+        limiter: Ratelimit.slidingWindow(ANONYMOUS_RATE_LIMIT, "60 s"),
+        prefix: "rl:anon_ip",
+        analytics: true,
+    });
+
+    return _ipLimiter;
+}
+
 /**
  * Check the rate limit for an API key.
  *
@@ -92,6 +116,46 @@ export async function checkRateLimit(
     }
 
     const result = await limiter.limit(keyId);
+    const resetSeconds = Math.floor(result.reset / 1000);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+
+    return {
+        success: result.success,
+        limit: result.limit,
+        remaining: result.remaining,
+        reset: resetSeconds,
+        ...(result.success
+            ? {}
+            : { retryAfter: Math.max(0, resetSeconds - nowSeconds) }),
+    };
+}
+
+/**
+ * Check the rate limit for an anonymous/unauthenticated caller by IP address.
+ *
+ * Used in middleware to protect public API routes from scraping.
+ * Fail-open when Upstash is not configured.
+ *
+ * @param ip - The caller's IP address (from x-forwarded-for or x-real-ip).
+ * @returns Result with success flag and values for rate limit response headers.
+ */
+export async function checkIpRateLimit(ip: string): Promise<RateLimitResult> {
+    const limiter = getIpLimiter();
+
+    // Fail-open: allow all requests if Upstash is not configured.
+    if (!limiter) {
+        return {
+            success: true,
+            limit: ANONYMOUS_RATE_LIMIT,
+            remaining: ANONYMOUS_RATE_LIMIT,
+            reset: Math.floor(Date.now() / 1000) + 60,
+        };
+    }
+
+    // Normalize IP to avoid key collisions (strip IPv6 brackets, etc.)
+    const key = ip.replace(/[[\]]/g, "").split(",")[0].trim() || "unknown";
+
+    const result = await limiter.limit(key);
     const resetSeconds = Math.floor(result.reset / 1000);
     const nowSeconds = Math.floor(Date.now() / 1000);
 

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,11 +1,80 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { checkIpRateLimit, buildRateLimitHeaders } from "@/lib/rate-limit";
 
-// Simple passthrough middleware - always works, no auth dependency.
-// Clerk was causing MIDDLEWARE_INVOCATION_FAILED 500 errors on all API
-// routes when CLERK_SECRET_KEY was not configured in Vercel.
-export default function middleware(request: NextRequest) {
+/**
+ * Public API routes that are rate-limited per source IP.
+ *
+ * These routes return publicly readable data with no auth requirement.
+ * Without rate limiting they could be scraped aggressively.
+ *
+ * Limit: 100 req/min per IP (same as free authenticated tier).
+ * Fail-open when Upstash env vars are absent (dev / pre-provisioned envs).
+ *
+ * Issue: #478
+ */
+const PUBLIC_RATE_LIMITED_PREFIXES = [
+    "/api/ledger/",
+    "/api/draft/",
+    "/api/search-index",
+    "/api/misses",
+    "/api/predictions",
+    "/api/personalization",
+];
+
+function isPublicRateLimited(pathname: string): boolean {
+    return PUBLIC_RATE_LIMITED_PREFIXES.some((prefix) =>
+        pathname.startsWith(prefix)
+    );
+}
+
+function getClientIp(request: NextRequest): string {
+    // Vercel sets x-real-ip; fall back to x-forwarded-for first element.
+    const realIp = request.headers.get("x-real-ip");
+    if (realIp) return realIp;
+
+    const forwarded = request.headers.get("x-forwarded-for");
+    if (forwarded) return forwarded.split(",")[0].trim();
+
+    return "unknown";
+}
+
+export async function middleware(request: NextRequest) {
     const requestHeaders = new Headers(request.headers);
-    requestHeaders.set('x-forwarded-proto', 'https');
+    requestHeaders.set("x-forwarded-proto", "https");
+
+    const { pathname } = request.nextUrl;
+
+    if (isPublicRateLimited(pathname)) {
+        const ip = getClientIp(request);
+        const result = await checkIpRateLimit(ip);
+        const rlHeaders = buildRateLimitHeaders(result);
+
+        if (!result.success) {
+            return NextResponse.json(
+                {
+                    error: "Too many requests. Please slow down.",
+                    retryAfter: result.retryAfter,
+                },
+                {
+                    status: 429,
+                    headers: {
+                        ...rlHeaders,
+                        "Content-Type": "application/json",
+                    },
+                }
+            );
+        }
+
+        // Forward rate-limit headers on allowed responses so clients can self-throttle.
+        const response = NextResponse.next({
+            request: { headers: requestHeaders },
+        });
+        const rlHeadersRecord = rlHeaders as Record<string, string>;
+        for (const [key, value] of Object.entries(rlHeadersRecord)) {
+            response.headers.set(key, value);
+        }
+        return response;
+    }
 
     return NextResponse.next({
         request: {


### PR DESCRIPTION
## Summary

- **Gap found:** `/api/ledger/*`, `/api/draft/*`, `/api/search-index`, `/api/misses`, `/api/predictions`, `/api/personalization` had **zero rate limiting** — anyone could scrape them without restriction.
- **Existing infrastructure:** `web/lib/rate-limit.ts` already had Upstash sliding-window limits for API-key tiers (100–1M req/min). `web/middleware.ts` was a passthrough with no enforcement.
- **Fix:** Added `checkIpRateLimit()` (100 req/min per IP, sliding window) and wired it in middleware for all public routes.

## Changes

| File | Change |
|---|---|
| `web/lib/rate-limit.ts` | `ANONYMOUS_RATE_LIMIT = 100`, `getIpLimiter()`, `checkIpRateLimit(ip)` |
| `web/middleware.ts` | Per-IP rate limit check on all public API prefixes; 429 on breach; `X-RateLimit-*` headers forwarded |
| `web/lib/__tests__/rate-limit.test.ts` | Tests for `checkIpRateLimit` — fail-open, Upstash-backed, IPv6, multi-IP forwarded headers |

## Rate limit coverage after this PR

| Route group | Coverage | Limit |
|---|---|---|
| `/api/ledger/*` | Per-IP (middleware) | 100 req/min |
| `/api/draft/*` | Per-IP (middleware) | 100 req/min |
| `/api/search-index` | Per-IP (middleware) | 100 req/min |
| `/api/misses`, `/api/predictions`, `/api/personalization` | Per-IP (middleware) | 100 req/min |
| `/api/ai/scouting-report` | Clerk auth + credit check | N/A (gated) |
| `/api/api-keys/*` | Clerk auth required | N/A (gated) |
| `/api/billing/*` | Clerk auth required | N/A (gated) |
| `/api/webhooks/*` | Secret token / Stripe signature | N/A (gated) |
| `/api/dashboard/usage` | Clerk auth required | N/A (gated) |
| API keys (Bearer token) | Per-key Upstash tier limits | 100–1M req/min |

## Behavior

- **Fail-open:** when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are absent (dev, unprovisioned envs), all requests pass through.
- **429 response:** `{ "error": "Too many requests. Please slow down.", "retryAfter": N }` with `Retry-After`, `X-RateLimit-*` headers.
- **Successful responses** also include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` so clients can self-throttle.

## Test plan

- [x] Unit tests for `checkIpRateLimit` — fail-open path, Upstash-backed allow/deny, IPv6 and multi-IP comma-separated inputs
- [x] Pre-commit lint passed
- [ ] Verify `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are set in Vercel production env (outside scope of this PR)

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)