### PR TITLE
fix(ci): add Clerk publishable key placeholder for CI build

### DIFF
--- a/.github/workflows/frontend_preflight.yml
+++ b/.github/workflows/frontend_preflight.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Static Build Schema Validation
         working-directory: ./web
         env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          # Clerk SDK throws Missing publishableKey at static-generation time when
+          # this env var is empty. A non-empty placeholder suppresses that error;
+          # real auth is never exercised during a build-only run.
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_placeholder_for_ci_build' }}
           # Stripe SDK initialises at module load time in billing API routes.
           # A non-empty placeholder is required so `next build` can import those
           # modules without throwing "Neither apiKey nor config.authenticator


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` had no fallback value in the preflight workflow, so it was empty in CI
- `@clerk/nextjs` throws `Missing publishableKey` during static page generation when the env var is falsy
- Added `|| 'pk_test_placeholder_for_ci_build'` fallback, matching the existing `STRIPE_SECRET_KEY` pattern
- Placeholder suppresses the missing-key error at build time; real auth is never exercised during `next build`

## Impact

Fixes the `preflight-build` CI failure on PRs #529–#537 (all currently failing with the same error).

## Test plan

- [ ] CI green on this PR
- [ ] Re-run CI on one of the affected PRs to confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)