### PR TITLE
chore(#1131): unfreeze llm_judge candidate vocab; keep legacy judge inert in cron

### DIFF
--- a/.github/workflows/pundit_pipeline.yml
+++ b/.github/workflows/pundit_pipeline.yml
@@ -137,13 +137,16 @@ jobs:
       - name: Resolve predictions
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          # #1131: make GEMINI_API_KEY available in the resolve step so the
+          # grounded judge (llm_judge_silver, provider_override=gemini-flash) can
+          # reach a model when it is wired into the cron. We intentionally do NOT
+          # set LLM_EXTRACTION_PROVIDER here: that would activate the legacy
+          # *ungrounded* parametric judge (get_provider role="extraction"), which
+          # adversarial review flagged for unbounded re-judge churn (cost) and
+          # scoring-metric pollution. Keep the legacy judge inert until it has a
+          # per-run LLM-call cap + unresolvable marker, or resolutions route
+          # through the grounded judge instead.
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # #1131: the LLM-judge fallback (run inside resolve_daily) was falling
-          # through to the llm_config.yaml default (Ollama @ localhost), which does
-          # not exist on the GitHub runner — every judge call was connection-refused.
-          # Mirror the Extract step's Gemini override so the judge reaches a real model.
-          LLM_EXTRACTION_PROVIDER: gemini
-          LLM_EXTRACTION_MODEL: gemini-3-flash-preview
           PYTHONPATH: ${{ github.workspace }}/pipeline
         run: |
           cd pipeline

--- a/.github/workflows/pundit_pipeline.yml
+++ b/.github/workflows/pundit_pipeline.yml
@@ -137,6 +137,13 @@ jobs:
       - name: Resolve predictions
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # #1131: the LLM-judge fallback (run inside resolve_daily) was falling
+          # through to the llm_config.yaml default (Ollama @ localhost), which does
+          # not exist on the GitHub runner — every judge call was connection-refused.
+          # Mirror the Extract step's Gemini override so the judge reaches a real model.
+          LLM_EXTRACTION_PROVIDER: gemini
+          LLM_EXTRACTION_MODEL: gemini-3-flash-preview
           PYTHONPATH: ${{ github.workspace }}/pipeline
         run: |
           cd pipeline

--- a/pipeline/src/resolvers/llm_judge.py
+++ b/pipeline/src/resolvers/llm_judge.py
@@ -26,7 +26,13 @@ from src.resolution_engine import ResolutionResult, record_resolution
 logger = logging.getLogger(__name__)
 
 # Predictions with these void reasons are eligible for LLM judge retry.
+# NOTE (#1131): #686 (ff5e7ab9, 2026-05-05) collapsed every void call site in
+# resolve_daily.py onto VoidReason.UNPARSEABLE_CLAIM ("unparseable_claim"). That
+# value was absent here, so the judge's candidate pool silently froze to the
+# pre-2026-05-05 backlog. The legacy strings are kept so that historical backlog
+# stays eligible.
 UNPARSEABLE_NOTES = (
+    "unparseable_claim",  # current VoidReason.UNPARSEABLE_CLAIM value (#686)
     "unparseable_draft_claim",
     "unparseable_game_claim",
     "unparseable_stat_claim",

--- a/pipeline/tests/test_llm_judge.py
+++ b/pipeline/tests/test_llm_judge.py
@@ -31,9 +31,12 @@ class TestUnparseableNotesVocab(unittest.TestCase):
 
     def test_unparseable_notes_values_are_plain_strings(self):
         # An Enum member (instead of its .value) would never match outcome_notes
-        # in the SQL IN clause.
+        # in the SQL IN clause. VoidReason is a `str, Enum`, so isinstance(...,
+        # str) is True for members too — use an identity check on the concrete
+        # type so a stray enum member is actually caught (an enum member renders
+        # as "VoidReason.X" in the f-string that builds the SQL).
         for note in UNPARSEABLE_NOTES:
-            assert isinstance(note, str)
+            assert type(note) is str
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_llm_judge.py
+++ b/pipeline/tests/test_llm_judge.py
@@ -13,9 +13,28 @@ from src.resolvers.llm_judge import (
     DEFAULT_MAX_RESOLUTIONS,
     CONFIDENCE_THRESHOLD,
     JudgeResult,
+    UNPARSEABLE_NOTES,
     judge_claim,
     run_llm_judge_pass,
 )
+from src.resolution_engine import VoidReason
+
+
+class TestUnparseableNotesVocab(unittest.TestCase):
+    """#1131 regression: the judge's candidate filter must include the current
+    VoidReason.UNPARSEABLE_CLAIM value. #686 renamed the void value out from
+    under UNPARSEABLE_NOTES once already (freezing the pool for ~77 days); pin
+    it so that drift can't silently recur."""
+
+    def test_current_unparseable_claim_value_is_eligible(self):
+        assert VoidReason.UNPARSEABLE_CLAIM.value in UNPARSEABLE_NOTES
+
+    def test_unparseable_notes_values_are_plain_strings(self):
+        # An Enum member (instead of its .value) would never match outcome_notes
+        # in the SQL IN clause.
+        for note in UNPARSEABLE_NOTES:
+            assert isinstance(note, str)
+
 
 # ---------------------------------------------------------------------------
 # judge_claim — unit tests (mocked LLM)


### PR DESCRIPTION
Refs #1131 (does NOT fully close it — see below).

Scope after adversarial review slimmed this PR down to **safe plumbing only**:

- **Vocab unfreeze:** add `"unparseable_claim"` (current `VoidReason.UNPARSEABLE_CLAIM.value`) to `UNPARSEABLE_NOTES`, which #686 renamed out from under the judge in 2026-05, silently freezing its candidate pool. Correct future-proofing + a regression test that pins it (type-identity check, so a stray enum member is caught).
- **`GEMINI_API_KEY` staged** into the Resolve step for the *grounded* judge (`llm_judge_silver`) once it is wired into the cron. Verified inert today: `get_provider` selection is `provider_override > LLM_EXTRACTION_PROVIDER > yaml`; the key plays no role in selection.
- **Legacy ungrounded judge stays OFF in cron by design** — `LLM_EXTRACTION_PROVIDER` is intentionally NOT set, so the legacy judge falls to the (dead) ollama default and writes nothing.

**Why this does not close #1131:** production has resolved nothing since 2026-06-02, but the root cause is a rule-resolver stall (see #1167), not the judge vocab — verified against live BigQuery, there are currently **zero** `unparseable_claim` void rows for the vocab fix to act on. This PR removes a latent blocker; it does not by itself restore production resolutions.

**Prerequisites before the legacy judge is ever enabled** (documented, not done here): a per-run LLM-call cap + a persisted "judged-unresolvable" marker (else unbounded re-judge churn), or route resolutions through the grounded judge instead.