### PR TITLE
fix(pipeline): ledger JSON-ingest 400 (#1132) + dedup fetch_df job_config (#1127)

### DIFF
--- a/pipeline/src/cryptographic_ledger.py
+++ b/pipeline/src/cryptographic_ledger.py
@@ -26,7 +26,6 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
-from google.cloud import bigquery
 
 from src.db_manager import DBManager
 
@@ -207,14 +206,23 @@ def _try_advance_chain_head(db: DBManager, expected_hash: str, new_hash: str) ->
 def _append_to_ledger(df: pd.DataFrame, db: DBManager) -> None:
     """
     Writes rows to gold_layer.prediction_ledger using WRITE_APPEND.
-    Uses the BQ client directly because the table lives in a different dataset
-    (gold_layer) than the default nfl_dead_money dataset in DBManager.
+
+    Fixes #1132: this used to call db.client.load_table_from_dataframe(...)
+    directly. target_entity is a JSON-typed destination column (migration
+    022), and load_table_from_dataframe rejects JSON columns with "400
+    Unsupported field type: JSON" (a Parquet limitation) — the identical bug
+    already fixed for write_silver_v2_claims/write_raw_utterances (#1119,
+    #1124/#1126) by routing through DBManager.append_dataframe_to_table,
+    which introspects the destination schema and uses load_table_from_json
+    for JSON-bearing tables instead. append_dataframe_to_table already
+    handles a fully-qualified project.dataset.table ref like this one (the
+    original reason for calling the BQ client directly here — this table
+    lives in gold_layer, not the default nfl_dead_money dataset — no longer
+    requires bypassing it).
     """
     project_id = os.environ.get("GCP_PROJECT_ID")
     table_ref = f"{project_id}.{LEDGER_TABLE}"
-    job_config = bigquery.LoadJobConfig(write_disposition="WRITE_APPEND")
-    job = db.client.load_table_from_dataframe(df, table_ref, job_config=job_config)
-    job.result()
+    db.append_dataframe_to_table(df, table_ref)
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/src/db_manager.py
+++ b/pipeline/src/db_manager.py
@@ -214,6 +214,7 @@ class DBManager:
         query: str,
         params: Optional[Dict[str, Any]] = None,
         query_parameters: Optional[list] = None,
+        job_config: Optional[bigquery.QueryJobConfig] = None,
     ) -> pd.DataFrame:
         """Executes a query and returns a Pandas DataFrame.
 
@@ -223,14 +224,28 @@ class DBManager:
             query_parameters: List of bigquery.ScalarQueryParameter / ArrayQueryParameter
                               for safe @param substitution. Use this for any external or
                               data-derived values to prevent SQL injection.
+            job_config: Optional pre-built bigquery.QueryJobConfig (e.g. one a
+                        caller already constructed via
+                        ``QueryJobConfig(query_parameters=[...])``). Its
+                        query_parameters are merged onto the default_dataset
+                        job_config built internally rather than replacing it,
+                        so default_dataset scoping is never lost. If both
+                        query_parameters and job_config.query_parameters are
+                        given, the explicit query_parameters argument wins.
+                        Fixes #1127: this kwarg previously did not exist, so
+                        any caller passing job_config= raised TypeError, which
+                        made the dedup fail-open handler treat every claim as
+                        a non-duplicate.
         """
         try:
             processed_query, bind_params = self._handle_dataframe_params(query, params)
             dataset_ref = bigquery.DatasetReference(self.project_id, self.dataset_id)
-            job_config = bigquery.QueryJobConfig(default_dataset=dataset_ref)
+            merged_job_config = bigquery.QueryJobConfig(default_dataset=dataset_ref)
+            if job_config is not None and job_config.query_parameters:
+                merged_job_config.query_parameters = job_config.query_parameters
             if query_parameters:
-                job_config.query_parameters = query_parameters
-            job = self.client.query(processed_query, job_config=job_config)
+                merged_job_config.query_parameters = query_parameters
+            job = self.client.query(processed_query, job_config=merged_job_config)
             return job.to_dataframe()
         except Exception as e:
             logger.error(f"Failed to fetch DataFrame: {e}")
@@ -1110,8 +1125,16 @@ class LocalDBManager:
             logger.error("[LOCAL] execute failed: %s\nQuery: %s", e, query[:200])
             raise
 
-    def fetch_df(self, query: str, params=None, query_parameters=None) -> pd.DataFrame:
+    def fetch_df(
+        self, query: str, params=None, query_parameters=None, job_config=None
+    ) -> pd.DataFrame:
+        """See DBManager.fetch_df. ``job_config`` (#1127) is accepted here too
+        so USE_LOCAL_DB=1 doesn't hit the same TypeError as the BigQuery
+        backend — its query_parameters are used when the caller didn't also
+        pass the ``query_parameters`` kwarg directly."""
         try:
+            if query_parameters is None and job_config is not None:
+                query_parameters = getattr(job_config, "query_parameters", None)
             translated = self._translate_query(query, query_parameters)
             return self._duck.execute(translated).df()
         except Exception as e:

--- a/pipeline/src/db_manager.py
+++ b/pipeline/src/db_manager.py
@@ -47,6 +47,15 @@ def _json_load_safe_value(value: Any, is_json_col: bool) -> Any:
                 preview,
             )
             return value
+    # #1165: pandas promotes an int column containing any NULL to float64, so an
+    # Optional[int] (e.g. prediction_ledger.season_year) arrives here as 2026.0.
+    # load_table_from_json would emit that as a JSON float against an INT64
+    # column, which BigQuery can reject ("Could not convert value to integer").
+    # The old load_table_from_dataframe (Parquet) path coerced via the
+    # destination schema; the JSON path does not, so demote integer-valued
+    # floats losslessly here. (NaN floats are already returned as None above.)
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
     return value
 
 

--- a/pipeline/tests/test_claim_dedup.py
+++ b/pipeline/tests/test_claim_dedup.py
@@ -231,6 +231,55 @@ class TestCheckClaimIsDuplicate:
         mock_db.fetch_df.assert_not_called()
 
 
+class _RealSignatureFetchDfStub:
+    """Stub whose fetch_df signature mirrors DBManager.fetch_df's real
+    parameter list exactly (query, params=, query_parameters=, job_config=),
+    rather than a bare MagicMock (which silently accepts any kwarg —
+    precisely why #1127 shipped: the existing `mock_db` fixture's
+    `MagicMock().fetch_df(query, job_config=...)` never raised, so no test
+    caught the signature drift between this call site and the real
+    DBManager.fetch_df, which lacked a job_config parameter).
+    """
+
+    def __init__(self, return_df):
+        self._return_df = return_df
+        self.last_call_kwargs = None
+
+    def fetch_df(self, query, params=None, query_parameters=None, job_config=None):
+        self.last_call_kwargs = {
+            "params": params,
+            "query_parameters": query_parameters,
+            "job_config": job_config,
+        }
+        return self._return_df
+
+
+class TestCheckClaimIsDuplicateRealFetchDfSignature:
+    """Regression coverage for #1127.
+
+    check_claim_is_duplicate calls db.fetch_df(query, job_config=job_config).
+    Before the fix, DBManager.fetch_df had no job_config parameter, so this
+    raised TypeError in production — swallowed by the fail-open handler,
+    which made dedup a permanent no-op. A bare MagicMock db never exercises
+    this because it accepts arbitrary kwargs; _RealSignatureFetchDfStub
+    enforces the actual signature so this test fails the same way
+    production did if the bug regresses.
+    """
+
+    def test_detects_duplicate_via_job_config_kwarg(self):
+        stub = _RealSignatureFetchDfStub(
+            pd.DataFrame([{"prediction_hash": "canonical_hash_hex"}])
+        )
+        result = check_claim_is_duplicate("abc123", stub)
+        assert result == "canonical_hash_hex"
+        assert stub.last_call_kwargs["job_config"] is not None
+
+    def test_returns_none_when_no_match_via_job_config_kwarg(self):
+        stub = _RealSignatureFetchDfStub(pd.DataFrame())
+        result = check_claim_is_duplicate("abc123", stub)
+        assert result is None
+
+
 # ---------------------------------------------------------------------------
 # log_duplicate_claim
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_claim_dedup.py
+++ b/pipeline/tests/test_claim_dedup.py
@@ -336,7 +336,17 @@ class TestLogDuplicateClaim:
 
 
 class TestRunExtractionDedupGate:
-    """Integration tests verifying the dedup gate inside run_extraction."""
+    """Integration tests verifying the dedup gate inside run_extraction.
+
+    All run_extraction() calls pass disable_triage=True: without it,
+    run_extraction spins up a real triage LLM provider (get_provider("triage",
+    ...), enabled by default) that hits localhost:11434 over the network.
+    Whether that host is reachable, times out, or returns a real
+    triage-filter verdict is entirely a function of the local machine's
+    Ollama state — extraction_extractor.py already exposes disable_triage
+    for exactly this reason (dry runs / tests), it just wasn't being passed
+    here, making these tests silently network-flaky.
+    """
 
     @patch("src.assertion_extractor.check_claim_is_duplicate")
     @patch("src.assertion_extractor.ingest_batch")
@@ -353,7 +363,9 @@ class TestRunExtractionDedupGate:
         mock_ingest.return_value = ["pred_hash_1"]
         mock_check_dup.return_value = None  # no duplicate found
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         assert summary["predictions_ingested"] == 1
         assert summary["duplicates_suppressed"] == 0
@@ -384,7 +396,9 @@ class TestRunExtractionDedupGate:
         # Simulate that the claim already exists in the ledger
         mock_check_dup.return_value = "existing_canonical_hash_abc123"
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         # Duplicate must be suppressed from the ledger
         assert summary["duplicates_suppressed"] == 1
@@ -424,7 +438,9 @@ class TestRunExtractionDedupGate:
         mock_ingest.return_value = ["pred_hash_x"]
         mock_check_dup.return_value = None  # neither is in the ledger
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         # Both should be ingested, none suppressed
         assert summary["duplicates_suppressed"] == 0
@@ -453,7 +469,9 @@ class TestRunExtractionDedupGate:
         mock_ingest.return_value = ["pred_hash_1"]
         mock_check_dup.return_value = None  # fail-open
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         assert summary["predictions_ingested"] == 1
         assert summary["duplicates_suppressed"] == 0
@@ -491,7 +509,9 @@ class TestRunExtractionDedupGate:
 
         mock_check_dup.side_effect = side_effect
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         assert summary["duplicates_suppressed"] == 1
         assert summary["predictions_ingested"] == 1
@@ -515,7 +535,9 @@ class TestRunExtractionDedupGate:
         )
         mock_check_dup.return_value = None
 
-        summary = run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         assert "duplicates_suppressed" in summary
         assert summary["duplicates_suppressed"] == 0
@@ -542,7 +564,9 @@ class TestRunExtractionDedupGate:
         mock_ingest.return_value = ["pred_hash_1"]
         mock_check_dup.return_value = None
 
-        run_extraction(limit=10, db=mock_db, provider=mock_provider)
+        run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
 
         passed = mock_ingest.call_args[0][0][0]
         expected_key = compute_claim_norm_key(

--- a/pipeline/tests/test_cryptographic_ledger.py
+++ b/pipeline/tests/test_cryptographic_ledger.py
@@ -56,6 +56,11 @@ def _make_mock_db(chain_head: str = HASH_SEED):
     - ``db.client.query().result()`` is a no-op (DDL / MERGE calls).
     - MERGE job reports 1 row affected (i.e. we win the race) by default.
     - ``db.client.load_table_from_dataframe`` returns a no-op job.
+    - ``db.append_dataframe_to_table`` delegates to
+      ``db.client.load_table_from_dataframe`` (#1132 routes _append_to_ledger
+      through append_dataframe_to_table instead of calling the client
+      method directly) so existing assertions against
+      ``db.client.load_table_from_dataframe.call_args`` keep working.
     """
     db = MagicMock()
 
@@ -75,10 +80,14 @@ def _make_mock_db(chain_head: str = HASH_SEED):
         # sentinel row exists
         db.fetch_df.return_value = pd.DataFrame({"chain_hash": [chain_head]})
 
-    # _append_to_ledger calls db.client.load_table_from_dataframe
+    # _append_to_ledger calls db.append_dataframe_to_table (#1132), which
+    # delegates to db.client.load_table_from_dataframe.
     append_job = MagicMock()
     append_job.result.return_value = None
     db.client.load_table_from_dataframe.return_value = append_job
+    db.append_dataframe_to_table.side_effect = lambda df, table_name: (
+        db.client.load_table_from_dataframe(df, table_name, job_config=None)
+    )
 
     return db
 
@@ -248,6 +257,113 @@ class TestIngestBatch:
         hashes = ingest_batch([], db=mock_db)
         assert hashes == []
         mock_db.client.load_table_from_dataframe.assert_not_called()
+
+
+class _LedgerClientStubDirectLoadRejectsJSON:
+    """Reproduces the production #1132 bug: load_table_from_dataframe is the
+    Parquet-backed path, and BigQuery rejects any destination table with a
+    JSON-typed column (gold_layer.prediction_ledger.target_entity, migration
+    022) with "400 Unsupported field type: JSON"."""
+
+    def query(self, sql, **kwargs):
+        job = MagicMock()
+        job.result.return_value = None
+        job.num_dml_affected_rows = 1
+        return job
+
+    def load_table_from_dataframe(self, *args, **kwargs):
+        raise Exception(
+            "400 Unsupported field type: JSON; reason: invalid, message: "
+            "Unsupported field type: JSON"
+        )
+
+
+class _LedgerDBStubOldPath:
+    """Simulates the pre-#1132-fix code: _append_to_ledger called
+    db.client.load_table_from_dataframe directly, so append_dataframe_to_table
+    was never reached. Calling it here raises to prove the point."""
+
+    def __init__(self):
+        self.client = _LedgerClientStubDirectLoadRejectsJSON()
+
+    def fetch_df(self, query, **kwargs):
+        return pd.DataFrame()  # empty sentinel -> HASH_SEED
+
+    def append_dataframe_to_table(self, df, table_name):
+        raise AssertionError(
+            "old (pre-#1132) code path never called append_dataframe_to_table"
+        )
+
+
+class _LedgerDBStubRoutedFixed:
+    """Simulates the post-#1132-fix code: db.append_dataframe_to_table is the
+    only write path _append_to_ledger uses. A real DBManager routes JSON-
+    bearing tables through load_table_from_json internally (covered by
+    test_db_manager_table_ref.py); here we just capture that the ledger write
+    goes through this method rather than the client directly."""
+
+    def __init__(self):
+        self.appended = []
+        self.client = MagicMock()
+        merge_job = MagicMock()
+        merge_job.result.return_value = None
+        merge_job.num_dml_affected_rows = 1
+        self.client.query.return_value = merge_job
+
+    def fetch_df(self, query, **kwargs):
+        return pd.DataFrame()
+
+    def append_dataframe_to_table(self, df, table_name):
+        self.appended.append((table_name, df.copy()))
+
+    def close(self):
+        pass
+
+
+class TestAppendToLedgerRoutesThroughDBManager:
+    """Regression coverage for #1132.
+
+    Same bug family as #1119/#1124/#1126: _append_to_ledger called
+    db.client.load_table_from_dataframe directly, bypassing
+    DBManager.append_dataframe_to_table's JSON-column handling. target_entity
+    is a JSON-typed destination column on gold_layer.prediction_ledger
+    (migration 022), so every real ingest 400'd with "Unsupported field type:
+    JSON". Fix mirrors #1119/#1124/#1126 exactly: route through
+    db.append_dataframe_to_table(df, table_ref) instead.
+    """
+
+    def test_direct_client_load_reproduces_production_400(self):
+        """Sanity check: the old-path stub's client rejects the write with
+        the exact error string seen in production logs."""
+        db = _LedgerDBStubOldPath()
+        df = pd.DataFrame([{"target_entity": '{"type": "player"}'}])
+        with pytest.raises(Exception, match="Unsupported field type: JSON"):
+            db.client.load_table_from_dataframe(df, "x")
+
+    def test_ingest_batch_routes_through_append_dataframe_to_table(
+        self, sample_prediction
+    ):
+        """ingest_batch -> _append_to_ledger must call
+        db.append_dataframe_to_table, not db.client.load_table_from_dataframe
+        directly — proven by using a stub where only the former succeeds."""
+        db = _LedgerDBStubRoutedFixed()
+        hashes = ingest_batch([sample_prediction], db=db)
+
+        assert len(hashes) == 1
+        assert len(db.appended) == 1
+        table_ref, df = db.appended[0]
+        assert table_ref.endswith("gold_layer.prediction_ledger")
+        assert df.iloc[0]["pundit_id"] == sample_prediction.pundit_id
+
+    def test_regression_guard_direct_client_call_raises(self, sample_prediction):
+        """If _append_to_ledger regresses to calling
+        db.client.load_table_from_dataframe directly again, ingest_batch
+        raises AssertionError instead of silently succeeding — proving the
+        fix is still wired up (mirrors the #1124 regression-test pattern for
+        write_raw_utterances)."""
+        db = _LedgerDBStubOldPath()
+        with pytest.raises(AssertionError, match="append_dataframe_to_table"):
+            ingest_batch([sample_prediction], db=db)
 
 
 class TestVerifyChainIntegrity:
@@ -470,6 +586,12 @@ class TestConcurrentIngestRaceCondition:
             db.client.query = mock_query
             db.fetch_df = mock_fetch_df
             db.client.load_table_from_dataframe = mock_load
+            # _append_to_ledger calls db.append_dataframe_to_table (#1132);
+            # delegate to the same mock_load so appended_rows still captures
+            # every write.
+            db.append_dataframe_to_table = lambda df, table_ref: mock_load(
+                df, table_ref
+            )
             return db
 
         # Thread A ingests pred_0, Thread B ingests pred_1 concurrently.

--- a/pipeline/tests/test_db_manager_table_ref.py
+++ b/pipeline/tests/test_db_manager_table_ref.py
@@ -18,6 +18,7 @@ unlike test_db_manager.py, which requires GCP_PROJECT_ID and hits real BQ.
 import logging
 
 import pandas as pd
+from google.cloud import bigquery
 
 from src.db_manager import DBManager
 
@@ -212,3 +213,78 @@ def test_json_load_safe_value_valid_json_no_warning(caplog):
 
     assert result == {"a": 1}
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for issue #1127 — fetch_df() job_config kwarg
+# ---------------------------------------------------------------------------
+
+
+class _FakeQueryJob:
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def to_dataframe(self) -> pd.DataFrame:
+        return self._df
+
+
+class _FakeQueryClient:
+    """Captures the job_config passed to client.query() so tests can assert
+    fetch_df merged the caller-supplied job_config's query_parameters onto
+    the default_dataset-scoped config it builds internally."""
+
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+        self.captured_job_config = None
+
+    def query(self, query, job_config=None):
+        self.captured_job_config = job_config
+        return _FakeQueryJob(self._df)
+
+
+def test_fetch_df_accepts_job_config_kwarg():
+    """Regression test for #1127: the dedup call site
+    (check_claim_is_duplicate) calls db.fetch_df(query, job_config=job_config)
+    where job_config is a pre-built bigquery.QueryJobConfig. Before the fix,
+    fetch_df()'s signature had no job_config parameter, so this raised
+    "TypeError: fetch_df() got an unexpected keyword argument 'job_config'" —
+    swallowed by the dedup fail-open handler, which made dedup a permanent
+    no-op. fetch_df must accept job_config= without raising and must use its
+    query_parameters."""
+    df = pd.DataFrame({"prediction_hash": ["canonical_hash_hex"]})
+    db = _make_db()
+    db.client = _FakeQueryClient(df)
+
+    caller_job_config = bigquery.QueryJobConfig(
+        query_parameters=[bigquery.ScalarQueryParameter("norm_key", "STRING", "abc123")]
+    )
+    result = db.fetch_df(
+        "SELECT prediction_hash FROM t WHERE claim_norm_key = @norm_key",
+        job_config=caller_job_config,
+    )
+
+    assert result.equals(df)
+    assert db.client.captured_job_config.query_parameters == (
+        caller_job_config.query_parameters
+    )
+    # default_dataset scoping must still be applied — fetch_df must not just
+    # pass the caller's job_config straight through and drop it.
+    assert db.client.captured_job_config.default_dataset is not None
+
+
+def test_fetch_df_query_parameters_kwarg_wins_over_job_config():
+    """When both query_parameters and job_config are given, the explicit
+    query_parameters argument takes precedence (matches every other fetch_df
+    caller's expectation that query_parameters is authoritative)."""
+    df = pd.DataFrame({"x": [1]})
+    db = _make_db()
+    db.client = _FakeQueryClient(df)
+
+    stale_job_config = bigquery.QueryJobConfig(
+        query_parameters=[bigquery.ScalarQueryParameter("a", "STRING", "stale")]
+    )
+    fresh_params = [bigquery.ScalarQueryParameter("a", "STRING", "fresh")]
+
+    db.fetch_df("SELECT 1", query_parameters=fresh_params, job_config=stale_job_config)
+
+    assert db.client.captured_job_config.query_parameters == fresh_params

--- a/pipeline/tests/test_db_manager_table_ref.py
+++ b/pipeline/tests/test_db_manager_table_ref.py
@@ -215,6 +215,27 @@ def test_json_load_safe_value_valid_json_no_warning(caplog):
     assert not any(r.levelno == logging.WARNING for r in caplog.records)
 
 
+def test_json_load_safe_value_demotes_integer_valued_float():
+    """#1165: pandas promotes an int column with any NULL to float64, so an
+    Optional[int] like prediction_ledger.season_year arrives as 2026.0. The
+    JSON load path (unlike the old Parquet path) does no schema coercion, so
+    BigQuery can reject a JSON float at an INT64 column. Integer-valued floats
+    must be demoted losslessly; genuine fractional floats must pass through."""
+    from src.db_manager import _json_load_safe_value
+
+    demoted = _json_load_safe_value(2026.0, is_json_col=False)
+    assert demoted == 2026
+    assert isinstance(demoted, int)
+
+    # Non-integral floats (e.g. a real FLOAT64 column) are untouched.
+    passthrough = _json_load_safe_value(0.75, is_json_col=False)
+    assert passthrough == 0.75
+    assert isinstance(passthrough, float)
+
+    # NaN is still normalised to None (handled before the demotion).
+    assert _json_load_safe_value(float("nan"), is_json_col=False) is None
+
+
 # ---------------------------------------------------------------------------
 # Regression coverage for issue #1127 — fetch_df() job_config kwarg
 # ---------------------------------------------------------------------------

--- a/pipeline/tests/test_sport_field.py
+++ b/pipeline/tests/test_sport_field.py
@@ -72,6 +72,13 @@ class TestIngestPredictionSport:
         mock_job = MagicMock()
         mock_job.result.return_value = None
         db.client.load_table_from_dataframe.return_value = mock_job
+        # _append_to_ledger calls db.append_dataframe_to_table (#1132), which
+        # delegates to db.client.load_table_from_dataframe — keep existing
+        # assertions against db.client.load_table_from_dataframe.call_args
+        # working.
+        db.append_dataframe_to_table.side_effect = lambda df, table_name: (
+            db.client.load_table_from_dataframe(df, table_name, job_config=None)
+        )
         # _try_advance_chain_head calls db.client.query(...); the returned job's
         # num_dml_affected_rows must be an int so `affected > 0` does not raise
         # TypeError on Python 3.10 (MagicMock is not comparable with int).


### PR DESCRIPTION
Closes #1132. Closes #1127.

Two silent-failure bugs in the pipeline data path, both verified against the repo venv.

## #1132 — prediction_ledger ingest 400s every run
`_append_to_ledger` (cryptographic_ledger.py) wrote via `db.client.load_table_from_dataframe` (Parquet path), which 400s on the JSON-typed `target_entity` column (migration 022): `400 Unsupported field type: JSON`. Same family as #1119/#1124/#1126, which fixed `write_silver_v2_claims`/`write_raw_utterances` by routing through `DBManager.append_dataframe_to_table` (introspects schema, uses `load_table_from_json` for JSON-bearing tables). Applied the same routing here. **This is why the ledger stopped accreting new predictions even when extraction succeeded.**

## #1127 — dedup silently fail-open (no-op)
The dedup call site passes `job_config=` to `DBManager.fetch_df()`, which didn't accept it → every call raised `TypeError` → the fail-open handler swallowed it and treated every claim as non-duplicate. Added a `job_config` param to `fetch_df` (both `DBManager` and `LocalDBManager`) that **merges** its `query_parameters` onto the internal `default_dataset` job_config (so dataset scoping is never lost; explicit `query_parameters=` still wins).

## Verification (repo venv)
- Direct regression tests for both bugs pass: the `job_config` fetch_df tests and all of `test_cryptographic_ledger.py` are green (56 passed in the combined run).
- `test_sport_field.py` mock updated to keep an existing assertion valid after the #1132 routing change.

## Known pre-existing failure (NOT introduced here)
`TestRunExtractionDedupGate` (5 tests) is still red — but these **fail on `main` too (6 red there; this PR fixes one)**. Root cause is a `run_extraction`/test-mock drift (the mocked `ingest_batch` is never reached), unrelated to the two fixes in this PR. Flagged for a follow-up rather than expanded here to avoid churning `assertion_extractor.py` while it's under active change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwhbCT9xrEJzKy3qZndPTA