### PR TITLE
fix(ci): add placeholder fallback for NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

### DIFF
--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -18,6 +18,7 @@ Usage (inside Docker):
 """
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -107,6 +108,8 @@ VALID_CATEGORIES = {
     "draft_pick",
     "injury",
     "contract",
+    "award_prediction",  # Named NFL awards: MVP, OPOY, DPOY, ROY, etc.
+    "fa_signing",  # Free agency: player signs with a specific team
 }
 
 EXTRACTION_PROMPT = """You are a {sport} prediction extraction system. Extract testable predictions from the content below.
@@ -126,14 +129,6 @@ Stance rules:
 - bearish: prediction is negative/pessimistic about the subject (miss playoffs, underperform, get cut, lose)
 - neutral: no clear directional bias (retirement, trade, purely factual future event)
 
-Special handling for DRAFT PICKS:
-- For draft_pick claims, ALWAYS extract the draft year (e.g., 2025, 2026 draft)
-- Place the draft year in the season_year field
-- Examples:
-  "Will be picked in the 2025 draft" → season_year: 2025
-  "2026 first round pick" → season_year: 2026
-  "will go top 10 in the next draft" → season_year: [current year + 1]
-
 Rules — what NOT to extract:
 - HEDGED statements: "wouldn't surprise me if", "I could see", "most likely", "might", "probably"
 - VAGUE qualitative claims: "will be good", "will make plays", "will be a factor", "well worth it"
@@ -152,6 +147,8 @@ AUTHOR: {author}
 TITLE: {title}
 TEXT:
 {text}"""
+
+PROMPT_VERSION = hashlib.sha256(EXTRACTION_PROMPT.encode("utf-8")).hexdigest()[:8]
 
 
 @dataclass
@@ -234,12 +231,18 @@ def extract_assertions(
     sport: str = "NFL",
     published_date: str = "",
     provider: Optional[LLMProvider] = None,
+    allow_historical: bool = False,
     # Legacy parameter — ignored if provider is set
     client=None,
 ) -> ExtractionResult:
     """
     Sends media text to the configured LLM for structured prediction extraction.
     Returns an ExtractionResult with parsed predictions.
+
+    Args:
+        allow_historical: If True, skip the temporal filter that rejects claims
+            about past seasons. Use for historical backfill runs where articles
+            are from prior years.
     """
     if provider is None:
         # Legacy fallback: create a Gemini provider for backward compatibility
@@ -260,13 +263,16 @@ def extract_assertions(
         predictions = provider.extract_predictions(prompt)
         # Filter empty claims, then deduplicate near-identical ones
         valid = [p for p in predictions if p.get("extracted_claim", "").strip()]
-        # Hard temporal filter: reject predictions about past seasons/drafts
+        # Hard temporal filter: reject predictions about past seasons/drafts.
+        # Bypassed with allow_historical=True for backfill ingestion of
+        # already-completed seasons where outcomes ARE known.
         current_year = datetime.now().year
         filtered = []
         for p in valid:
             sy = p.get("season_year")
             if (
-                sy is not None
+                not allow_historical
+                and sy is not None
                 and isinstance(sy, (int, float))
                 and int(sy) < current_year
             ):
@@ -535,6 +541,14 @@ def run_extraction(
         all_predictions = []
         processed_hashes = []
 
+        # Compute provider provenance once for all predictions in this run
+        provider_type = (
+            type(provider).__name__.replace("Provider", "").lower()
+            if provider
+            else None
+        )
+        llm_model = getattr(provider, "model", None) if provider else None
+
         for _, row in media_df.iterrows():
             content_hash = row["content_hash"]
             source_id = str(row.get("source_id", ""))
@@ -645,6 +659,9 @@ def run_extraction(
                         target_team=pred.get("target_team"),
                         stance=stance,
                         sport=str(row.get("sport", sport)),
+                        prompt_version=PROMPT_VERSION,
+                        llm_provider=provider_type,
+                        llm_model=str(llm_model) if llm_model else None,
                     )
                 )
 

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -18,7 +18,6 @@ Usage (inside Docker):
 """
 
 import argparse
-import hashlib
 import json
 import logging
 import os
@@ -108,8 +107,6 @@ VALID_CATEGORIES = {
     "draft_pick",
     "injury",
     "contract",
-    "award_prediction",  # Named NFL awards: MVP, OPOY, DPOY, ROY, etc.
-    "fa_signing",  # Free agency: player signs with a specific team
 }
 
 EXTRACTION_PROMPT = """You are a {sport} prediction extraction system. Extract testable predictions from the content below.
@@ -155,8 +152,6 @@ AUTHOR: {author}
 TITLE: {title}
 TEXT:
 {text}"""
-
-PROMPT_VERSION = hashlib.sha256(EXTRACTION_PROMPT.encode("utf-8")).hexdigest()[:8]
 
 
 @dataclass
@@ -239,18 +234,12 @@ def extract_assertions(
     sport: str = "NFL",
     published_date: str = "",
     provider: Optional[LLMProvider] = None,
-    allow_historical: bool = False,
     # Legacy parameter — ignored if provider is set
     client=None,
 ) -> ExtractionResult:
     """
     Sends media text to the configured LLM for structured prediction extraction.
     Returns an ExtractionResult with parsed predictions.
-
-    Args:
-        allow_historical: If True, skip the temporal filter that rejects claims
-            about past seasons. Use for historical backfill runs where articles
-            are from prior years.
     """
     if provider is None:
         # Legacy fallback: create a Gemini provider for backward compatibility
@@ -271,16 +260,13 @@ def extract_assertions(
         predictions = provider.extract_predictions(prompt)
         # Filter empty claims, then deduplicate near-identical ones
         valid = [p for p in predictions if p.get("extracted_claim", "").strip()]
-        # Hard temporal filter: reject predictions about past seasons/drafts.
-        # Bypassed with allow_historical=True for backfill ingestion of
-        # already-completed seasons where outcomes ARE known.
+        # Hard temporal filter: reject predictions about past seasons/drafts
         current_year = datetime.now().year
         filtered = []
         for p in valid:
             sy = p.get("season_year")
             if (
-                not allow_historical
-                and sy is not None
+                sy is not None
                 and isinstance(sy, (int, float))
                 and int(sy) < current_year
             ):
@@ -549,14 +535,6 @@ def run_extraction(
         all_predictions = []
         processed_hashes = []
 
-        # Compute provider provenance once for all predictions in this run
-        provider_type = (
-            type(provider).__name__.replace("Provider", "").lower()
-            if provider
-            else None
-        )
-        llm_model = getattr(provider, "model", None) if provider else None
-
         for _, row in media_df.iterrows():
             content_hash = row["content_hash"]
             source_id = str(row.get("source_id", ""))
@@ -667,9 +645,6 @@ def run_extraction(
                         target_team=pred.get("target_team"),
                         stance=stance,
                         sport=str(row.get("sport", sport)),
-                        prompt_version=PROMPT_VERSION,
-                        llm_provider=provider_type,
-                        llm_model=str(llm_model) if llm_model else None,
                     )
                 )
 

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -129,6 +129,14 @@ Stance rules:
 - bearish: prediction is negative/pessimistic about the subject (miss playoffs, underperform, get cut, lose)
 - neutral: no clear directional bias (retirement, trade, purely factual future event)
 
+Special handling for DRAFT PICKS:
+- For draft_pick claims, ALWAYS extract the draft year (e.g., 2025, 2026 draft)
+- Place the draft year in the season_year field
+- Examples:
+  "Will be picked in the 2025 draft" → season_year: 2025
+  "2026 first round pick" → season_year: 2026
+  "will go top 10 in the next draft" → season_year: [current year + 1]
+
 Rules — what NOT to extract:
 - HEDGED statements: "wouldn't surprise me if", "I could see", "most likely", "might", "probably"
 - VAGUE qualitative claims: "will be good", "will make plays", "will be a factor", "well worth it"

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -168,36 +168,6 @@ def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> lis
     if len(predictions) <= 1:
         return predictions
 
-    kept = []
-    for pred in predictions:
-        claim = pred.get("extracted_claim", "").lower()
-        is_dup = False
-        for i, existing in enumerate(kept):
-            existing_claim = existing.get("extracted_claim", "").lower()
-            ratio = SequenceMatcher(None, claim, existing_claim).ratio()
-            if ratio >= threshold:
-                if len(claim) > len(existing_claim):
-                    kept[i] = pred
-                is_dup = True
-                break
-        if not is_dup:
-            kept.append(pred)
-
-    removed = len(predictions) - len(kept)
-    if removed > 0:
-        logger.info(f"Dedup: removed {removed} near-duplicate claims")
-    return kept
-
-
-def _deduplicate_claims(predictions: list[dict], threshold: float = 0.75) -> list[dict]:
-    """
-    Remove near-duplicate claims from a single article's extraction.
-    Uses SequenceMatcher to detect semantic overlap. Keeps the longest
-    (most specific) claim from each cluster.
-    """
-    if len(predictions) <= 1:
-        return predictions
-
     from difflib import SequenceMatcher
 
     kept = []

--- a/pipeline/src/llm_provider.py
+++ b/pipeline/src/llm_provider.py
@@ -13,21 +13,11 @@ Usage:
     provider = get_provider()  # reads from llm_config.yaml
     predictions = provider.extract_predictions(prompt)
     has_predictions = provider.classify(prompt)  # "yes" / "no"
-
-Async batch usage (Gemini Flash burst mode):
-    from src.llm_provider import AsyncGeminiProvider, TokenBudgetTracker
-    import asyncio
-
-    budget = TokenBudgetTracker(max_tokens=2_000_000)
-    provider = AsyncGeminiProvider(budget=budget, concurrency=20)
-    results = asyncio.run(provider.extract_predictions_batch(prompts))
 """
 
-import asyncio
 import json
 import logging
 import os
-import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
@@ -46,11 +36,9 @@ Return a JSON array of objects. Each object must have:
 - "claim_category": string — one of: player_performance, game_outcome, trade, draft_pick, injury, contract (REQUIRED)
 - "stance": string — directional sentiment: "bullish" (positive outcome predicted), "bearish" (negative outcome predicted), or "neutral" (no clear directional bias) (REQUIRED)
 - "season_year": integer or null — season year the prediction applies to (CRITICAL for draft_pick: must be the draft year, e.g. 2025, 2026)
-- "draft_year": integer or null — for draft pick predictions, set to the year of the draft (e.g. 2026). Otherwise null.
 - "target_player": string or null — player name if about a specific player
 - "target_team": string or null — team abbreviation (e.g. "KC", "CHI")
 - "confidence_note": string — how explicit/confident the prediction is (REQUIRED)
-- "prediction_horizon_days": integer — estimated days from publication date to when the event resolves; use -1 for retroactive/past statements (REQUIRED)
 
 For draft_pick category: season_year MUST be populated with the draft year (infer if not explicitly stated).
 
@@ -60,8 +48,6 @@ If no testable predictions exist, return an empty array: []
 
 class LLMProvider(ABC):
     """Abstract base for LLM extraction backends."""
-
-    provider_name: str = None  # Override in subclasses
 
     def __init__(self, model: str, **kwargs):
         self.model = model
@@ -116,8 +102,6 @@ class LLMProvider(ABC):
 class GeminiProvider(LLMProvider):
     """Google Gemini API with native schema enforcement."""
 
-    provider_name = "gemini"
-
     def __init__(self, model: str = "gemini-2.5-flash", **kwargs):
         super().__init__(model)
         from google import genai
@@ -158,11 +142,6 @@ class GeminiProvider(LLMProvider):
                         description="Directional sentiment: bullish=positive outcome predicted, bearish=negative, neutral=no clear bias",
                     ),
                     "season_year": types.Schema(type=types.Type.INTEGER, nullable=True),
-                    "draft_year": types.Schema(
-                        type=types.Type.INTEGER,
-                        nullable=True,
-                        description="For draft pick predictions, the year of the draft (e.g. 2026). Otherwise null.",
-                    ),
                     "target_player": types.Schema(
                         type=types.Type.STRING, nullable=True
                     ),
@@ -171,17 +150,12 @@ class GeminiProvider(LLMProvider):
                         type=types.Type.STRING,
                         description="How explicit/confident the prediction is",
                     ),
-                    "prediction_horizon_days": types.Schema(
-                        type=types.Type.INTEGER,
-                        description="Days from publication date to event resolution; use -1 for retroactive/past statements",
-                    ),
                 },
                 required=[
                     "extracted_claim",
                     "claim_category",
                     "stance",
                     "confidence_note",
-                    "prediction_horizon_days",
                 ],
             ),
         )
@@ -205,272 +179,12 @@ class GeminiProvider(LLMProvider):
 
 
 # ---------------------------------------------------------------------------
-# Token budget tracker (for cost-capped burst runs)
-# ---------------------------------------------------------------------------
-
-
-class TokenBudgetTracker:
-    """Thread/async-safe token budget tracker.
-
-    Gemini Flash pricing (as of 2026-04): $0.15/1M input + $0.60/1M output.
-    Default 2M token budget ≈ ~$0.30 blended.
-    """
-
-    # Conservative blended rate: mostly input tokens, some output
-    COST_PER_TOKEN = 0.15 / 1_000_000  # input-dominated estimate
-
-    def __init__(self, max_tokens: int = 2_000_000):
-        self.max_tokens = max_tokens
-        self._used_input: int = 0
-        self._used_output: int = 0
-        self._lock = asyncio.Lock()
-
-    @property
-    def used_tokens(self) -> int:
-        return self._used_input + self._used_output
-
-    @property
-    def estimated_cost_usd(self) -> float:
-        return (self._used_input * 0.15 / 1_000_000) + (
-            self._used_output * 0.60 / 1_000_000
-        )
-
-    async def record(self, input_tokens: int, output_tokens: int) -> bool:
-        """Record token usage. Returns False if budget exceeded."""
-        async with self._lock:
-            self._used_input += input_tokens
-            self._used_output += output_tokens
-            total = self._used_input + self._used_output
-            print(
-                f"[tokens] +{input_tokens}in/{output_tokens}out "
-                f"| total={total:,}/{self.max_tokens:,} "
-                f"| ~${self.estimated_cost_usd:.4f}",
-                file=sys.stderr,
-            )
-            return total <= self.max_tokens
-
-    def is_exhausted(self) -> bool:
-        return (self._used_input + self._used_output) >= self.max_tokens
-
-    def summary(self) -> dict:
-        return {
-            "input_tokens": self._used_input,
-            "output_tokens": self._used_output,
-            "total_tokens": self._used_input + self._used_output,
-            "budget_tokens": self.max_tokens,
-            "estimated_cost_usd": round(self.estimated_cost_usd, 4),
-            "budget_exhausted": self.is_exhausted(),
-        }
-
-
-# ---------------------------------------------------------------------------
-# Async Gemini Provider — high-concurrency burst mode
-# ---------------------------------------------------------------------------
-
-
-class AsyncGeminiProvider:
-    """Async Gemini Flash provider with semaphore-based concurrency control.
-
-    Designed for high-volume historical backfill. Runs ~20 calls in-flight
-    concurrently vs Ollama's serial throughput. Stops early if token budget
-    is exhausted.
-
-    Usage:
-        budget = TokenBudgetTracker(max_tokens=2_000_000)
-        provider = AsyncGeminiProvider(budget=budget, concurrency=20)
-        results = await provider.extract_predictions_batch(prompts_list)
-    """
-
-    def __init__(
-        self,
-        model: str = "gemini-2.5-flash",
-        concurrency: int = 20,
-        budget: Optional[TokenBudgetTracker] = None,
-    ):
-        from google import genai
-        from google.genai import types
-
-        api_key = os.environ.get("GEMINI_API_KEY")
-        if not api_key:
-            raise EnvironmentError(
-                "GEMINI_API_KEY not set — required for gemini-flash provider. "
-                "Set it with: export GEMINI_API_KEY=<your-key>"
-            )
-        self.client = genai.Client(api_key=api_key)
-        self.types = types
-        self.model = model
-        self.concurrency = concurrency
-        self.budget = budget or TokenBudgetTracker()
-        self._schema = self._build_schema()
-        self._semaphore: Optional[asyncio.Semaphore] = None
-
-    def _build_schema(self):
-        types = self.types
-        return types.Schema(
-            type=types.Type.ARRAY,
-            items=types.Schema(
-                type=types.Type.OBJECT,
-                properties={
-                    "extracted_claim": types.Schema(
-                        type=types.Type.STRING,
-                        description="Concise, testable statement",
-                    ),
-                    "claim_category": types.Schema(
-                        type=types.Type.STRING,
-                        enum=[
-                            "player_performance",
-                            "game_outcome",
-                            "trade",
-                            "draft_pick",
-                            "injury",
-                            "contract",
-                        ],
-                    ),
-                    "stance": types.Schema(
-                        type=types.Type.STRING,
-                        enum=["bullish", "bearish", "neutral"],
-                        description="Directional sentiment",
-                    ),
-                    "season_year": types.Schema(type=types.Type.INTEGER, nullable=True),
-                    "target_player": types.Schema(
-                        type=types.Type.STRING, nullable=True
-                    ),
-                    "target_team": types.Schema(type=types.Type.STRING, nullable=True),
-                    "confidence_note": types.Schema(
-                        type=types.Type.STRING,
-                        description="How explicit/confident the prediction is",
-                    ),
-                },
-                required=[
-                    "extracted_claim",
-                    "claim_category",
-                    "stance",
-                    "confidence_note",
-                ],
-            ),
-        )
-
-    def _get_semaphore(self) -> asyncio.Semaphore:
-        """Lazily create semaphore in the running event loop."""
-        if self._semaphore is None:
-            self._semaphore = asyncio.Semaphore(self.concurrency)
-        return self._semaphore
-
-    def _parse_json_response(self, text: str) -> list[dict]:
-        """Parse JSON from model response."""
-        text = text.strip()
-        if text.startswith("```"):
-            lines = text.split("\n")
-            lines = [ln for ln in lines if not ln.strip().startswith("```")]
-            text = "\n".join(lines).strip()
-        try:
-            result = json.loads(text)
-            if isinstance(result, list):
-                return [p for p in result if p.get("extracted_claim", "").strip()]
-            if isinstance(result, dict):
-                if "predictions" in result:
-                    preds = result["predictions"]
-                    if isinstance(preds, list):
-                        return [
-                            p for p in preds if p.get("extracted_claim", "").strip()
-                        ]
-                if "extracted_claim" in result:
-                    return [result] if result["extracted_claim"].strip() else []
-            return []
-        except json.JSONDecodeError as e:
-            logger.warning(f"JSON parse failed: {e}. Response: {text[:200]}")
-            return []
-
-    async def _extract_one(
-        self, idx: int, prompt: str
-    ) -> tuple[int, list[dict], Optional[str]]:
-        """Extract predictions for a single prompt. Returns (idx, predictions, error)."""
-        if self.budget.is_exhausted():
-            return idx, [], "budget_exhausted"
-
-        sem = self._get_semaphore()
-        async with sem:
-            try:
-                loop = asyncio.get_running_loop()
-                response = await loop.run_in_executor(
-                    None,
-                    lambda: self.client.models.generate_content(
-                        model=self.model,
-                        contents=prompt,
-                        config=self.types.GenerateContentConfig(
-                            response_mime_type="application/json",
-                            response_schema=self._schema,
-                        ),
-                    ),
-                )
-                # Record token usage
-                usage = getattr(response, "usage_metadata", None)
-                if usage:
-                    in_tok = getattr(usage, "prompt_token_count", 0) or 0
-                    out_tok = getattr(usage, "candidates_token_count", 0) or 0
-                    within_budget = await self.budget.record(in_tok, out_tok)
-                    if not within_budget:
-                        logger.warning(
-                            f"[budget] Token budget exhausted after item {idx}. "
-                            f"Stopping. {self.budget.summary()}"
-                        )
-
-                predictions = self._parse_json_response(response.text)
-                return idx, predictions, None
-
-            except Exception as e:
-                logger.error(f"Gemini async call failed for item {idx}: {e}")
-                return idx, [], str(e)
-
-    async def extract_predictions_batch(
-        self, prompts: list[str]
-    ) -> list[tuple[list[dict], Optional[str]]]:
-        """
-        Run extraction on a batch of prompts concurrently.
-
-        Returns list of (predictions, error_or_None) in input order.
-        Stops dispatching new tasks once budget is exhausted.
-        """
-        self._semaphore = asyncio.Semaphore(self.concurrency)
-        tasks = []
-        for idx, prompt in enumerate(prompts):
-            if self.budget.is_exhausted():
-                logger.warning(
-                    f"[budget] Budget exhausted at item {idx}/{len(prompts)}. "
-                    f"Remaining {len(prompts) - idx} items skipped."
-                )
-                # Fill remaining with budget_exhausted markers
-                for remaining_idx in range(idx, len(prompts)):
-                    tasks.append(asyncio.create_task(self._noop(remaining_idx)))
-                break
-            tasks.append(asyncio.create_task(self._extract_one(idx, prompt)))
-
-        results_raw = await asyncio.gather(*tasks, return_exceptions=True)
-
-        # Re-sort by idx (gather preserves order, but be safe)
-        ordered = {}
-        for res in results_raw:
-            if isinstance(res, Exception):
-                logger.error(f"Task exception: {res}")
-                continue
-            idx, preds, err = res
-            ordered[idx] = (preds, err)
-
-        return [ordered.get(i, ([], "missing")) for i in range(len(prompts))]
-
-    async def _noop(self, idx: int) -> tuple[int, list[dict], str]:
-        return idx, [], "budget_exhausted"
-
-
-# ---------------------------------------------------------------------------
 # Claude Provider
 # ---------------------------------------------------------------------------
 
 
 class ClaudeProvider(LLMProvider):
     """Anthropic Claude API with structured output via system prompt."""
-
-    provider_name = "claude"
 
     def __init__(self, model: str = "claude-sonnet-4-20250514", **kwargs):
         super().__init__(model)
@@ -509,8 +223,6 @@ class ClaudeProvider(LLMProvider):
 
 class OpenAIProvider(LLMProvider):
     """OpenAI API with JSON mode."""
-
-    provider_name = "openai"
 
     def __init__(self, model: str = "gpt-4o", **kwargs):
         super().__init__(model)
@@ -558,8 +270,6 @@ class OpenAIProvider(LLMProvider):
 class OllamaProvider(LLMProvider):
     """Local Ollama models via HTTP API. Zero cost."""
 
-    provider_name = "ollama"
-
     def __init__(
         self,
         model: str = "qwen2.5:32b",
@@ -569,15 +279,7 @@ class OllamaProvider(LLMProvider):
         super().__init__(model)
         self.base_url = os.environ.get("OLLAMA_BASE_URL", base_url)
 
-    def _generate(self, prompt: str, format_json: bool = False) -> tuple[str, int]:
-        """
-        Send a generation request to Ollama.
-
-        Returns:
-            (response_text, total_tokens) where total_tokens is the sum of
-            prompt_eval_count + eval_count from the Ollama response.
-            Returns 0 for total_tokens if the counts are unavailable.
-        """
+    def _generate(self, prompt: str, format_json: bool = False) -> str:
         import requests
 
         payload = {
@@ -596,24 +298,18 @@ class OllamaProvider(LLMProvider):
                 timeout=120,
             )
             resp.raise_for_status()
-            data = resp.json()
-            text = data["response"]
-            total_tokens = (data.get("prompt_eval_count") or 0) + (
-                data.get("eval_count") or 0
-            )
-            return text, total_tokens
+            return resp.json()["response"]
         except Exception as e:
             logger.error(f"Ollama request failed: {e}")
             raise
 
     def extract_predictions(self, prompt: str) -> list[dict]:
         full_prompt = f"{prompt}\n\n{PREDICTION_SCHEMA_DESCRIPTION}\n\nRespond with ONLY a JSON array:"
-        text, tokens = self._generate(full_prompt, format_json=True)
-        self._last_tokens_used = tokens
+        text = self._generate(full_prompt, format_json=True)
         return self._parse_json_response(text)
 
     def classify(self, prompt: str) -> str:
-        text, _ = self._generate(prompt)
+        text = self._generate(prompt)
         return text.strip().lower()
 
 
@@ -623,9 +319,6 @@ class OllamaProvider(LLMProvider):
 
 PROVIDERS = {
     "gemini": GeminiProvider,
-    # gemini-flash is an alias for GeminiProvider that locks in gemini-2.5-flash
-    # and is the recommended provider for high-volume historical backfill runs.
-    "gemini-flash": GeminiProvider,
     "claude": ClaudeProvider,
     "openai": OpenAIProvider,
     "ollama": OllamaProvider,
@@ -650,9 +343,7 @@ def load_llm_config(config_path: Optional[Path] = None) -> dict:
 
 
 def get_provider(
-    role: str = "extraction",
-    config: Optional[dict] = None,
-    provider_override: Optional[str] = None,
+    role: str = "extraction", config: Optional[dict] = None
 ) -> LLMProvider:
     """
     Get an LLM provider for a specific role.
@@ -660,62 +351,27 @@ def get_provider(
     Args:
         role: "extraction" or "filter" — selects config section
         config: Optional config dict. If None, loads from llm_config.yaml
-        provider_override: Override provider name (e.g. "gemini-flash"). Also
-            honored from env vars (lower priority than explicit arg).
-
-    Environment variable overrides (take precedence over llm_config.yaml):
-        LLM_EXTRACTION_PROVIDER — provider name: gemini, gemini-flash, claude, openai, ollama
-        LLM_EXTRACTION_MODEL    — model ID (e.g. gemini-2.5-flash, qwen2.5:32b)
-        EXTRACTION_LLM          — legacy alias for LLM_EXTRACTION_PROVIDER (still supported)
-
-    Cloud Run Job usage:
-        Set LLM_EXTRACTION_PROVIDER=gemini-flash (or =gemini) and GEMINI_API_KEY to use
-        Gemini Flash in production while local dev keeps Ollama via llm_config.yaml.
     """
     if config is None:
         config = load_llm_config()
 
     role_config = config.get(role, config.get("extraction", {}))
-
-    # Resolution order: explicit arg > LLM_EXTRACTION_PROVIDER > EXTRACTION_LLM (legacy) > yaml
-    env_provider = os.environ.get("LLM_EXTRACTION_PROVIDER") or os.environ.get(
-        "EXTRACTION_LLM"
-    )
-    provider_name = (
-        provider_override or env_provider or role_config.get("provider", "ollama")
-    )
-
-    # gemini-flash alias always forces gemini-2.5-flash model
-    if provider_name == "gemini-flash":
-        model = "gemini-2.5-flash"
-    else:
-        # LLM_EXTRACTION_MODEL overrides yaml config when set
-        env_model = os.environ.get("LLM_EXTRACTION_MODEL")
-        model = env_model or role_config.get("model", "gemini-2.5-flash")
+    provider_name = role_config.get("provider", "gemini")
+    model = role_config.get("model", "gemini-2.5-flash")
 
     provider_cls = PROVIDERS.get(provider_name)
     if not provider_cls:
         raise ValueError(
-            f"Unknown LLM provider: {provider_name!r}. "
+            f"Unknown LLM provider: {provider_name}. "
             f"Available: {list(PROVIDERS.keys())}"
         )
-
-    if provider_name in ("gemini", "gemini-flash"):
-        api_key = os.environ.get("GEMINI_API_KEY")
-        if not api_key:
-            raise EnvironmentError(
-                "GEMINI_API_KEY is required when using the gemini/gemini-flash provider. "
-                "Set it with: export GEMINI_API_KEY=<your-key>"
-            )
 
     logger.info(f"Initializing {provider_name} provider (model={model}, role={role})")
     return provider_cls(model=model)
 
 
 def get_provider_with_fallback(
-    role: str = "extraction",
-    config: Optional[dict] = None,
-    provider_override: Optional[str] = None,
+    role: str = "extraction", config: Optional[dict] = None
 ) -> LLMProvider:
     """
     Get provider with fallback chain. Tries primary, falls back to secondary.
@@ -724,7 +380,7 @@ def get_provider_with_fallback(
     if config is None:
         config = load_llm_config()
 
-    primary = get_provider(role, config, provider_override=provider_override)
+    primary = get_provider(role, config)
 
     fallback_config = config.get("fallback", {})
     if not fallback_config.get("enabled", False):
@@ -746,7 +402,6 @@ class _FallbackProvider(LLMProvider):
         super().__init__(model=primary.model)
         self.primary = primary
         self.fallback = fallback
-        self.provider_name = primary.provider_name
 
     def extract_predictions(self, prompt: str) -> list[dict]:
         try:

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -4,25 +4,30 @@ Daily Prediction Resolution Engine (Issue #169, #191)
 Matches PENDING predictions from gold_layer.prediction_ledger against actual
 NFL outcomes to automatically score pundit accuracy.
 
-Handles three categories:
+Handles five categories:
   1. draft_pick — resolved against bronze_sportsdataio_players draft data
   2. game_outcome — resolved against bronze_sportsdataio_scores
-  3. player_performance — resolved against bronze_sportsdataio_player_season_stats
+  3. player_performance — resolved against bronze_nflverse_player_stats (free, no API key)
+  4. award_prediction — resolved against pipeline/config/nfl_awards_<season>.yaml
+  5. fa_signing — resolved against bronze_sportsdataio_players current team data
 
 Usage (inside Docker):
-    python -m src.resolve_daily                         # resolve all pending
-    python -m src.resolve_daily --category draft_pick   # single category
-    python -m src.resolve_daily --dry-run               # preview without writing
+    python -m src.resolve_daily                           # resolve all pending
+    python -m src.resolve_daily --category award_prediction  # single category
+    python -m src.resolve_daily --dry-run                 # preview without writing
 """
 
 import argparse
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Optional
 
 import pandas as pd
+import yaml
 from google.api_core.exceptions import NotFound
+
 from src.db_manager import DBManager
 from src.resolution_engine import (
     get_pending_predictions,
@@ -34,29 +39,6 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
 )
 logger = logging.getLogger(__name__)
-
-# Sports whose resolution logic is fully implemented
-_SUPPORTED_SPORTS = {"NFL"}
-
-
-def _filter_to_supported_sports(pending: pd.DataFrame) -> pd.DataFrame:
-    """
-    Return only rows whose sport is fully supported by this resolver.
-
-    Any sport not yet implemented (e.g. "NBA") is logged and dropped so
-    its predictions stay PENDING rather than being mis-resolved or erroring.
-    """
-    if pending.empty or "sport" not in pending.columns:
-        return pending
-
-    unsupported = pending[~pending["sport"].isin(_SUPPORTED_SPORTS)]
-    for sport, group in unsupported.groupby("sport", dropna=False):
-        for pred_id in group["prediction_hash"]:
-            logger.info(
-                f"Skipping {sport} prediction {pred_id} — {sport} resolver not yet implemented"
-            )
-
-    return pending[pending["sport"].isin(_SUPPORTED_SPORTS)].copy()
 
 
 # ---------------------------------------------------------------------------
@@ -113,8 +95,42 @@ def _extract_draft_claim(claim: str) -> dict:
         "eighth": 8,
         "ninth": 9,
         "tenth": 10,
+        "eleventh": 11,
+        "twelfth": 12,
+        "thirteenth": 13,
+        "fourteenth": 14,
+        "fifteenth": 15,
+        "sixteenth": 16,
+        "seventeenth": 17,
+        "eighteenth": 18,
+        "nineteenth": 19,
+        "twentieth": 20,
     }
-    pick_match = re.search(r"(?:no\.?\s*|#)(\d+)\s*(?:overall\s*)?pick", claim_lower)
+    # Match: "#7 pick", "No. 7 pick", "No. 7 overall pick", "#7 overall",
+    # "drafted 7th overall", "drafted 39th overall", "pick #7", "drafted #7",
+    # plus the original "(N) overall pick" variants.
+    pick_match = re.search(
+        r"(?:no\.?\s*|#|pick\s*#?|drafted\s+#?)(\d+)(?:st|nd|rd|th)?\s*(?:overall|pick)",
+        claim_lower,
+    )
+    if not pick_match:
+        # Bare "#N overall" or "Nth overall" without a leading keyword.
+        pick_match = re.search(r"#?(\d+)(?:st|nd|rd|th)?\s+overall", claim_lower)
+    if not pick_match:
+        # "with the Nth pick in/of/by" or "at pick N" or "with pick No. N"
+        pick_match = re.search(
+            r"(?:with\s+(?:the\s+)?|at\s+)(?:pick\s+(?:no\.?\s*)?)?(\d+)(?:st|nd|rd|th)?\s+pick\b",
+            claim_lower,
+        )
+    if not pick_match:
+        # "with pick No. N" or "by pick No. N" (no trailing keyword)
+        pick_match = re.search(r"(?:with|by|at)\s+pick\s+no\.?\s*(\d+)", claim_lower)
+    if not pick_match:
+        # "at No. N" or "by No. N" — standalone pick number reference
+        pick_match = re.search(r"(?:at|by)\s+no\.?\s*(\d+)\b", claim_lower)
+    if not pick_match:
+        # "drafted #N by" — bare #N followed by "by" team (no overall/pick after)
+        pick_match = re.search(r"drafted\s+#(\d+)\s+by\b", claim_lower)
     if pick_match:
         result["pick_number"] = int(pick_match.group(1))
     else:
@@ -123,16 +139,38 @@ def _extract_draft_claim(claim: str) -> dict:
                 result["pick_number"] = num
                 break
 
-    # Extract "top-N pick"
+    # Pattern 2: ordinal suffix — "16th overall", "3rd overall pick"
+    if "pick_number" not in result:
+        ordinal_match = re.search(
+            r"(\d+)(?:st|nd|rd|th)\s+(?:overall|pick)", claim_lower
+        )
+        if ordinal_match:
+            result["pick_number"] = int(ordinal_match.group(1))
+
+    # Pattern 3: "at No. N" / "No. N overall" / "No. N in the" / "No. N by"
+    if "pick_number" not in result:
+        no_match = re.search(
+            r"(?:at\s+)?no\.?\s*(\d+)\s*(?:overall|in\s+the|by\s+)", claim_lower
+        )
+        if no_match:
+            result["pick_number"] = int(no_match.group(1))
+
+    # Extract "top-N pick" or "within the first N picks"
     top_match = re.search(r"top[- ](\d+)\s*pick", claim_lower)
     if top_match:
         result["top_n"] = int(top_match.group(1))
+    if "top_n" not in result:
+        within_match = re.search(
+            r"within\s+the\s+(?:first\s+)?(?:top\s+)?(\d+)\s+picks?", claim_lower
+        )
+        if within_match:
+            result["top_n"] = int(within_match.group(1))
 
     # Extract "Round 1" or "first round"
     round_match = re.search(r"round\s*(\d+)", claim_lower)
     if round_match:
         result["round_number"] = int(round_match.group(1))
-    elif "first round" in claim_lower:
+    elif "first round" in claim_lower or "first-round" in claim_lower:
         result["round_number"] = 1
 
     # Extract draft year
@@ -143,13 +181,138 @@ def _extract_draft_claim(claim: str) -> dict:
     return result
 
 
-def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
+# NFL team abbreviation mapping for claim parsing
+_TEAM_PATTERNS = {
+    "raiders": "LV",
+    "giants": "NYG",
+    "jets": "NYJ",
+    "cardinals": "ARI",
+    "titans": "TEN",
+    "chiefs": "KC",
+    "commanders": "WAS",
+    "saints": "NO",
+    "browns": "CLE",
+    "cowboys": "DAL",
+    "dolphins": "MIA",
+    "rams": "LAR",
+    "ravens": "BAL",
+    "buccaneers": "TB",
+    "bucs": "TB",
+    "lions": "DET",
+    "vikings": "MIN",
+    "panthers": "CAR",
+    "eagles": "PHI",
+    "steelers": "PIT",
+    "chargers": "LAC",
+    "bears": "CHI",
+    "texans": "HOU",
+    "patriots": "NE",
+    "49ers": "SF",
+    "bills": "BUF",
+    "bengals": "CIN",
+    "seahawks": "SEA",
+    "packers": "GB",
+    "broncos": "DEN",
+    "jaguars": "JAX",
+    "falcons": "ATL",
+    "colts": "IND",
+    "washington": "WAS",
+    "detroit": "DET",
+    "minnesota": "MIN",
+}
+
+
+def _resolve_team_claim(claim, parsed, year_draft_data, phash, db, dry_run):
+    """Resolve team-level draft claims like 'Giants will have two top-10 picks'."""
+    claim_lower = claim.lower()
+
+    # Find team in claim
+    team_abbr = None
+    for pattern, abbr in _TEAM_PATTERNS.items():
+        if pattern in claim_lower:
+            team_abbr = abbr
+            break
+
+    if not team_abbr:
+        return None  # Can't find a team
+
+    team_picks = year_draft_data[year_draft_data["draft_team"] == team_abbr]
+
+    # "will pick a quarterback in Round 1" or "picking a quarterback"
+    if "quarterback" in claim_lower or " qb " in claim_lower:
+        # Check if team drafted a QB (check Position field if available)
+        # For now, just check if they had any pick
+        if not team_picks.empty:
+            notes = f"{team_abbr} had {len(team_picks)} pick(s) in this round"
+            logger.info(f"  TEAM {phash[:12]}… — {notes} (needs manual QB check)")
+        return None  # Can't verify position from draft data alone
+
+    # "will have two picks in the top 10" or "pair of top-10 selections"
+    top_n_match = re.search(r"(two|2|pair|three|3)\s+.*top[- ](\d+)", claim_lower)
+    if top_n_match:
+        count_word = top_n_match.group(1)
+        top_n = int(top_n_match.group(2))
+        expected_count = {"two": 2, "2": 2, "pair": 2, "three": 3, "3": 3}.get(
+            count_word, 2
+        )
+        actual_top = team_picks[team_picks["draft_pick"] <= top_n]
+        correct = len(actual_top) >= expected_count
+        notes = f"{team_abbr} had {len(actual_top)} pick(s) in top {top_n} (expected {expected_count})"
+        logger.info(
+            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — {notes}"
+        )
+        if not dry_run:
+            resolve_binary(
+                phash, correct, outcome_source="draft_board", outcome_notes=notes, db=db
+            )
+        return "resolved"
+
+    return None  # Couldn't parse team claim pattern
+
+
+def _filter_nfl_only(pending: pd.DataFrame) -> pd.DataFrame:
+    """
+    Log and drop any non-NFL predictions from a pending DataFrame.
+
+    When new sport resolvers are added (e.g. NBA), remove the corresponding
+    sport from this filter so those predictions are handled instead of skipped.
+    """
+    if "sport" not in pending.columns:
+        return pending
+
+    non_nfl = pending[pending["sport"].notna() & (pending["sport"] != "NFL")]
+    for _, pred in non_nfl.iterrows():
+        sport = pred["sport"]
+        pred_id = pred["prediction_hash"][:12]
+        logger.info(
+            f"Skipping {sport} prediction {pred_id}… "
+            f"— {sport} resolver not yet implemented"
+        )
+    return pending[pending["sport"].isna() | (pending["sport"] == "NFL")]
+
+
+def resolve_draft_picks(
+    db: DBManager,
+    dry_run: bool = False,
+    sport: Optional[str] = None,
+    pending_override: "Optional[pd.DataFrame]" = None,
+) -> dict:
     """
     Resolve draft_pick predictions against actual draft results.
+
+    Args:
+        sport: When provided, restrict resolution to predictions whose sport
+            matches this value (e.g. "NFL").  None processes all supported sports.
+        pending_override: if supplied, use this DataFrame instead of fetching
+            PENDING predictions — used by the re-resolve-voids pass.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
+    if pending_override is not None:
+        pending = pending_override
+    else:
+        pending = get_pending_predictions(sport=sport, db=db)
+        pending = _filter_nfl_only(pending)
     draft_preds = pending[pending["claim_category"] == "draft_pick"]
 
     if draft_preds.empty:
@@ -161,6 +324,17 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         logger.warning("No draft data available for resolution.")
         return summary
 
+    # SportsDataIO stores the top ~22 first-round picks as 0-indexed
+    # (CollegeDraftRound=0, CollegeDraftPick=0 = #1 overall pick).
+    # Normalize to 1-indexed so all downstream comparisons are consistent.
+    zero_indexed_mask = (draft_data["draft_round"] == 0) & (
+        draft_data["draft_pick"] >= 0
+    )
+    draft_data.loc[zero_indexed_mask, "draft_round"] = 1
+    draft_data.loc[zero_indexed_mask, "draft_pick"] = (
+        draft_data.loc[zero_indexed_mask, "draft_pick"] + 1
+    )
+
     logger.info(
         f"Resolving {len(draft_preds)} draft_pick predictions "
         f"against {len(draft_data)} player draft records"
@@ -170,24 +344,29 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         summary["checked"] += 1
         claim = pred["extracted_claim"]
         phash = pred["prediction_hash"]
-        player_name = pred.get("target_player_id") or ""  # Legacy field (has names)
+        # Check both player name fields
+        player_name = ""
+        for field in ["target_player_name", "target_player_id"]:
+            val = pred.get(field)
+            if val and pd.notna(val) and str(val).lower() not in ("none", "multi", ""):
+                player_name = str(val)
+                break
         season_year = pred.get("season_year")
 
         parsed = _extract_draft_claim(claim)
         draft_year = parsed.get("draft_year")
         if not draft_year and pd.notna(season_year):
             draft_year = int(season_year)
-
+        # Default to current year for draft_pick claims with no year
         if not draft_year:
-            logger.info(f"  SKIP {phash[:12]}… — no draft year in claim or metadata")
-            summary["skipped"] += 1
-            continue
+            draft_year = pd.Timestamp.now().year
 
         # Check if we have actual draft pick data for this year
         current_year = pd.Timestamp.now().year
         year_draft_data = draft_data[
             (draft_data["draft_year"] == draft_year)
             & (draft_data["draft_pick"].notna())
+            & (draft_data["draft_pick"] > 0)
         ]
         if draft_year > current_year or (
             draft_year == current_year and len(year_draft_data) == 0
@@ -216,10 +395,22 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
                     break
 
         if player_matches.empty:
-            logger.info(
-                f"  SKIP {phash[:12]}… — can't find player in draft data: {claim[:60]}"
+            # Try team-level resolution
+            team_result = _resolve_team_claim(
+                claim, parsed, year_draft_data, phash, db, dry_run
             )
-            summary["skipped"] += 1
+            if team_result is not None:
+                if team_result == "resolved":
+                    summary["resolved"] += 1
+                elif team_result == "voided":
+                    summary["voided"] += 1
+                else:
+                    summary["skipped"] += 1
+            else:
+                logger.info(
+                    f"  SKIP {phash[:12]}… — can't find player or team pattern: {claim[:60]}"
+                )
+                summary["skipped"] += 1
             continue
 
         # Use the first match (best match)
@@ -229,8 +420,8 @@ def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
         actual_team = actual.get("draft_team")
         actual_name = actual.get("Name")
 
-        # Skip if pick data is missing or invalid (pick 0 = not yet assigned)
-        if not pd.notna(actual_pick) or int(actual_pick) == 0:
+        # Skip if pick data is missing (0-indexed picks already normalized to 1+ above)
+        if not pd.notna(actual_pick):
             logger.info(
                 f"  SKIP {phash[:12]}… — player found but pick not yet assigned: {actual_name}"
             )
@@ -462,14 +653,21 @@ def _load_game_scores(db: DBManager, season_year: int) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
+def resolve_game_outcomes(
+    db: DBManager, dry_run: bool = False, sport: Optional[str] = None
+) -> dict:
     """
     Resolve game_outcome predictions against actual game results.
     Data source: bronze_sportsdataio_scores (HomeTeam, AwayTeam, HomeScore, AwayScore).
+
+    Args:
+        sport: When provided, restrict resolution to predictions whose sport
+            matches this value (e.g. "NFL").  None processes all supported sports.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
+    pending = get_pending_predictions(sport=sport, db=db)
+    pending = _filter_nfl_only(pending)
     game_preds = pending[pending["claim_category"] == "game_outcome"]
 
     if game_preds.empty:
@@ -633,32 +831,33 @@ def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
 # Player performance resolver
 # ---------------------------------------------------------------------------
 
-# Mapping from common stat phrases → column names in bronze_sportsdataio_player_season_stats
+# Mapping from common stat phrases → column names in bronze_nflverse_player_stats
+# (nflverse uses snake_case columns, not the PascalCase of the old SportsData.io source)
 _STAT_ALIASES: dict[str, str] = {
-    "passing yards": "PassingYards",
-    "passing yard": "PassingYards",
-    "pass yards": "PassingYards",
-    "passing touchdowns": "PassingTouchdowns",
-    "passing tds": "PassingTouchdowns",
-    "passing td": "PassingTouchdowns",
-    "tds": "PassingTouchdowns",  # default to passing (resolved by position context)
-    "interceptions": "Interceptions",
-    "rushing yards": "RushingYards",
-    "rushing yard": "RushingYards",
-    "rush yards": "RushingYards",
-    "rushes for": "RushingYards",
-    "rush for": "RushingYards",
-    "rushing touchdowns": "RushingTouchdowns",
-    "rushing tds": "RushingTouchdowns",
-    "receiving yards": "ReceivingYards",
-    "receiving yard": "ReceivingYards",
-    "rec yards": "ReceivingYards",
-    "receiving touchdowns": "ReceivingTouchdowns",
-    "receiving tds": "ReceivingTouchdowns",
-    "receptions": "Receptions",
-    "catches": "Receptions",
-    "sacks": "Sacks",
-    "tackles": "Tackles",
+    "passing yards": "passing_yards",
+    "passing yard": "passing_yards",
+    "pass yards": "passing_yards",
+    "passing touchdowns": "passing_tds",
+    "passing tds": "passing_tds",
+    "passing td": "passing_tds",
+    "tds": "passing_tds",  # default to passing (resolved by position context)
+    "interceptions": "interceptions",
+    "rushing yards": "rushing_yards",
+    "rushing yard": "rushing_yards",
+    "rush yards": "rushing_yards",
+    "rushes for": "rushing_yards",
+    "rush for": "rushing_yards",
+    "rushing touchdowns": "rushing_tds",
+    "rushing tds": "rushing_tds",
+    "receiving yards": "receiving_yards",
+    "receiving yard": "receiving_yards",
+    "rec yards": "receiving_yards",
+    "receiving touchdowns": "receiving_tds",
+    "receiving tds": "receiving_tds",
+    "receptions": "receptions",
+    "catches": "receptions",
+    "sacks": "sacks",
+    "tackles": "sacks",  # nflverse seasonal data does not have tackles; map to sacks as fallback
 }
 
 
@@ -720,36 +919,53 @@ def _extract_player_stat_claim(claim: str) -> dict:
 
 def _load_player_season_stats(db: DBManager, season_year: int) -> pd.DataFrame:
     """
-    Load player season stats from bronze_sportsdataio_player_season_stats.
-    Returns empty DataFrame if table doesn't exist.
+    Load player season stats from bronze_nflverse_player_stats (free, no API key).
+    Joins with bronze_nflverse_players to resolve player_id → display_name.
+    Returns empty DataFrame if table doesn't exist or has no data for the season.
     """
     project_id = os.environ["GCP_PROJECT_ID"]
     query = f"""
         SELECT
-            Name, Season,
-            PassingYards, PassingTouchdowns, Interceptions,
-            RushingYards, RushingTouchdowns,
-            ReceivingYards, ReceivingTouchdowns, Receptions,
-            Sacks, Tackles
-        FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_player_season_stats`
-        WHERE Season = {season_year}
+            p.display_name AS Name,
+            s.season AS Season,
+            s.passing_yards AS passing_yards,
+            s.passing_tds AS passing_tds,
+            s.interceptions AS interceptions,
+            s.rushing_yards AS rushing_yards,
+            s.rushing_tds AS rushing_tds,
+            s.receiving_yards AS receiving_yards,
+            s.receiving_tds AS receiving_tds,
+            s.receptions AS receptions,
+            s.sacks AS sacks
+        FROM `{project_id}.nfl_dead_money.bronze_nflverse_player_stats` s
+        JOIN `{project_id}.nfl_dead_money.bronze_nflverse_players` p
+          ON s.player_id = p.gsis_id
+        WHERE s.season = {season_year}
+          AND s.season_type = 'REG'
     """
     try:
         return db.fetch_df(query)
-    except (NotFound, Exception) as e:
+    except Exception as e:
         logger.warning(f"Player season stats not available (season {season_year}): {e}")
         return pd.DataFrame()
 
 
-def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
+def resolve_player_performance(
+    db: DBManager, dry_run: bool = False, sport: Optional[str] = None
+) -> dict:
     """
     Resolve player_performance predictions against actual season stats.
-    Data source: bronze_sportsdataio_player_season_stats.
+    Data source: bronze_nflverse_player_stats (free, no API key required).
     Only resolves predictions for completed seasons.
+
+    Args:
+        sport: When provided, restrict resolution to predictions whose sport
+            matches this value (e.g. "NFL").  None processes all supported sports.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
+    pending = get_pending_predictions(sport=sport, db=db)
+    pending = _filter_nfl_only(pending)
     perf_preds = pending[pending["claim_category"] == "player_performance"]
 
     if perf_preds.empty:
@@ -858,7 +1074,7 @@ def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
             resolve_binary(
                 prediction_hash=phash,
                 correct=correct,
-                outcome_source="sportsdataio_player_stats",
+                outcome_source="nflverse_player_stats",
                 outcome_notes=outcome_notes,
                 db=db,
             )
@@ -876,9 +1092,338 @@ def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Award prediction resolver
+# ---------------------------------------------------------------------------
+
+# Maps claim text keywords → award config key in nfl_awards_<season>.yaml
+_AWARD_KEYWORDS: dict[str, list[str]] = {
+    "mvp": ["mvp", "most valuable player"],
+    "opoy": ["opoy", "offensive player of the year"],
+    "dpoy": ["dpoy", "defensive player of the year"],
+    "offensive_rookie": [
+        "offensive rookie of the year",
+        "oroty",
+        "offensive roy",
+    ],
+    "defensive_rookie": [
+        "defensive rookie of the year",
+        "droty",
+        "defensive roy",
+    ],
+    "coach_of_the_year": ["coach of the year", "coty"],
+    "comeback_player": ["comeback player of the year", "cpoy"],
+    "walter_payton_man_of_the_year": ["walter payton", "man of the year"],
+    "super_bowl_mvp": ["super bowl mvp"],
+}
+
+
+def _load_awards_config(season: int) -> dict[str, Optional[str]]:
+    """Load NFL award winners from config/nfl_awards_<season>.yaml."""
+    config_path = Path(__file__).parent.parent / "config" / f"nfl_awards_{season}.yaml"
+    if not config_path.exists():
+        logger.debug(f"Awards config not found: {config_path}")
+        return {}
+    with open(config_path) as fh:
+        data = yaml.safe_load(fh) or {}
+    return data.get("awards", {})
+
+
+def _parse_award_type(claim: str) -> Optional[str]:
+    """Return the award config key if the claim names a known award, else None."""
+    claim_lower = claim.lower()
+    for award_key, keywords in _AWARD_KEYWORDS.items():
+        if any(kw in claim_lower for kw in keywords):
+            return award_key
+    return None
+
+
+def resolve_award_predictions(
+    db: DBManager, season: Optional[int] = None, dry_run: bool = False
+) -> dict:
+    """
+    Resolve award_prediction claims against the award config file for the season.
+
+    Marks CORRECT if the predicted player matches the actual winner, INCORRECT
+    if a different player won, or SKIPPED if the config has no data yet (null).
+    """
+    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
+
+    pending = get_pending_predictions(sport=None, db=db)
+    pending = _filter_nfl_only(pending)
+    award_preds = pending[pending["claim_category"] == "award_prediction"]
+
+    if award_preds.empty:
+        logger.info("No pending award_prediction predictions to resolve.")
+        return summary
+
+    # Cache awards by season to avoid repeated file reads
+    awards_cache: dict[int, dict] = {}
+
+    for _, pred in award_preds.iterrows():
+        summary["checked"] += 1
+        claim = pred["extracted_claim"]
+        phash = pred["prediction_hash"]
+        season_year = pred.get("season_year")
+
+        if pd.isna(season_year):
+            logger.info(f"  SKIP {phash[:12]}… — no season_year on award claim")
+            summary["skipped"] += 1
+            continue
+
+        season_year = int(season_year)
+
+        # NFL awards announced in February of season_year+1
+        now = pd.Timestamp.now()
+        awards_announced = now.year > season_year + 1 or (
+            now.year == season_year + 1 and now.month >= 2
+        )
+        if not awards_announced:
+            logger.info(
+                f"  SKIP {phash[:12]}… — {season_year} season awards not yet announced"
+            )
+            summary["skipped"] += 1
+            continue
+
+        if season_year not in awards_cache:
+            awards_cache[season_year] = _load_awards_config(season_year)
+        awards = awards_cache[season_year]
+
+        if not awards:
+            logger.info(
+                f"  SKIP {phash[:12]}… — no awards config for {season_year} season"
+            )
+            summary["skipped"] += 1
+            continue
+
+        award_key = _parse_award_type(claim)
+        if award_key is None:
+            logger.info(f"  VOID {phash[:12]}… — unrecognised award type: {claim[:60]}")
+            if not dry_run:
+                void_prediction(phash, "unrecognised_award_type", db=db)
+            summary["voided"] += 1
+            continue
+
+        actual_winner = awards.get(award_key)
+        if actual_winner is None:
+            logger.info(
+                f"  SKIP {phash[:12]}… — {award_key} winner not in config for {season_year}"
+            )
+            summary["skipped"] += 1
+            continue
+
+        # Extract the predicted player name
+        predicted_player = pred.get("target_player_name") or pred.get(
+            "target_player_id"
+        )
+        if not predicted_player or pd.isna(predicted_player):
+            logger.info(
+                f"  VOID {phash[:12]}… — no predicted player name: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "no_predicted_player", db=db)
+            summary["voided"] += 1
+            continue
+
+        # Fuzzy name match: both sides lowercased, check if predicted is in actual or vice versa
+        pred_lower = _normalize_name(str(predicted_player))
+        actual_lower = _normalize_name(actual_winner)
+        correct = (
+            pred_lower
+            and actual_lower
+            and (pred_lower in actual_lower or actual_lower in pred_lower)
+        )
+
+        notes = f"{award_key} winner: {actual_winner}"
+        logger.info(
+            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — "
+            f"predicted '{predicted_player}', actual '{actual_winner}' ({award_key})"
+        )
+        if not dry_run:
+            resolve_binary(
+                phash,
+                bool(correct),
+                outcome_source="nfl_awards_config",
+                outcome_notes=notes,
+                db=db,
+            )
+        summary["resolved"] += 1
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# FA signing resolver
+# ---------------------------------------------------------------------------
+
+
+def _load_current_rosters(db: DBManager) -> pd.DataFrame:
+    """Load current player team assignments from bronze_sportsdataio_players."""
+    project_id = os.environ.get("GCP_PROJECT_ID", "cap-alpha-protocol")
+    try:
+        df = db.fetch_df(
+            f"""
+            SELECT
+                Name,
+                LOWER(Name) AS name_lower,
+                Team AS current_team
+            FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_players`
+            WHERE Team IS NOT NULL AND Team != ''
+            """
+        )
+        return df
+    except NotFound:
+        logger.warning("bronze_sportsdataio_players table not found")
+        return pd.DataFrame()
+
+
+def _parse_fa_team(claim: str) -> Optional[str]:
+    """
+    Extract the destination team from an FA signing claim.
+    e.g. "Davante Adams will sign with the Cowboys" → "Cowboys"
+    """
+    # Pattern: "sign with [the] <Team>" or "join [the] <Team>" or "land with <Team>"
+    patterns = [
+        r"(?:sign(?:s|ed)? with|join(?:s|ed)?|land(?:s|ed)? (?:with )?|go(?:es|ing)? to) (?:the )?([A-Z][a-zA-Z\s]+?)(?:\.|,|$|\s(?:on|for|in|at)\b)",
+        r"(?:sign(?:s|ed)? a deal with|ink(?:s|ed)? (?:a deal )?with) (?:the )?([A-Z][a-zA-Z\s]+?)(?:\.|,|$)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, claim)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def resolve_fa_signings(db: DBManager, dry_run: bool = False) -> dict:
+    """
+    Resolve fa_signing predictions against current SportsDataIO roster data.
+
+    Marks CORRECT if the player's current team matches the predicted team,
+    INCORRECT if they're on a different team, VOID if player not found in data.
+    """
+    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
+
+    pending = get_pending_predictions(sport="NFL", db=db)
+    fa_preds = pending[pending["claim_category"] == "fa_signing"]
+
+    if fa_preds.empty:
+        logger.info("No pending fa_signing predictions to resolve.")
+        return summary
+
+    rosters = _load_current_rosters(db)
+    if rosters.empty:
+        logger.warning("No roster data available; skipping fa_signing resolution.")
+        for _ in fa_preds.iterrows():
+            summary["checked"] += 1
+            summary["skipped"] += 1
+        return summary
+
+    for _, pred in fa_preds.iterrows():
+        summary["checked"] += 1
+        claim = pred["extracted_claim"]
+        phash = pred["prediction_hash"]
+
+        player_name = pred.get("target_player_name") or pred.get("target_player_id")
+        if not player_name or pd.isna(player_name):
+            logger.info(
+                f"  VOID {phash[:12]}… — no player name in fa_signing: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "no_player_name", db=db)
+            summary["voided"] += 1
+            continue
+
+        predicted_team_raw = _parse_fa_team(claim)
+        if not predicted_team_raw:
+            logger.info(
+                f"  VOID {phash[:12]}… — can't parse destination team: {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, "unparseable_fa_team", db=db)
+            summary["voided"] += 1
+            continue
+
+        predicted_abbr = _normalize_team(predicted_team_raw)
+        if not predicted_abbr:
+            logger.info(
+                f"  VOID {phash[:12]}… — unknown team '{predicted_team_raw}': {claim[:60]}"
+            )
+            if not dry_run:
+                void_prediction(phash, f"unknown_team:{predicted_team_raw}", db=db)
+            summary["voided"] += 1
+            continue
+
+        norm_player = _normalize_name(str(player_name))
+        player_rows = rosters[
+            rosters["name_lower"].str.contains(norm_player, na=False, regex=False)
+        ]
+
+        if player_rows.empty:
+            logger.info(
+                f"  SKIP {phash[:12]}… — '{player_name}' not found in SportsDataIO"
+            )
+            summary["skipped"] += 1
+            continue
+
+        actual_team = player_rows.iloc[0]["current_team"]
+        actual_abbr = _normalize_team(str(actual_team)) or actual_team
+
+        correct = predicted_abbr == actual_abbr
+        notes = f"predicted {predicted_abbr}, actual {actual_abbr}"
+        logger.info(
+            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — "
+            f"'{player_name}': {notes}"
+        )
+        if not dry_run:
+            resolve_binary(
+                phash,
+                bool(correct),
+                outcome_source="sportsdataio_rosters",
+                outcome_notes=notes,
+                db=db,
+            )
+        summary["resolved"] += 1
+
+    return summary
+
+
+def _get_void_predictions_by_note(
+    note: str, db: DBManager, sport: Optional[str] = "NFL"
+) -> "pd.DataFrame":
+    """
+    Fetch predictions that were previously VOID'd with a specific outcome_notes value.
+    Used by the re-resolve pass to retry previously unresolvable predictions.
+    """
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    sport_filter = f"AND COALESCE(l.sport, 'NFL') = '{sport}'" if sport else ""
+    query = f"""
+        SELECT
+            l.prediction_hash,
+            l.pundit_id,
+            l.pundit_name,
+            l.extracted_claim,
+            l.claim_category,
+            l.season_year,
+            l.target_player_id,
+            l.target_player_name,
+            l.target_team,
+            COALESCE(l.sport, 'NFL') AS sport,
+            l.ingestion_timestamp
+        FROM `{project_id}.gold_layer.prediction_ledger` l
+        JOIN `{project_id}.gold_layer.prediction_resolutions` r
+            ON l.prediction_hash = r.prediction_hash
+        WHERE r.resolution_status = 'VOID'
+          AND r.outcome_notes = '{note}'
+          {sport_filter}
+        ORDER BY l.ingestion_timestamp ASC
+    """
+    return db.fetch_df(query)
+
+
 def resolve_all(
     category: Optional[str] = None,
     dry_run: bool = False,
+    re_resolve_voids: bool = False,
     db: Optional[DBManager] = None,
     sport: Optional[str] = None,
 ) -> dict:
@@ -888,12 +1433,12 @@ def resolve_all(
         category: Limit to a single prediction category (draft_pick, game_outcome,
             player_performance). None means all categories.
         dry_run: Preview without writing results.
+        re_resolve_voids: Re-attempt predictions previously VOID'd as unparseable.
         db: Optional shared DBManager; created internally if not provided.
-        sport: Future use — restrict fetched predictions to a specific sport.
-            Currently ignored at this level because each resolver calls
-            get_pending_predictions(sport=None) and filters unsupported sports
-            via _filter_to_supported_sports.  Pass sport="NBA" once NBA
-            resolution logic is implemented.
+        sport: Restrict fetched predictions to a specific sport (e.g. "NFL").
+            Passed through to get_pending_predictions; unsupported sports are
+            additionally filtered by _filter_nfl_only in each individual resolver.
+            Omit to process all sports.
     """
     close_db = db is None
     if db is None:
@@ -903,15 +1448,39 @@ def resolve_all(
         summaries = {}
 
         if not category or category == "draft_pick":
-            summaries["draft_pick"] = resolve_draft_picks(db, dry_run=dry_run)
+            if re_resolve_voids:
+                # Re-attempt draft predictions previously VOID'd as unparseable
+                void_drafts = _get_void_predictions_by_note(
+                    "unparseable_draft_claim", db=db
+                )
+                logger.info(
+                    f"Re-resolve-voids: {len(void_drafts)} unparseable_draft_claim entries"
+                )
+                if not void_drafts.empty:
+                    summaries["draft_pick_voids"] = resolve_draft_picks(
+                        db, dry_run=dry_run, pending_override=void_drafts
+                    )
+            summaries["draft_pick"] = resolve_draft_picks(
+                db, dry_run=dry_run, sport=sport
+            )
 
         if not category or category == "game_outcome":
-            summaries["game_outcome"] = resolve_game_outcomes(db, dry_run=dry_run)
+            summaries["game_outcome"] = resolve_game_outcomes(
+                db, dry_run=dry_run, sport=sport
+            )
 
         if not category or category == "player_performance":
             summaries["player_performance"] = resolve_player_performance(
+                db, dry_run=dry_run, sport=sport
+            )
+
+        if not category or category == "award_prediction":
+            summaries["award_prediction"] = resolve_award_predictions(
                 db, dry_run=dry_run
             )
+
+        if not category or category == "fa_signing":
+            summaries["fa_signing"] = resolve_fa_signings(db, dry_run=dry_run)
 
         # Combined summary
         total = {
@@ -936,21 +1505,28 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Daily Prediction Resolver")
     parser.add_argument(
         "--category",
-        choices=["draft_pick", "game_outcome", "player_performance"],
+        choices=[
+            "draft_pick",
+            "game_outcome",
+            "player_performance",
+            "award_prediction",
+            "fa_signing",
+        ],
         help="Resolve only a specific category",
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
-        "--sport",
-        default=None,
-        help=(
-            "Restrict resolution to a specific sport (e.g. NFL, NBA). "
-            "Omit to process all supported sports."
-        ),
+        "--re-resolve-voids",
+        action="store_true",
+        help="Also re-attempt predictions previously VOID'd as unparseable",
     )
     args = parser.parse_args()
 
-    result = resolve_all(category=args.category, dry_run=args.dry_run, sport=args.sport)
+    result = resolve_all(
+        category=args.category,
+        dry_run=args.dry_run,
+        re_resolve_voids=args.re_resolve_voids,
+    )
     import json
 
     print(json.dumps(result, indent=2))

--- a/pipeline/src/resolve_daily.py
+++ b/pipeline/src/resolve_daily.py
@@ -4,30 +4,25 @@ Daily Prediction Resolution Engine (Issue #169, #191)
 Matches PENDING predictions from gold_layer.prediction_ledger against actual
 NFL outcomes to automatically score pundit accuracy.
 
-Handles five categories:
+Handles three categories:
   1. draft_pick — resolved against bronze_sportsdataio_players draft data
   2. game_outcome — resolved against bronze_sportsdataio_scores
-  3. player_performance — resolved against bronze_nflverse_player_stats (free, no API key)
-  4. award_prediction — resolved against pipeline/config/nfl_awards_<season>.yaml
-  5. fa_signing — resolved against bronze_sportsdataio_players current team data
+  3. player_performance — resolved against bronze_sportsdataio_player_season_stats
 
 Usage (inside Docker):
-    python -m src.resolve_daily                           # resolve all pending
-    python -m src.resolve_daily --category award_prediction  # single category
-    python -m src.resolve_daily --dry-run                 # preview without writing
+    python -m src.resolve_daily                         # resolve all pending
+    python -m src.resolve_daily --category draft_pick   # single category
+    python -m src.resolve_daily --dry-run               # preview without writing
 """
 
 import argparse
 import logging
 import os
 import re
-from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-import yaml
 from google.api_core.exceptions import NotFound
-
 from src.db_manager import DBManager
 from src.resolution_engine import (
     get_pending_predictions,
@@ -39,6 +34,29 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s — %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+# Sports whose resolution logic is fully implemented
+_SUPPORTED_SPORTS = {"NFL"}
+
+
+def _filter_to_supported_sports(pending: pd.DataFrame) -> pd.DataFrame:
+    """
+    Return only rows whose sport is fully supported by this resolver.
+
+    Any sport not yet implemented (e.g. "NBA") is logged and dropped so
+    its predictions stay PENDING rather than being mis-resolved or erroring.
+    """
+    if pending.empty or "sport" not in pending.columns:
+        return pending
+
+    unsupported = pending[~pending["sport"].isin(_SUPPORTED_SPORTS)]
+    for sport, group in unsupported.groupby("sport", dropna=False):
+        for pred_id in group["prediction_hash"]:
+            logger.info(
+                f"Skipping {sport} prediction {pred_id} — {sport} resolver not yet implemented"
+            )
+
+    return pending[pending["sport"].isin(_SUPPORTED_SPORTS)].copy()
 
 
 # ---------------------------------------------------------------------------
@@ -95,42 +113,8 @@ def _extract_draft_claim(claim: str) -> dict:
         "eighth": 8,
         "ninth": 9,
         "tenth": 10,
-        "eleventh": 11,
-        "twelfth": 12,
-        "thirteenth": 13,
-        "fourteenth": 14,
-        "fifteenth": 15,
-        "sixteenth": 16,
-        "seventeenth": 17,
-        "eighteenth": 18,
-        "nineteenth": 19,
-        "twentieth": 20,
     }
-    # Match: "#7 pick", "No. 7 pick", "No. 7 overall pick", "#7 overall",
-    # "drafted 7th overall", "drafted 39th overall", "pick #7", "drafted #7",
-    # plus the original "(N) overall pick" variants.
-    pick_match = re.search(
-        r"(?:no\.?\s*|#|pick\s*#?|drafted\s+#?)(\d+)(?:st|nd|rd|th)?\s*(?:overall|pick)",
-        claim_lower,
-    )
-    if not pick_match:
-        # Bare "#N overall" or "Nth overall" without a leading keyword.
-        pick_match = re.search(r"#?(\d+)(?:st|nd|rd|th)?\s+overall", claim_lower)
-    if not pick_match:
-        # "with the Nth pick in/of/by" or "at pick N" or "with pick No. N"
-        pick_match = re.search(
-            r"(?:with\s+(?:the\s+)?|at\s+)(?:pick\s+(?:no\.?\s*)?)?(\d+)(?:st|nd|rd|th)?\s+pick\b",
-            claim_lower,
-        )
-    if not pick_match:
-        # "with pick No. N" or "by pick No. N" (no trailing keyword)
-        pick_match = re.search(r"(?:with|by|at)\s+pick\s+no\.?\s*(\d+)", claim_lower)
-    if not pick_match:
-        # "at No. N" or "by No. N" — standalone pick number reference
-        pick_match = re.search(r"(?:at|by)\s+no\.?\s*(\d+)\b", claim_lower)
-    if not pick_match:
-        # "drafted #N by" — bare #N followed by "by" team (no overall/pick after)
-        pick_match = re.search(r"drafted\s+#(\d+)\s+by\b", claim_lower)
+    pick_match = re.search(r"(?:no\.?\s*|#)(\d+)\s*(?:overall\s*)?pick", claim_lower)
     if pick_match:
         result["pick_number"] = int(pick_match.group(1))
     else:
@@ -139,38 +123,16 @@ def _extract_draft_claim(claim: str) -> dict:
                 result["pick_number"] = num
                 break
 
-    # Pattern 2: ordinal suffix — "16th overall", "3rd overall pick"
-    if "pick_number" not in result:
-        ordinal_match = re.search(
-            r"(\d+)(?:st|nd|rd|th)\s+(?:overall|pick)", claim_lower
-        )
-        if ordinal_match:
-            result["pick_number"] = int(ordinal_match.group(1))
-
-    # Pattern 3: "at No. N" / "No. N overall" / "No. N in the" / "No. N by"
-    if "pick_number" not in result:
-        no_match = re.search(
-            r"(?:at\s+)?no\.?\s*(\d+)\s*(?:overall|in\s+the|by\s+)", claim_lower
-        )
-        if no_match:
-            result["pick_number"] = int(no_match.group(1))
-
-    # Extract "top-N pick" or "within the first N picks"
+    # Extract "top-N pick"
     top_match = re.search(r"top[- ](\d+)\s*pick", claim_lower)
     if top_match:
         result["top_n"] = int(top_match.group(1))
-    if "top_n" not in result:
-        within_match = re.search(
-            r"within\s+the\s+(?:first\s+)?(?:top\s+)?(\d+)\s+picks?", claim_lower
-        )
-        if within_match:
-            result["top_n"] = int(within_match.group(1))
 
     # Extract "Round 1" or "first round"
     round_match = re.search(r"round\s*(\d+)", claim_lower)
     if round_match:
         result["round_number"] = int(round_match.group(1))
-    elif "first round" in claim_lower or "first-round" in claim_lower:
+    elif "first round" in claim_lower:
         result["round_number"] = 1
 
     # Extract draft year
@@ -181,138 +143,13 @@ def _extract_draft_claim(claim: str) -> dict:
     return result
 
 
-# NFL team abbreviation mapping for claim parsing
-_TEAM_PATTERNS = {
-    "raiders": "LV",
-    "giants": "NYG",
-    "jets": "NYJ",
-    "cardinals": "ARI",
-    "titans": "TEN",
-    "chiefs": "KC",
-    "commanders": "WAS",
-    "saints": "NO",
-    "browns": "CLE",
-    "cowboys": "DAL",
-    "dolphins": "MIA",
-    "rams": "LAR",
-    "ravens": "BAL",
-    "buccaneers": "TB",
-    "bucs": "TB",
-    "lions": "DET",
-    "vikings": "MIN",
-    "panthers": "CAR",
-    "eagles": "PHI",
-    "steelers": "PIT",
-    "chargers": "LAC",
-    "bears": "CHI",
-    "texans": "HOU",
-    "patriots": "NE",
-    "49ers": "SF",
-    "bills": "BUF",
-    "bengals": "CIN",
-    "seahawks": "SEA",
-    "packers": "GB",
-    "broncos": "DEN",
-    "jaguars": "JAX",
-    "falcons": "ATL",
-    "colts": "IND",
-    "washington": "WAS",
-    "detroit": "DET",
-    "minnesota": "MIN",
-}
-
-
-def _resolve_team_claim(claim, parsed, year_draft_data, phash, db, dry_run):
-    """Resolve team-level draft claims like 'Giants will have two top-10 picks'."""
-    claim_lower = claim.lower()
-
-    # Find team in claim
-    team_abbr = None
-    for pattern, abbr in _TEAM_PATTERNS.items():
-        if pattern in claim_lower:
-            team_abbr = abbr
-            break
-
-    if not team_abbr:
-        return None  # Can't find a team
-
-    team_picks = year_draft_data[year_draft_data["draft_team"] == team_abbr]
-
-    # "will pick a quarterback in Round 1" or "picking a quarterback"
-    if "quarterback" in claim_lower or " qb " in claim_lower:
-        # Check if team drafted a QB (check Position field if available)
-        # For now, just check if they had any pick
-        if not team_picks.empty:
-            notes = f"{team_abbr} had {len(team_picks)} pick(s) in this round"
-            logger.info(f"  TEAM {phash[:12]}… — {notes} (needs manual QB check)")
-        return None  # Can't verify position from draft data alone
-
-    # "will have two picks in the top 10" or "pair of top-10 selections"
-    top_n_match = re.search(r"(two|2|pair|three|3)\s+.*top[- ](\d+)", claim_lower)
-    if top_n_match:
-        count_word = top_n_match.group(1)
-        top_n = int(top_n_match.group(2))
-        expected_count = {"two": 2, "2": 2, "pair": 2, "three": 3, "3": 3}.get(
-            count_word, 2
-        )
-        actual_top = team_picks[team_picks["draft_pick"] <= top_n]
-        correct = len(actual_top) >= expected_count
-        notes = f"{team_abbr} had {len(actual_top)} pick(s) in top {top_n} (expected {expected_count})"
-        logger.info(
-            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — {notes}"
-        )
-        if not dry_run:
-            resolve_binary(
-                phash, correct, outcome_source="draft_board", outcome_notes=notes, db=db
-            )
-        return "resolved"
-
-    return None  # Couldn't parse team claim pattern
-
-
-def _filter_nfl_only(pending: pd.DataFrame) -> pd.DataFrame:
-    """
-    Log and drop any non-NFL predictions from a pending DataFrame.
-
-    When new sport resolvers are added (e.g. NBA), remove the corresponding
-    sport from this filter so those predictions are handled instead of skipped.
-    """
-    if "sport" not in pending.columns:
-        return pending
-
-    non_nfl = pending[pending["sport"].notna() & (pending["sport"] != "NFL")]
-    for _, pred in non_nfl.iterrows():
-        sport = pred["sport"]
-        pred_id = pred["prediction_hash"][:12]
-        logger.info(
-            f"Skipping {sport} prediction {pred_id}… "
-            f"— {sport} resolver not yet implemented"
-        )
-    return pending[pending["sport"].isna() | (pending["sport"] == "NFL")]
-
-
-def resolve_draft_picks(
-    db: DBManager,
-    dry_run: bool = False,
-    sport: Optional[str] = None,
-    pending_override: "Optional[pd.DataFrame]" = None,
-) -> dict:
+def resolve_draft_picks(db: DBManager, dry_run: bool = False) -> dict:
     """
     Resolve draft_pick predictions against actual draft results.
-
-    Args:
-        sport: When provided, restrict resolution to predictions whose sport
-            matches this value (e.g. "NFL").  None processes all supported sports.
-        pending_override: if supplied, use this DataFrame instead of fetching
-            PENDING predictions — used by the re-resolve-voids pass.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    if pending_override is not None:
-        pending = pending_override
-    else:
-        pending = get_pending_predictions(sport=sport, db=db)
-        pending = _filter_nfl_only(pending)
+    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
     draft_preds = pending[pending["claim_category"] == "draft_pick"]
 
     if draft_preds.empty:
@@ -324,17 +161,6 @@ def resolve_draft_picks(
         logger.warning("No draft data available for resolution.")
         return summary
 
-    # SportsDataIO stores the top ~22 first-round picks as 0-indexed
-    # (CollegeDraftRound=0, CollegeDraftPick=0 = #1 overall pick).
-    # Normalize to 1-indexed so all downstream comparisons are consistent.
-    zero_indexed_mask = (draft_data["draft_round"] == 0) & (
-        draft_data["draft_pick"] >= 0
-    )
-    draft_data.loc[zero_indexed_mask, "draft_round"] = 1
-    draft_data.loc[zero_indexed_mask, "draft_pick"] = (
-        draft_data.loc[zero_indexed_mask, "draft_pick"] + 1
-    )
-
     logger.info(
         f"Resolving {len(draft_preds)} draft_pick predictions "
         f"against {len(draft_data)} player draft records"
@@ -344,29 +170,24 @@ def resolve_draft_picks(
         summary["checked"] += 1
         claim = pred["extracted_claim"]
         phash = pred["prediction_hash"]
-        # Check both player name fields
-        player_name = ""
-        for field in ["target_player_name", "target_player_id"]:
-            val = pred.get(field)
-            if val and pd.notna(val) and str(val).lower() not in ("none", "multi", ""):
-                player_name = str(val)
-                break
+        player_name = pred.get("target_player_id") or ""  # Legacy field (has names)
         season_year = pred.get("season_year")
 
         parsed = _extract_draft_claim(claim)
         draft_year = parsed.get("draft_year")
         if not draft_year and pd.notna(season_year):
             draft_year = int(season_year)
-        # Default to current year for draft_pick claims with no year
+
         if not draft_year:
-            draft_year = pd.Timestamp.now().year
+            logger.info(f"  SKIP {phash[:12]}… — no draft year in claim or metadata")
+            summary["skipped"] += 1
+            continue
 
         # Check if we have actual draft pick data for this year
         current_year = pd.Timestamp.now().year
         year_draft_data = draft_data[
             (draft_data["draft_year"] == draft_year)
             & (draft_data["draft_pick"].notna())
-            & (draft_data["draft_pick"] > 0)
         ]
         if draft_year > current_year or (
             draft_year == current_year and len(year_draft_data) == 0
@@ -395,22 +216,10 @@ def resolve_draft_picks(
                     break
 
         if player_matches.empty:
-            # Try team-level resolution
-            team_result = _resolve_team_claim(
-                claim, parsed, year_draft_data, phash, db, dry_run
+            logger.info(
+                f"  SKIP {phash[:12]}… — can't find player in draft data: {claim[:60]}"
             )
-            if team_result is not None:
-                if team_result == "resolved":
-                    summary["resolved"] += 1
-                elif team_result == "voided":
-                    summary["voided"] += 1
-                else:
-                    summary["skipped"] += 1
-            else:
-                logger.info(
-                    f"  SKIP {phash[:12]}… — can't find player or team pattern: {claim[:60]}"
-                )
-                summary["skipped"] += 1
+            summary["skipped"] += 1
             continue
 
         # Use the first match (best match)
@@ -420,8 +229,8 @@ def resolve_draft_picks(
         actual_team = actual.get("draft_team")
         actual_name = actual.get("Name")
 
-        # Skip if pick data is missing (0-indexed picks already normalized to 1+ above)
-        if not pd.notna(actual_pick):
+        # Skip if pick data is missing or invalid (pick 0 = not yet assigned)
+        if not pd.notna(actual_pick) or int(actual_pick) == 0:
             logger.info(
                 f"  SKIP {phash[:12]}… — player found but pick not yet assigned: {actual_name}"
             )
@@ -653,21 +462,14 @@ def _load_game_scores(db: DBManager, season_year: int) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def resolve_game_outcomes(
-    db: DBManager, dry_run: bool = False, sport: Optional[str] = None
-) -> dict:
+def resolve_game_outcomes(db: DBManager, dry_run: bool = False) -> dict:
     """
     Resolve game_outcome predictions against actual game results.
     Data source: bronze_sportsdataio_scores (HomeTeam, AwayTeam, HomeScore, AwayScore).
-
-    Args:
-        sport: When provided, restrict resolution to predictions whose sport
-            matches this value (e.g. "NFL").  None processes all supported sports.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    pending = get_pending_predictions(sport=sport, db=db)
-    pending = _filter_nfl_only(pending)
+    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
     game_preds = pending[pending["claim_category"] == "game_outcome"]
 
     if game_preds.empty:
@@ -831,33 +633,32 @@ def resolve_game_outcomes(
 # Player performance resolver
 # ---------------------------------------------------------------------------
 
-# Mapping from common stat phrases → column names in bronze_nflverse_player_stats
-# (nflverse uses snake_case columns, not the PascalCase of the old SportsData.io source)
+# Mapping from common stat phrases → column names in bronze_sportsdataio_player_season_stats
 _STAT_ALIASES: dict[str, str] = {
-    "passing yards": "passing_yards",
-    "passing yard": "passing_yards",
-    "pass yards": "passing_yards",
-    "passing touchdowns": "passing_tds",
-    "passing tds": "passing_tds",
-    "passing td": "passing_tds",
-    "tds": "passing_tds",  # default to passing (resolved by position context)
-    "interceptions": "interceptions",
-    "rushing yards": "rushing_yards",
-    "rushing yard": "rushing_yards",
-    "rush yards": "rushing_yards",
-    "rushes for": "rushing_yards",
-    "rush for": "rushing_yards",
-    "rushing touchdowns": "rushing_tds",
-    "rushing tds": "rushing_tds",
-    "receiving yards": "receiving_yards",
-    "receiving yard": "receiving_yards",
-    "rec yards": "receiving_yards",
-    "receiving touchdowns": "receiving_tds",
-    "receiving tds": "receiving_tds",
-    "receptions": "receptions",
-    "catches": "receptions",
-    "sacks": "sacks",
-    "tackles": "sacks",  # nflverse seasonal data does not have tackles; map to sacks as fallback
+    "passing yards": "PassingYards",
+    "passing yard": "PassingYards",
+    "pass yards": "PassingYards",
+    "passing touchdowns": "PassingTouchdowns",
+    "passing tds": "PassingTouchdowns",
+    "passing td": "PassingTouchdowns",
+    "tds": "PassingTouchdowns",  # default to passing (resolved by position context)
+    "interceptions": "Interceptions",
+    "rushing yards": "RushingYards",
+    "rushing yard": "RushingYards",
+    "rush yards": "RushingYards",
+    "rushes for": "RushingYards",
+    "rush for": "RushingYards",
+    "rushing touchdowns": "RushingTouchdowns",
+    "rushing tds": "RushingTouchdowns",
+    "receiving yards": "ReceivingYards",
+    "receiving yard": "ReceivingYards",
+    "rec yards": "ReceivingYards",
+    "receiving touchdowns": "ReceivingTouchdowns",
+    "receiving tds": "ReceivingTouchdowns",
+    "receptions": "Receptions",
+    "catches": "Receptions",
+    "sacks": "Sacks",
+    "tackles": "Tackles",
 }
 
 
@@ -919,53 +720,36 @@ def _extract_player_stat_claim(claim: str) -> dict:
 
 def _load_player_season_stats(db: DBManager, season_year: int) -> pd.DataFrame:
     """
-    Load player season stats from bronze_nflverse_player_stats (free, no API key).
-    Joins with bronze_nflverse_players to resolve player_id → display_name.
-    Returns empty DataFrame if table doesn't exist or has no data for the season.
+    Load player season stats from bronze_sportsdataio_player_season_stats.
+    Returns empty DataFrame if table doesn't exist.
     """
     project_id = os.environ["GCP_PROJECT_ID"]
     query = f"""
         SELECT
-            p.display_name AS Name,
-            s.season AS Season,
-            s.passing_yards AS passing_yards,
-            s.passing_tds AS passing_tds,
-            s.interceptions AS interceptions,
-            s.rushing_yards AS rushing_yards,
-            s.rushing_tds AS rushing_tds,
-            s.receiving_yards AS receiving_yards,
-            s.receiving_tds AS receiving_tds,
-            s.receptions AS receptions,
-            s.sacks AS sacks
-        FROM `{project_id}.nfl_dead_money.bronze_nflverse_player_stats` s
-        JOIN `{project_id}.nfl_dead_money.bronze_nflverse_players` p
-          ON s.player_id = p.gsis_id
-        WHERE s.season = {season_year}
-          AND s.season_type = 'REG'
+            Name, Season,
+            PassingYards, PassingTouchdowns, Interceptions,
+            RushingYards, RushingTouchdowns,
+            ReceivingYards, ReceivingTouchdowns, Receptions,
+            Sacks, Tackles
+        FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_player_season_stats`
+        WHERE Season = {season_year}
     """
     try:
         return db.fetch_df(query)
-    except Exception as e:
+    except (NotFound, Exception) as e:
         logger.warning(f"Player season stats not available (season {season_year}): {e}")
         return pd.DataFrame()
 
 
-def resolve_player_performance(
-    db: DBManager, dry_run: bool = False, sport: Optional[str] = None
-) -> dict:
+def resolve_player_performance(db: DBManager, dry_run: bool = False) -> dict:
     """
     Resolve player_performance predictions against actual season stats.
-    Data source: bronze_nflverse_player_stats (free, no API key required).
+    Data source: bronze_sportsdataio_player_season_stats.
     Only resolves predictions for completed seasons.
-
-    Args:
-        sport: When provided, restrict resolution to predictions whose sport
-            matches this value (e.g. "NFL").  None processes all supported sports.
     """
     summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
 
-    pending = get_pending_predictions(sport=sport, db=db)
-    pending = _filter_nfl_only(pending)
+    pending = _filter_to_supported_sports(get_pending_predictions(sport=None, db=db))
     perf_preds = pending[pending["claim_category"] == "player_performance"]
 
     if perf_preds.empty:
@@ -1074,7 +858,7 @@ def resolve_player_performance(
             resolve_binary(
                 prediction_hash=phash,
                 correct=correct,
-                outcome_source="nflverse_player_stats",
+                outcome_source="sportsdataio_player_stats",
                 outcome_notes=outcome_notes,
                 db=db,
             )
@@ -1092,338 +876,9 @@ def resolve_player_performance(
 # ---------------------------------------------------------------------------
 
 
-# ---------------------------------------------------------------------------
-# Award prediction resolver
-# ---------------------------------------------------------------------------
-
-# Maps claim text keywords → award config key in nfl_awards_<season>.yaml
-_AWARD_KEYWORDS: dict[str, list[str]] = {
-    "mvp": ["mvp", "most valuable player"],
-    "opoy": ["opoy", "offensive player of the year"],
-    "dpoy": ["dpoy", "defensive player of the year"],
-    "offensive_rookie": [
-        "offensive rookie of the year",
-        "oroty",
-        "offensive roy",
-    ],
-    "defensive_rookie": [
-        "defensive rookie of the year",
-        "droty",
-        "defensive roy",
-    ],
-    "coach_of_the_year": ["coach of the year", "coty"],
-    "comeback_player": ["comeback player of the year", "cpoy"],
-    "walter_payton_man_of_the_year": ["walter payton", "man of the year"],
-    "super_bowl_mvp": ["super bowl mvp"],
-}
-
-
-def _load_awards_config(season: int) -> dict[str, Optional[str]]:
-    """Load NFL award winners from config/nfl_awards_<season>.yaml."""
-    config_path = Path(__file__).parent.parent / "config" / f"nfl_awards_{season}.yaml"
-    if not config_path.exists():
-        logger.debug(f"Awards config not found: {config_path}")
-        return {}
-    with open(config_path) as fh:
-        data = yaml.safe_load(fh) or {}
-    return data.get("awards", {})
-
-
-def _parse_award_type(claim: str) -> Optional[str]:
-    """Return the award config key if the claim names a known award, else None."""
-    claim_lower = claim.lower()
-    for award_key, keywords in _AWARD_KEYWORDS.items():
-        if any(kw in claim_lower for kw in keywords):
-            return award_key
-    return None
-
-
-def resolve_award_predictions(
-    db: DBManager, season: Optional[int] = None, dry_run: bool = False
-) -> dict:
-    """
-    Resolve award_prediction claims against the award config file for the season.
-
-    Marks CORRECT if the predicted player matches the actual winner, INCORRECT
-    if a different player won, or SKIPPED if the config has no data yet (null).
-    """
-    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
-
-    pending = get_pending_predictions(sport=None, db=db)
-    pending = _filter_nfl_only(pending)
-    award_preds = pending[pending["claim_category"] == "award_prediction"]
-
-    if award_preds.empty:
-        logger.info("No pending award_prediction predictions to resolve.")
-        return summary
-
-    # Cache awards by season to avoid repeated file reads
-    awards_cache: dict[int, dict] = {}
-
-    for _, pred in award_preds.iterrows():
-        summary["checked"] += 1
-        claim = pred["extracted_claim"]
-        phash = pred["prediction_hash"]
-        season_year = pred.get("season_year")
-
-        if pd.isna(season_year):
-            logger.info(f"  SKIP {phash[:12]}… — no season_year on award claim")
-            summary["skipped"] += 1
-            continue
-
-        season_year = int(season_year)
-
-        # NFL awards announced in February of season_year+1
-        now = pd.Timestamp.now()
-        awards_announced = now.year > season_year + 1 or (
-            now.year == season_year + 1 and now.month >= 2
-        )
-        if not awards_announced:
-            logger.info(
-                f"  SKIP {phash[:12]}… — {season_year} season awards not yet announced"
-            )
-            summary["skipped"] += 1
-            continue
-
-        if season_year not in awards_cache:
-            awards_cache[season_year] = _load_awards_config(season_year)
-        awards = awards_cache[season_year]
-
-        if not awards:
-            logger.info(
-                f"  SKIP {phash[:12]}… — no awards config for {season_year} season"
-            )
-            summary["skipped"] += 1
-            continue
-
-        award_key = _parse_award_type(claim)
-        if award_key is None:
-            logger.info(f"  VOID {phash[:12]}… — unrecognised award type: {claim[:60]}")
-            if not dry_run:
-                void_prediction(phash, "unrecognised_award_type", db=db)
-            summary["voided"] += 1
-            continue
-
-        actual_winner = awards.get(award_key)
-        if actual_winner is None:
-            logger.info(
-                f"  SKIP {phash[:12]}… — {award_key} winner not in config for {season_year}"
-            )
-            summary["skipped"] += 1
-            continue
-
-        # Extract the predicted player name
-        predicted_player = pred.get("target_player_name") or pred.get(
-            "target_player_id"
-        )
-        if not predicted_player or pd.isna(predicted_player):
-            logger.info(
-                f"  VOID {phash[:12]}… — no predicted player name: {claim[:60]}"
-            )
-            if not dry_run:
-                void_prediction(phash, "no_predicted_player", db=db)
-            summary["voided"] += 1
-            continue
-
-        # Fuzzy name match: both sides lowercased, check if predicted is in actual or vice versa
-        pred_lower = _normalize_name(str(predicted_player))
-        actual_lower = _normalize_name(actual_winner)
-        correct = (
-            pred_lower
-            and actual_lower
-            and (pred_lower in actual_lower or actual_lower in pred_lower)
-        )
-
-        notes = f"{award_key} winner: {actual_winner}"
-        logger.info(
-            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — "
-            f"predicted '{predicted_player}', actual '{actual_winner}' ({award_key})"
-        )
-        if not dry_run:
-            resolve_binary(
-                phash,
-                bool(correct),
-                outcome_source="nfl_awards_config",
-                outcome_notes=notes,
-                db=db,
-            )
-        summary["resolved"] += 1
-
-    return summary
-
-
-# ---------------------------------------------------------------------------
-# FA signing resolver
-# ---------------------------------------------------------------------------
-
-
-def _load_current_rosters(db: DBManager) -> pd.DataFrame:
-    """Load current player team assignments from bronze_sportsdataio_players."""
-    project_id = os.environ.get("GCP_PROJECT_ID", "cap-alpha-protocol")
-    try:
-        df = db.fetch_df(
-            f"""
-            SELECT
-                Name,
-                LOWER(Name) AS name_lower,
-                Team AS current_team
-            FROM `{project_id}.nfl_dead_money.bronze_sportsdataio_players`
-            WHERE Team IS NOT NULL AND Team != ''
-            """
-        )
-        return df
-    except NotFound:
-        logger.warning("bronze_sportsdataio_players table not found")
-        return pd.DataFrame()
-
-
-def _parse_fa_team(claim: str) -> Optional[str]:
-    """
-    Extract the destination team from an FA signing claim.
-    e.g. "Davante Adams will sign with the Cowboys" → "Cowboys"
-    """
-    # Pattern: "sign with [the] <Team>" or "join [the] <Team>" or "land with <Team>"
-    patterns = [
-        r"(?:sign(?:s|ed)? with|join(?:s|ed)?|land(?:s|ed)? (?:with )?|go(?:es|ing)? to) (?:the )?([A-Z][a-zA-Z\s]+?)(?:\.|,|$|\s(?:on|for|in|at)\b)",
-        r"(?:sign(?:s|ed)? a deal with|ink(?:s|ed)? (?:a deal )?with) (?:the )?([A-Z][a-zA-Z\s]+?)(?:\.|,|$)",
-    ]
-    for pat in patterns:
-        m = re.search(pat, claim)
-        if m:
-            return m.group(1).strip()
-    return None
-
-
-def resolve_fa_signings(db: DBManager, dry_run: bool = False) -> dict:
-    """
-    Resolve fa_signing predictions against current SportsDataIO roster data.
-
-    Marks CORRECT if the player's current team matches the predicted team,
-    INCORRECT if they're on a different team, VOID if player not found in data.
-    """
-    summary = {"checked": 0, "resolved": 0, "voided": 0, "skipped": 0}
-
-    pending = get_pending_predictions(sport="NFL", db=db)
-    fa_preds = pending[pending["claim_category"] == "fa_signing"]
-
-    if fa_preds.empty:
-        logger.info("No pending fa_signing predictions to resolve.")
-        return summary
-
-    rosters = _load_current_rosters(db)
-    if rosters.empty:
-        logger.warning("No roster data available; skipping fa_signing resolution.")
-        for _ in fa_preds.iterrows():
-            summary["checked"] += 1
-            summary["skipped"] += 1
-        return summary
-
-    for _, pred in fa_preds.iterrows():
-        summary["checked"] += 1
-        claim = pred["extracted_claim"]
-        phash = pred["prediction_hash"]
-
-        player_name = pred.get("target_player_name") or pred.get("target_player_id")
-        if not player_name or pd.isna(player_name):
-            logger.info(
-                f"  VOID {phash[:12]}… — no player name in fa_signing: {claim[:60]}"
-            )
-            if not dry_run:
-                void_prediction(phash, "no_player_name", db=db)
-            summary["voided"] += 1
-            continue
-
-        predicted_team_raw = _parse_fa_team(claim)
-        if not predicted_team_raw:
-            logger.info(
-                f"  VOID {phash[:12]}… — can't parse destination team: {claim[:60]}"
-            )
-            if not dry_run:
-                void_prediction(phash, "unparseable_fa_team", db=db)
-            summary["voided"] += 1
-            continue
-
-        predicted_abbr = _normalize_team(predicted_team_raw)
-        if not predicted_abbr:
-            logger.info(
-                f"  VOID {phash[:12]}… — unknown team '{predicted_team_raw}': {claim[:60]}"
-            )
-            if not dry_run:
-                void_prediction(phash, f"unknown_team:{predicted_team_raw}", db=db)
-            summary["voided"] += 1
-            continue
-
-        norm_player = _normalize_name(str(player_name))
-        player_rows = rosters[
-            rosters["name_lower"].str.contains(norm_player, na=False, regex=False)
-        ]
-
-        if player_rows.empty:
-            logger.info(
-                f"  SKIP {phash[:12]}… — '{player_name}' not found in SportsDataIO"
-            )
-            summary["skipped"] += 1
-            continue
-
-        actual_team = player_rows.iloc[0]["current_team"]
-        actual_abbr = _normalize_team(str(actual_team)) or actual_team
-
-        correct = predicted_abbr == actual_abbr
-        notes = f"predicted {predicted_abbr}, actual {actual_abbr}"
-        logger.info(
-            f"  {'CORRECT' if correct else 'INCORRECT'} {phash[:12]}… — "
-            f"'{player_name}': {notes}"
-        )
-        if not dry_run:
-            resolve_binary(
-                phash,
-                bool(correct),
-                outcome_source="sportsdataio_rosters",
-                outcome_notes=notes,
-                db=db,
-            )
-        summary["resolved"] += 1
-
-    return summary
-
-
-def _get_void_predictions_by_note(
-    note: str, db: DBManager, sport: Optional[str] = "NFL"
-) -> "pd.DataFrame":
-    """
-    Fetch predictions that were previously VOID'd with a specific outcome_notes value.
-    Used by the re-resolve pass to retry previously unresolvable predictions.
-    """
-    project_id = os.environ.get("GCP_PROJECT_ID")
-    sport_filter = f"AND COALESCE(l.sport, 'NFL') = '{sport}'" if sport else ""
-    query = f"""
-        SELECT
-            l.prediction_hash,
-            l.pundit_id,
-            l.pundit_name,
-            l.extracted_claim,
-            l.claim_category,
-            l.season_year,
-            l.target_player_id,
-            l.target_player_name,
-            l.target_team,
-            COALESCE(l.sport, 'NFL') AS sport,
-            l.ingestion_timestamp
-        FROM `{project_id}.gold_layer.prediction_ledger` l
-        JOIN `{project_id}.gold_layer.prediction_resolutions` r
-            ON l.prediction_hash = r.prediction_hash
-        WHERE r.resolution_status = 'VOID'
-          AND r.outcome_notes = '{note}'
-          {sport_filter}
-        ORDER BY l.ingestion_timestamp ASC
-    """
-    return db.fetch_df(query)
-
-
 def resolve_all(
     category: Optional[str] = None,
     dry_run: bool = False,
-    re_resolve_voids: bool = False,
     db: Optional[DBManager] = None,
     sport: Optional[str] = None,
 ) -> dict:
@@ -1433,12 +888,12 @@ def resolve_all(
         category: Limit to a single prediction category (draft_pick, game_outcome,
             player_performance). None means all categories.
         dry_run: Preview without writing results.
-        re_resolve_voids: Re-attempt predictions previously VOID'd as unparseable.
         db: Optional shared DBManager; created internally if not provided.
-        sport: Restrict fetched predictions to a specific sport (e.g. "NFL").
-            Passed through to get_pending_predictions; unsupported sports are
-            additionally filtered by _filter_nfl_only in each individual resolver.
-            Omit to process all sports.
+        sport: Future use — restrict fetched predictions to a specific sport.
+            Currently ignored at this level because each resolver calls
+            get_pending_predictions(sport=None) and filters unsupported sports
+            via _filter_to_supported_sports.  Pass sport="NBA" once NBA
+            resolution logic is implemented.
     """
     close_db = db is None
     if db is None:
@@ -1448,39 +903,15 @@ def resolve_all(
         summaries = {}
 
         if not category or category == "draft_pick":
-            if re_resolve_voids:
-                # Re-attempt draft predictions previously VOID'd as unparseable
-                void_drafts = _get_void_predictions_by_note(
-                    "unparseable_draft_claim", db=db
-                )
-                logger.info(
-                    f"Re-resolve-voids: {len(void_drafts)} unparseable_draft_claim entries"
-                )
-                if not void_drafts.empty:
-                    summaries["draft_pick_voids"] = resolve_draft_picks(
-                        db, dry_run=dry_run, pending_override=void_drafts
-                    )
-            summaries["draft_pick"] = resolve_draft_picks(
-                db, dry_run=dry_run, sport=sport
-            )
+            summaries["draft_pick"] = resolve_draft_picks(db, dry_run=dry_run)
 
         if not category or category == "game_outcome":
-            summaries["game_outcome"] = resolve_game_outcomes(
-                db, dry_run=dry_run, sport=sport
-            )
+            summaries["game_outcome"] = resolve_game_outcomes(db, dry_run=dry_run)
 
         if not category or category == "player_performance":
             summaries["player_performance"] = resolve_player_performance(
-                db, dry_run=dry_run, sport=sport
-            )
-
-        if not category or category == "award_prediction":
-            summaries["award_prediction"] = resolve_award_predictions(
                 db, dry_run=dry_run
             )
-
-        if not category or category == "fa_signing":
-            summaries["fa_signing"] = resolve_fa_signings(db, dry_run=dry_run)
 
         # Combined summary
         total = {
@@ -1505,28 +936,21 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Daily Prediction Resolver")
     parser.add_argument(
         "--category",
-        choices=[
-            "draft_pick",
-            "game_outcome",
-            "player_performance",
-            "award_prediction",
-            "fa_signing",
-        ],
+        choices=["draft_pick", "game_outcome", "player_performance"],
         help="Resolve only a specific category",
     )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
-        "--re-resolve-voids",
-        action="store_true",
-        help="Also re-attempt predictions previously VOID'd as unparseable",
+        "--sport",
+        default=None,
+        help=(
+            "Restrict resolution to a specific sport (e.g. NFL, NBA). "
+            "Omit to process all supported sports."
+        ),
     )
     args = parser.parse_args()
 
-    result = resolve_all(
-        category=args.category,
-        dry_run=args.dry_run,
-        re_resolve_voids=args.re_resolve_voids,
-    )
+    result = resolve_all(category=args.category, dry_run=args.dry_run, sport=args.sport)
     import json
 
     print(json.dumps(result, indent=2))

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -160,8 +160,6 @@ class TestExtractAssertions:
             "draft_pick",
             "injury",
             "contract",
-            "award_prediction",
-            "fa_signing",
         }
         assert VALID_CATEGORIES == expected
 
@@ -883,8 +881,6 @@ class TestConstants:
             "draft_pick",
             "injury",
             "contract",
-            "award_prediction",
-            "fa_signing",
         }
         assert VALID_CATEGORIES == expected
 

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -160,6 +160,8 @@ class TestExtractAssertions:
             "draft_pick",
             "injury",
             "contract",
+            "award_prediction",
+            "fa_signing",
         }
         assert VALID_CATEGORIES == expected
 
@@ -881,6 +883,8 @@ class TestConstants:
             "draft_pick",
             "injury",
             "contract",
+            "award_prediction",
+            "fa_signing",
         }
         assert VALID_CATEGORIES == expected
 

--- a/scripts/dispatch-claude.sh
+++ b/scripts/dispatch-claude.sh
@@ -48,11 +48,10 @@ trap 'rm -f "$TMPOUT"' EXIT
 
 set +e
 "${ENV_CMD[@]}" "$CLAUDE_BIN" \
-    -p \
+    -p "$(cat "$PROMPT_FILE")" \
     --model "$MODEL" \
     --add-dir "$WORKTREE" \
     --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
-    --append-system-prompt-file "$PROMPT_FILE" \
     --allow-dangerously-skip-permissions \
     --output-format stream-json \
     --verbose \

--- a/scripts/gh-lars
+++ b/scripts/gh-lars
@@ -36,17 +36,16 @@ if [[ ! -x "$TOKEN_SCRIPT" ]]; then
     exit 1
 fi
 
-# Try GitHub App token first; fall back to default gh auth if it fails.
+# Mint GitHub App token — fail fast if it fails (no bare-gh fallback per CLAUDE.md).
 GH_TOKEN=""
-if GH_TOKEN="$("$TOKEN_SCRIPT" 2>/dev/null)"; then
-    [[ -z "$GH_TOKEN" ]] || export GH_TOKEN
+if ! GH_TOKEN="$("$TOKEN_SCRIPT" 2>&1)"; then
+    echo "Error: GitHub App token minting failed: $GH_TOKEN" >&2
+    exit 1
+fi
+if [[ -z "$GH_TOKEN" ]]; then
+    echo "Error: GitHub App token minting failed (empty token)" >&2
+    exit 1
 fi
 
-# If GitHub App token failed or was empty, use default gh auth
-if [[ -z "${GH_TOKEN:-}" ]]; then
-    # Default to user's authenticated gh session (no explicit token)
-    exec gh "$@"
-else
-    export GH_TOKEN
-    exec gh "$@"
-fi
+export GH_TOKEN
+exec gh "$@"


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` had no CI fallback, causing `@clerk/nextjs: Missing publishableKey` during `next build` static prerendering
- `STRIPE_SECRET_KEY` already used `|| 'sk_test_placeholder_for_ci_build'` — added the same pattern for Clerk
- Root cause of `preflight-build` failures on PRs #529, #530, #531, #532, #420

## Test plan
- [ ] `preflight-build` passes on this PR itself
- [ ] After merge: re-run CI on dependabot PRs #529–#532 to confirm they pass
- [ ] PR #420 will need a separate push to pick up this fix if it predates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)