### PR TITLE
chore(gitignore): ignore Claude Code session runtime log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ docker-compose.override.yml
 .env*
 docker_env.txt
 
+
+# Claude Code session runtime artifacts
+.claude/usage_log.jsonl


### PR DESCRIPTION
## Summary

- Adds `.claude/usage_log.jsonl` to `.gitignore` — this file is auto-generated per Claude Code session and should not be tracked.

## Test plan

- [ ] Verify `.claude/usage_log.jsonl` no longer appears as an untracked file after a session run

https://claude.ai/code/session_01BuYvUoiHmTfMwAuYJSpd4A

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuYvUoiHmTfMwAuYJSpd4A)_