### PR TITLE
fix(migrations): 031 embedding ARRAY cannot be NOT NULL — unblocks pipeline (part 2)

### DIFF
--- a/pipeline/migrations/031_create_claim_embedding.sql
+++ b/pipeline/migrations/031_create_claim_embedding.sql
@@ -23,7 +23,12 @@
 CREATE TABLE IF NOT EXISTS `{project_id}.silver_v2_claims.claim_embedding`
 (
   claim_id     STRING         NOT NULL  OPTIONS(description="FK to silver_v2_claims.claim.claim_id being embedded."),
-  embedding    ARRAY<FLOAT64> NOT NULL  OPTIONS(description="Dense embedding vector of the claim's raw_utterance.text, produced by model_id. 384-dim for the default model_id BAAI/bge-small-en-v1.5 -- see pipeline/src/matching/embed.py."),
+  -- NOTE: ARRAY columns cannot be declared NOT NULL in BigQuery ("NOT NULL
+  -- cannot be applied to ARRAY field; NULL arrays are always stored as an empty
+  -- array"). An empty array is the effective "no embedding" state; writers
+  -- always populate it. Do not add NOT NULL here — it makes the migration a
+  -- hard 400.
+  embedding    ARRAY<FLOAT64>  OPTIONS(description="Dense embedding vector of the claim's raw_utterance.text, produced by model_id. 384-dim for the default model_id BAAI/bge-small-en-v1.5 -- see pipeline/src/matching/embed.py."),
   model_id     STRING         NOT NULL  OPTIONS(description="Embedding model identifier, e.g. BAAI/bge-small-en-v1.5. Part of this table's effective key: one row per (claim_id, model_id); re-embedding under a new model_id inserts a NEW row rather than overwriting the old one, so old vectors are never silently lost on a model upgrade."),
   embedded_at  TIMESTAMP      NOT NULL  OPTIONS(description="UTC wall-clock time this embedding was computed.")
 )

--- a/pipeline/tests/migrations/test_claim_embedding_migration.py
+++ b/pipeline/tests/migrations/test_claim_embedding_migration.py
@@ -103,12 +103,26 @@ class TestSchema:
                 f"Expected column '{col}' not found in migration SQL"
             )
 
-    def test_all_columns_not_null(self, migration_sql):
-        """Every column in this table is required -- there is no
-        legitimate NULL state for a fully-written embedding row."""
-        for col in self.EXPECTED_COLUMNS:
+    # BigQuery rejects NOT NULL on ARRAY columns ("NULL arrays are always stored
+    # as an empty array"), so `embedding` must NOT be NOT NULL — declaring it so
+    # is a hard 400 that aborts the whole migration step (incident 2026-07-29).
+    NOT_NULL_COLUMNS = {"claim_id", "model_id", "embedded_at"}
+
+    def test_scalar_columns_not_null(self, migration_sql):
+        """Every scalar column is required. `embedding` (ARRAY) is excluded:
+        BigQuery disallows NOT NULL on ARRAY fields."""
+        for col in self.NOT_NULL_COLUMNS:
             match = re.search(rf"\b{col}\s+\S+(<\S+>)?\s+NOT NULL", migration_sql)
             assert match, f"Column '{col}' is not declared NOT NULL"
+
+    def test_embedding_array_is_not_not_null(self, migration_sql):
+        """Regression: the embedding ARRAY column must NOT carry NOT NULL, or
+        BigQuery 400s the migration (incident 2026-07-29)."""
+        assert not re.search(
+            r"\bembedding\s+ARRAY<FLOAT64>\s+NOT NULL", migration_sql
+        ), (
+            "embedding ARRAY<FLOAT64> must not be declared NOT NULL (BigQuery rejects it)"
+        )
 
     def test_uses_project_id_placeholder(self, migration_sql):
         """Matches every other migration's envsubst convention --


### PR DESCRIPTION
After #1169 fixed the comment-stripping parse error, migration 031 (#1163) reached BigQuery and failed with a real schema error: `400 NOT NULL cannot be applied to ARRAY field 'embedding'`. 031 has never successfully applied, so ingest/extract/resolve still aborts at the migration step. Fix: drop `NOT NULL` from `embedding ARRAY<FLOAT64>` (BigQuery disallows it; empty array is the no-embedding state); scalar columns stay NOT NULL. Also fixed the migration's own test, which asserted every column incl. the array is NOT NULL (it validated the invalid schema). 14 passed; real 031 parses to 1 clean statement. 031 was never applied, so editing in place is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwhbCT9xrEJzKy3qZndPTA