### PR TITLE
fix(migrations): string-aware comment stripping — unblocks scheduled pipeline (migration 031)

### DIFF
--- a/pipeline/scripts/apply_migrations.py
+++ b/pipeline/scripts/apply_migrations.py
@@ -106,20 +106,38 @@ def _split_statements(sql: str) -> list[str]:
     """
     Split a SQL file into individual statements on semicolons.
 
-    Strips line comments first, then splits on semicolons that are NOT inside
-    single-quoted or double-quoted string literals. BigQuery OPTIONS(description="...")
-    clauses commonly contain semicolons which must not be treated as statement
-    delimiters.
+    Strips `--` line comments and splits on `;`, in a SINGLE string-literal-aware
+    pass: both are only recognized when NOT inside a single- or double-quoted
+    string. BigQuery OPTIONS(description="...") clauses routinely contain both `;`
+    and `--` inside the quoted description (e.g. migration 031's embedding-column
+    description), and neither must be treated as a delimiter/comment. The previous
+    implementation stripped `--...` with a naive regex BEFORE this pass, which
+    truncated any description containing `--` mid-string and produced a BigQuery
+    "Unclosed string literal" error.
     """
-    # Strip line comments. Safe because our migration descriptions don't contain --.
-    stripped = re.sub(r"--[^\n]*", "", sql)
-
     parts: list[str] = []
     current: list[str] = []
     in_single = False
     in_double = False
 
-    for ch in stripped:
+    i = 0
+    n = len(sql)
+    while i < n:
+        ch = sql[i]
+        # `--` line comment, only outside a string literal: skip to end of line
+        # (keep the newline itself so line structure / later tokens are intact).
+        if (
+            ch == "-"
+            and i + 1 < n
+            and sql[i + 1] == "-"
+            and not in_single
+            and not in_double
+        ):
+            nl = sql.find("\n", i)
+            if nl == -1:
+                break
+            i = nl
+            continue
         if ch == "'" and not in_double:
             in_single = not in_single
         elif ch == '"' and not in_single:
@@ -129,8 +147,10 @@ def _split_statements(sql: str) -> list[str]:
             if stmt:
                 parts.append(stmt)
             current = []
+            i += 1
             continue
         current.append(ch)
+        i += 1
 
     remainder = "".join(current).strip()
     if remainder:

--- a/pipeline/tests/test_apply_migrations.py
+++ b/pipeline/tests/test_apply_migrations.py
@@ -83,6 +83,35 @@ class TestSplitStatements:
         parts = _split_statements(sql)
         assert len(parts) == 2
 
+    def test_double_dash_inside_string_literal_not_stripped(self):
+        # Regression (migration 031): a `--` inside an OPTIONS(description="...")
+        # must NOT be treated as a line comment. The old naive re.sub stripped
+        # from `--` to EOL, truncating the double-quoted string mid-literal and
+        # producing a BigQuery "Unclosed string literal" 400.
+        sql = (
+            "CREATE TABLE t (\n"
+            '  a STRING OPTIONS(description="dim vector -- see embed.py for details."),\n'
+            '  b INT64 OPTIONS(description="key; one row per id -- never overwritten.")\n'
+            ");"
+        )
+        parts = _split_statements(sql)
+        assert len(parts) == 1, f"Expected 1 statement, got {len(parts)}: {parts}"
+        # The description text (incl. the -- and everything after it) must survive.
+        assert "see embed.py for details." in parts[0]
+        assert "never overwritten." in parts[0]
+        # Balanced double-quotes => no unclosed literal.
+        assert parts[0].count('"') % 2 == 0
+
+    def test_line_comment_still_stripped_outside_strings(self):
+        sql = (
+            "-- header comment\n"
+            "SELECT 1;  -- trailing comment with -- dashes\n"
+            "-- another\nSELECT 2"
+        )
+        parts = _split_statements(sql)
+        assert len(parts) == 2
+        assert "comment" not in " ".join(parts)
+
 
 class TestSha256:
     def test_deterministic(self):


### PR DESCRIPTION
## Incident
The scheduled **Pundit Prediction Pipeline** has failed on every run since ~2026-07-29 23:09 (e.g. runs 30407071890, 30412597948) at the migration step:
`400 Syntax error: Unclosed string literal at [4:61]`. The migration step runs first, so the entire ingest → extract → resolve job aborts — nothing is ingested/extracted/resolved, which also blocks the freshly-merged resolver fix (#1168) from producing any resolution.

## Root cause
`pipeline/scripts/apply_migrations.py::_split_statements` stripped `--` line comments with a naive `re.sub(r"--[^\n]*", "", sql)` **before** its quote-aware split pass, on the explicit (now-false) assumption *"Safe because our migration descriptions don't contain --."* Migration **031** (`031_create_claim_embedding.sql`, #1163) contains ` -- ` inside `OPTIONS(description="...")` strings, so the regex truncated the description mid-literal, leaving an unterminated `"`.

## Fix
Fold comment-stripping into the existing single string-literal-aware pass: a `--` comment (and a `;` delimiter) is only recognized when NOT inside a single/double-quoted string. **The merged migration is left untouched (migrations are immutable) — the tool is corrected.** Verified the real `031` now parses to exactly 1 statement with balanced quotes and the `--`-containing description preserved.

## Tests
+2 regression tests in `TestSplitStatements` (double-dash inside a string literal preserved; line comments outside strings still stripped). Full `test_apply_migrations.py`: 37 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwhbCT9xrEJzKy3qZndPTA