### PR TITLE
fix(ci): add Clerk publishable key placeholder for preflight build

### DIFF
--- a/.github/workflows/frontend_preflight.yml
+++ b/.github/workflows/frontend_preflight.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Static Build Schema Validation
         working-directory: ./web
         env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          # Clerk SDK throws Missing publishableKey at static-generation time when
+          # this env var is empty. A non-empty placeholder suppresses that error;
+          # real auth is never exercised during a build-only run.
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || 'pk_test_placeholder_for_ci_build' }}
           # Stripe SDK initialises at module load time in billing API routes.
           # A non-empty placeholder is required so `next build` can import those
           # modules without throwing "Neither apiKey nor config.authenticator


### PR DESCRIPTION
## Root Cause

\`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY\` was not set (empty) in CI, causing \`@clerk/nextjs\` to throw \`Missing publishableKey\` during \`next build\` static generation. This broke \`preflight-build\` on all PRs: #529, #530, #531, #532, #533, #534, and others.

## Fix

Added a \`|| 'pk_test_placeholder_for_ci_build'\` fallback, matching the existing pattern used for \`STRIPE_SECRET_KEY\`. The placeholder suppresses the error at build time — no real auth is exercised during a build-only run.

## Test plan
- [ ] \`preflight-build\` passes on this PR
- [ ] Dependabot PRs (#529–#534) re-run and pass after this lands on \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)