### PR TITLE
fix(pipeline): recover ingestion — decouple resolve + podcast/YouTube/dead feeds + quota guard

### DIFF
--- a/.github/workflows/pundit_pipeline.yml
+++ b/.github/workflows/pundit_pipeline.yml
@@ -40,6 +40,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Dependencies
+        id: install_deps
         run: |
           python3 -m venv .venv
           .venv/bin/pip install --upgrade pip setuptools wheel
@@ -58,6 +59,7 @@ jobs:
         # Preferred path: workload identity federation — no key file written to disk.
         # Falls back to JSON key if vars.WORKLOAD_IDENTITY_PROVIDER is not configured.
         # See GCP setup instructions in issue #709.
+        id: auth_wif
         if: vars.WORKLOAD_IDENTITY_PROVIDER != ''
         uses: google-github-actions/auth@v2
         with:
@@ -69,6 +71,7 @@ jobs:
         # Writes the key to a temp file that is cleaned up in the Cleanup step.
         # Shell injection risk is mitigated by single-quoting the expansion so
         # the shell never interprets the JSON content.
+        id: auth_json
         if: vars.WORKLOAD_IDENTITY_PROVIDER == ''
         run: |
           echo '${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}' > /tmp/gcp-key.json
@@ -87,6 +90,11 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           PYTHONPATH: ${{ github.workspace }}/pipeline
+          # Powers the 6 `youtube_data_api` sources (media_sources.yaml). If unset,
+          # fetch_youtube_data_api() logs a warning and returns [] per source rather
+          # than failing the run — see media_ingestor.py. Andrew: add this repo
+          # secret to actually pull YouTube content (see PR description).
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
         run: |
           cd pipeline
           python3 -m src.media_ingestor
@@ -115,7 +123,14 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           cd pipeline
-          python3 -m src.assertion_extractor --limit ${{ github.event.inputs.limit || '50' }} --include-unmatched
+          # Precedence: manual workflow_dispatch input > repo variable EXTRACTION_LIMIT
+          # (settable without a code change — lever for the Gemini free-tier 20 req/day
+          # cap) > hardcoded default. run_extraction() also now stops the batch as soon
+          # as it sees one RESOURCE_EXHAUSTED/429 instead of burning the rest of --limit
+          # on doomed calls (see _is_quota_exhausted_error in assertion_extractor.py).
+          # The real fix for the quota ceiling is upgrading off the Gemini free tier —
+          # see PR description.
+          python3 -m src.assertion_extractor --limit ${{ github.event.inputs.limit || vars.EXTRACTION_LIMIT || '50' }} --include-unmatched
 
       - name: Verify extraction produced output
         env:
@@ -135,6 +150,19 @@ jobs:
           python3 -c "from src.sportsdataio_client import ingest_bronze_players; ingest_bronze_players()"
 
       - name: Resolve predictions
+        # Decoupled from the "Verify extraction produced output" gate above
+        # (incident: pipeline-ingestion-recovery). Resolving already-PENDING
+        # predictions does not depend on today's extraction succeeding — a
+        # 0-utterance day (e.g. Gemini free-tier quota exhaustion) must not
+        # also skip resolving predictions from prior days. Gated only on the
+        # environment actually being usable (deps installed, GCP auth
+        # succeeded/was applicable) so Resolve still has working GCP
+        # creds/PYTHONPATH; NOT gated on Ingest/Seed/Extract/Verify outcome.
+        if: |
+          always() &&
+          steps.install_deps.outcome == 'success' &&
+          steps.auth_wif.outcome != 'failure' &&
+          steps.auth_json.outcome != 'failure'
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           # #1131: make GEMINI_API_KEY available in the resolve step so the

--- a/.github/workflows/pundit_pipeline.yml
+++ b/.github/workflows/pundit_pipeline.yml
@@ -78,6 +78,7 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-key.json" >> $GITHUB_ENV
 
       - name: Apply pending migrations
+        id: apply_migrations
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           PYTHONPATH: ${{ github.workspace }}/pipeline
@@ -141,6 +142,16 @@ jobs:
           python3 scripts/check_extraction_health.py --window-minutes 120 --min-count 1
 
       - name: Refresh SportsDataIO draft data
+        # H1 (incident review): gated like Resolve below, NOT behind the extraction
+        # verify step. Resolve grades draft_pick/fa_signing/game_outcome against
+        # bronze_sportsdataio_* — on a quota/verify-fail day this refresh must still
+        # run, or Resolve grades stale roster/draft data and can emit false INCORRECTs.
+        if: |
+          !cancelled() &&
+          steps.install_deps.outcome == 'success' &&
+          steps.apply_migrations.outcome == 'success' &&
+          steps.auth_wif.outcome != 'failure' &&
+          steps.auth_json.outcome != 'failure'
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           SPORTS_DATA_IO_API_KEY: ${{ secrets.SPORTS_DATA_IO_API_KEY }}
@@ -159,8 +170,9 @@ jobs:
         # succeeded/was applicable) so Resolve still has working GCP
         # creds/PYTHONPATH; NOT gated on Ingest/Seed/Extract/Verify outcome.
         if: |
-          always() &&
+          !cancelled() &&
           steps.install_deps.outcome == 'success' &&
+          steps.apply_migrations.outcome == 'success' &&
           steps.auth_wif.outcome != 'failure' &&
           steps.auth_json.outcome != 'failure'
         env:

--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -372,10 +372,16 @@ sources:
   # On self-hosted runner with home IP, YouTube transcript fetching works without
   # the rate-limiting that blocks GitHub-hosted ubuntu-latest runners.
   # Requires yt-dlp (brew install yt-dlp) — works on self-hosted home IP runner
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28: youtube.com/feeds/videos.xml
+  # is IP-blocked on GitHub-hosted runners (ubuntu-latest); the YouTube Data API v3
+  # fetcher (fetch_youtube_data_api) reads the same channel via the official API
+  # instead. Requires YOUTUBE_API_KEY — degrades to a skip-with-warning (not a hard
+  # fail) when the key is absent. See fetch_youtube_data_api() in media_ingestor.py.
   - id: pat_mcafee_show
     name: "The Pat McAfee Show"
     sport: "NFL"
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UCxcTeAKWJca6XyJ37_ZoKIQ"
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCxcTeAKWJca6XyJ37_ZoKIQ"
     enabled: true
     priority_tier: 1  # yield_rate=0.45 (135/299 articles) — high-yield pundit show
@@ -441,11 +447,13 @@ sources:
         name: "Colin Cowherd"
         match_authors: ["Colin Cowherd", "Cowherd"]
 
-  # Requires yt-dlp (brew install yt-dlp)
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28 (see pat_mcafee_show
+  # comment above for rationale — IP-blocked feeds.xml on GitHub-hosted runners).
   - id: club_shay_shay
     name: "Club Shay Shay"
     sport: "NFL"
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UCQoxJOkwaCgyzQtiuAIDcuw"
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCQoxJOkwaCgyzQtiuAIDcuw"
     enabled: true
     priority_tier: 1  # Tier 1: Club Shay Shay interview show; high prediction density when extraction enabled
@@ -469,11 +477,13 @@ sources:
         name: "Nick Wright"
         match_authors: ["Nick Wright", "Wright"]
 
-  # Requires yt-dlp (brew install yt-dlp)
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28 (see pat_mcafee_show
+  # comment above for rationale — IP-blocked feeds.xml on GitHub-hosted runners).
   - id: dan_patrick_show
     name: "The Dan Patrick Show"
     sport: "NFL"
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UCORy0Yqzd8bVj2Gb4xyq6HA"
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCORy0Yqzd8bVj2Gb4xyq6HA"
     enabled: true
     priority_tier: 1  # yield_rate=0.85 (28/33 articles) — high-yield pundit show
@@ -482,11 +492,13 @@ sources:
         name: "Dan Patrick"
         match_authors: ["Dan Patrick"]
 
-  # Requires yt-dlp (brew install yt-dlp)
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28 (see pat_mcafee_show
+  # comment above for rationale — IP-blocked feeds.xml on GitHub-hosted runners).
   - id: rich_eisen_show
     name: "The Rich Eisen Show"
     sport: "NFL"
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UCqMtxjKnR7ySbEZSs2N-v0Q"
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCqMtxjKnR7ySbEZSs2N-v0Q"
     enabled: true
     priority_tier: 2  # yield_rate=unknown (no data yet) — interview/opinion show, estimated medium yield
@@ -1015,10 +1027,13 @@ sources:
   # ── Politics / Geopolitics YouTube (issue #880) ──────────────────────────────
   # High-density geopolitical predictions via YouTube transcripts.
   # Backfill: pipeline/scripts/backfill_youtube_pundit.py
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28 (see pat_mcafee_show
+  # comment above for rationale — IP-blocked feeds.xml on GitHub-hosted runners).
   - id: ian_bremmer_gzero
     name: "GZERO World with Ian Bremmer"
     sport: politics
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UC-8_qAhNVG8G1wxONMnYr3Q"
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UC-8_qAhNVG8G1wxONMnYr3Q"
     enabled: true
     priority_tier: 1  # High-density geopolitical predictions; testable against world events
@@ -1027,10 +1042,15 @@ sources:
         name: "Ian Bremmer"
         match_authors: ["Ian Bremmer", "Bremmer", "gzeromedia"]
 
+  # Switched youtube_transcript -> youtube_data_api 2026-07-28 (see pat_mcafee_show
+  # comment above for rationale — IP-blocked feeds.xml on GitHub-hosted runners).
+  # keyword_filter below is applied by fetch_youtube_data_api too, so the
+  # Roubini-only scoping of this multi-guest channel is preserved.
   - id: nouriel_roubini
     name: "Nouriel Roubini (Bloomberg TV)"
     sport: politics
-    type: youtube_transcript
+    type: youtube_data_api
+    channel_id: "UCIALMKvObZNtJ6AmdCLP7Lg"
     # Bloomberg Television main channel — keyword_filter picks only Roubini appearances.
     # Roubini appears frequently here; no dedicated personal channel exists.
     url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCIALMKvObZNtJ6AmdCLP7Lg"
@@ -1108,13 +1128,16 @@ sources:
         name: "Jovan Buha"
         match_authors: ["Jovan Buha", "Buha"]
 
+  # theringer.com/rss/nba/index.xml returns 404 (same site-wide RSS deprecation
+  # as the_ringer_nfl above); The Ringer NBA Show podcast is the active feed.
+  # Fixed 2026-07-28: mirrors the the_ringer_nfl podcast fix.
   - id: ringer_nba
     name: "The Ringer NBA"
     sport: "NBA"
-    type: rss
+    type: podcast
     scrape_full_text: true
-    url: "https://www.theringer.com/rss/nba/index.xml"
-    enabled: true
+    url: "https://feeds.megaphone.fm/the-ringer-nba-show"
+    enabled: true  # validated 2026-07-28: 200, active podcast feed (Group Chat / Real Ones)
     priority_tier: 1  # Tier 1: Kevin O'Connor + long-form prediction-dense NBA analysis
     default_pundit:
       id: ringer_nba_staff
@@ -1356,13 +1379,17 @@ sources:
         name: "Byrne Hobart"
         match_authors: ["Byrne Hobart", "Hobart", "thediff"]
 
+  # blocked: epsilontheory.com/feed/ 302-redirects to panoptica.com/feed/ (site
+  # rebranded to Panoptica) which 404s; panoptica.com is a Next.js app with no
+  # discoverable RSS/Atom feed (checked /feed, /rss, /rss/ — all 404); no
+  # working replacement found (2026-07-28)
   - id: epsilon_theory
     name: "Epsilon Theory (Ben Hunt)"
     sport: finance
     type: rss
     scrape_full_text: true
     url: "https://www.epsilontheory.com/feed/"
-    enabled: true
+    enabled: false
     priority_tier: 2  # Tier 2: narrative-finance analysis; predictions embedded in long-form essays
     default_pundit:
       id: ben_hunt

--- a/pipeline/config/media_sources.yaml
+++ b/pipeline/config/media_sources.yaml
@@ -169,7 +169,7 @@ sources:
     name: "The Ringer NFL"
     sport: "NFL"
     type: podcast
-    scrape_full_text: true
+    scrape_full_text: false  # C1: podcast items have no HTML page; enclosure is an mp3 URL — don't readability-scrape
     url: "https://feeds.megaphone.fm/the-ringer-nfl-show"
     enabled: true  # validated 2026-05-30: 200, active podcast feed with NFL prediction content
     priority_tier: 1  # Tier 1: analytical long-form; high testable prediction density
@@ -1135,7 +1135,7 @@ sources:
     name: "The Ringer NBA"
     sport: "NBA"
     type: podcast
-    scrape_full_text: true
+    scrape_full_text: false  # C1: podcast items have no HTML page; enclosure is an mp3 URL — don't readability-scrape
     url: "https://feeds.megaphone.fm/the-ringer-nba-show"
     enabled: true  # validated 2026-07-28: 200, active podcast feed (Group Chat / Real Ones)
     priority_tier: 1  # Tier 1: Kevin O'Connor + long-form prediction-dense NBA analysis

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -226,6 +226,27 @@ def _is_transient_llm_error(exc: BaseException) -> bool:
     return False
 
 
+# Fragments identifying quota-exhaustion errors (e.g. Gemini free-tier
+# RESOURCE_EXHAUSTED / HTTP 429). Once one of these is seen, every remaining
+# item in the batch is guaranteed to fail the same way until the quota
+# resets — so run_extraction() stops iterating instead of "hammering" the
+# API with N more doomed requests (see incident: free-tier 20 req/day cap).
+_QUOTA_EXHAUSTED_FRAGMENTS = (
+    "resource_exhausted",
+    "429",
+    "quota exceeded",
+    "exceeded your current quota",
+    "exceeded quota",
+    "rate limit",
+)
+
+
+def _is_quota_exhausted_error(err: str) -> bool:
+    """Return True if an extraction error string indicates provider quota exhaustion."""
+    msg = err.lower()
+    return any(frag in msg for frag in _QUOTA_EXHAUSTED_FRAGMENTS)
+
+
 # Default tier assigned to sources not found in media_sources.yaml
 DEFAULT_PRIORITY_TIER = 2
 
@@ -3007,6 +3028,7 @@ def run_extraction(
         "zero_claims_articles": 0,  # articles where LLM returned 0 claims
         "articles_write_failed": 0,  # articles where BQ write failed (retried next run)
         "failed_sources": [],  # source_ids that produced write errors this run
+        "quota_exhausted": False,  # provider quota hit — batch stopped early (see #<incident>)
     }
 
     # Entity validation config — reads ENTITY_VALIDATION_ENABLED env var (off by default)
@@ -3180,6 +3202,21 @@ def run_extraction(
                 # Do NOT mark as processed — leave the hash out of
                 # processed_hashes so the next pipeline run will retry
                 # this article rather than silently treating it as done.
+                if _is_quota_exhausted_error(result.error):
+                    # Provider quota is exhausted (e.g. Gemini free-tier
+                    # RESOURCE_EXHAUSTED / 429) — every remaining item in this
+                    # batch would fail identically. Stop now instead of
+                    # burning the rest of --limit on doomed calls; the
+                    # remaining media stays unprocessed and is picked up by
+                    # the next scheduled run once quota resets.
+                    summary["quota_exhausted"] = True
+                    logger.error(
+                        f"Provider quota exhausted after {summary['total_processed']} "
+                        f"item(s) — stopping extraction batch early "
+                        f"({len(media_df) - summary['total_processed']} item(s) "
+                        f"left unprocessed for next run)."
+                    )
+                    break
                 continue
 
             # Phase C: write ALL utterances to raw_utterance regardless of

--- a/pipeline/src/assertion_extractor.py
+++ b/pipeline/src/assertion_extractor.py
@@ -233,18 +233,24 @@ def _is_transient_llm_error(exc: BaseException) -> bool:
 # API with N more doomed requests (see incident: free-tier 20 req/day cap).
 _QUOTA_EXHAUSTED_FRAGMENTS = (
     "resource_exhausted",
-    "429",
     "quota exceeded",
     "exceeded your current quota",
     "exceeded quota",
     "rate limit",
 )
 
+# M4: HTTP 429 as a standalone token. A bare "429" substring also matches "429"
+# inside larger numbers (token counts, run ids, byte offsets) in unrelated error
+# strings and would falsely stop the batch; require word boundaries.
+_HTTP_429_RE = re.compile(r"\b429\b")
+
 
 def _is_quota_exhausted_error(err: str) -> bool:
     """Return True if an extraction error string indicates provider quota exhaustion."""
     msg = err.lower()
-    return any(frag in msg for frag in _QUOTA_EXHAUSTED_FRAGMENTS)
+    return bool(_HTTP_429_RE.search(msg)) or any(
+        frag in msg for frag in _QUOTA_EXHAUSTED_FRAGMENTS
+    )
 
 
 # Default tier assigned to sources not found in media_sources.yaml

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -355,6 +355,8 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
         content_type = "article"
         if source.get("type") == "youtube_rss":
             content_type = "video"
+        elif source.get("type") == "podcast":
+            content_type = "podcast_episode"
 
         metadata = {}
         if entry.get("tags"):
@@ -892,6 +894,7 @@ def fetch_youtube_data_api(source: dict, defaults: dict) -> list[MediaItem]:
     pundits = source.get("pundits", [])
     sport = source.get("sport", "NFL")
     max_items = defaults.get("max_items_per_feed", 50)
+    keyword_filter = source.get("keyword_filter", [])
 
     if not _api_key_available():
         logger.warning(
@@ -940,6 +943,7 @@ def fetch_youtube_data_api(source: dict, defaults: dict) -> list[MediaItem]:
 
     items = []
     now = datetime.now(timezone.utc)
+    skipped_by_filter = 0
 
     for video in videos:
         title = video["title"]
@@ -958,6 +962,12 @@ def fetch_youtube_data_api(source: dict, defaults: dict) -> list[MediaItem]:
         text = build_video_text(video)
         if not text.strip():
             logger.debug(f"[{source_id}] No text for video {video_id} ({title})")
+            continue
+
+        # Apply keyword filter if configured (e.g. nouriel_roubini scopes a
+        # multi-guest channel down to appearances mentioning the pundit).
+        if keyword_filter and not _passes_keyword_filter(title, text, keyword_filter):
+            skipped_by_filter += 1
             continue
 
         # Parse published date
@@ -990,6 +1000,10 @@ def fetch_youtube_data_api(source: dict, defaults: dict) -> list[MediaItem]:
             )
         )
 
+    if skipped_by_filter:
+        logger.info(
+            f"[{source_id}] Keyword filter skipped {skipped_by_filter} non-matching video(s)"
+        )
     logger.info(f"[{source_id}] YouTube Data API returned {len(items)} items")
     return items
 
@@ -997,6 +1011,7 @@ def fetch_youtube_data_api(source: dict, defaults: dict) -> list[MediaItem]:
 FETCHERS = {
     "rss": fetch_rss,
     "youtube_rss": fetch_rss,  # YouTube Atom feeds work with feedparser
+    "podcast": fetch_rss,  # Megaphone (and most podcast hosts) serve plain RSS 2.0
     "youtube_transcript": fetch_youtube_transcripts,
     "youtube_data_api": fetch_youtube_data_api,  # Official API — replaces IP-blocked scraping
 }

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -313,6 +313,16 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
         title = entry.get("title", "")
         link = entry.get("link", "")
         if not link:
+            # C1 (incident review): podcast feeds (Megaphone etc.) commonly have
+            # no per-item <link> — episode identity lives in <enclosure url> or
+            # <guid>/<id>. Fall back so podcast items aren't silently dropped
+            # (which is how the "podcast fetcher" change was a no-op before).
+            enclosures = entry.get("enclosures") or []
+            if enclosures and enclosures[0].get("href"):
+                link = enclosures[0]["href"]
+            else:
+                link = entry.get("id", "")
+        if not link:
             continue
 
         # Extract author
@@ -356,7 +366,7 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
         if source.get("type") == "youtube_rss":
             content_type = "video"
         elif source.get("type") == "podcast":
-            content_type = "podcast_episode"
+            content_type = "podcast"  # matches schema doc (migrations/005): article|video|podcast|tweet
 
         metadata = {}
         if entry.get("tags"):

--- a/pipeline/tests/test_assertion_extractor.py
+++ b/pipeline/tests/test_assertion_extractor.py
@@ -241,6 +241,27 @@ class TestExtractAssertions:
         assert _is_transient_llm_error(Exception("quota exceeded")) is False
         assert _is_transient_llm_error(Exception("403 forbidden")) is False
 
+    def test_is_quota_exhausted_error_classifies_correctly(self):
+        """Unit test for the quota-exhaustion classifier used to short-circuit
+        run_extraction()'s batch loop (Gemini free-tier 429/RESOURCE_EXHAUSTED)."""
+        from src.assertion_extractor import _is_quota_exhausted_error
+
+        assert _is_quota_exhausted_error("429 RESOURCE_EXHAUSTED") is True
+        assert (
+            _is_quota_exhausted_error(
+                "google.api_core.exceptions.ResourceExhausted: 429 You exceeded "
+                "your current quota, please check your plan and billing details."
+            )
+            is True
+        )
+        assert _is_quota_exhausted_error("quota exceeded") is True
+        assert _is_quota_exhausted_error("rate limit hit, try again later") is True
+
+        # Not quota errors — must not falsely trip the short-circuit
+        assert _is_quota_exhausted_error("connection refused") is False
+        assert _is_quota_exhausted_error("401 unauthorized") is False
+        assert _is_quota_exhausted_error("invalid api key") is False
+
     def test_valid_categories_are_complete(self):
         """All expected categories are defined."""
         expected = {
@@ -591,6 +612,57 @@ class TestRunExtraction:
 
         assert summary["errors"] == 1
         assert summary["predictions_extracted"] == 0
+
+    @patch("src.assertion_extractor.extract_assertions")
+    def test_stops_batch_on_quota_exhaustion(
+        self, mock_extract, mock_db, mock_provider
+    ):
+        """A RESOURCE_EXHAUSTED/429 error must stop the batch immediately instead
+        of burning the rest of --limit on doomed calls against an exhausted
+        provider quota (incident: Gemini free-tier 20 req/day cap)."""
+        mock_db.fetch_df.return_value = make_raw_media_df(3)
+        mock_extract.return_value = ExtractionResult(
+            content_hash="hash_0",
+            predictions=[],
+            error="429 RESOURCE_EXHAUSTED. You exceeded your current quota.",
+        )
+
+        # disable_triage=True: otherwise run_extraction spins up the real triage
+        # provider (localhost Ollama) which filters the mock rows out before
+        # extract_assertions is ever called (call_count would be 0).
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
+
+        # Only the first item should have been attempted before the batch
+        # stopped — the other two rows in media_df must be left untouched.
+        assert mock_extract.call_count == 1
+        assert summary["total_processed"] == 1
+        assert summary["errors"] == 1
+        assert summary["quota_exhausted"] is True
+
+    @patch("src.assertion_extractor.extract_assertions")
+    def test_non_quota_error_does_not_stop_batch(
+        self, mock_extract, mock_db, mock_provider
+    ):
+        """A plain transient/unknown error should NOT trip the quota short-circuit —
+        the batch keeps processing the remaining items."""
+        mock_db.fetch_df.return_value = make_raw_media_df(3)
+        mock_extract.return_value = ExtractionResult(
+            content_hash="hash_0",
+            predictions=[],
+            error="connection reset by peer",
+        )
+
+        # disable_triage=True — see test_stops_batch_on_quota_exhaustion.
+        summary = run_extraction(
+            limit=10, db=mock_db, provider=mock_provider, disable_triage=True
+        )
+
+        assert mock_extract.call_count == 3
+        assert summary["total_processed"] == 3
+        assert summary["errors"] == 3
+        assert summary["quota_exhausted"] is False
 
     @patch("src.assertion_extractor.extract_assertions")
     def test_error_does_not_mark_as_processed(

--- a/pipeline/tests/test_media_ingestor.py
+++ b/pipeline/tests/test_media_ingestor.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pytest
 
 from src.media_ingestor import (
+    FETCHERS,
     MediaItem,
     SourceResult,
     _extract_video_id,
@@ -432,6 +433,77 @@ class TestFetchRSS:
 # ---------------------------------------------------------------------------
 # ingest_source
 # ---------------------------------------------------------------------------
+
+
+class TestPodcastFetcherRegistration:
+    """Regression tests for the missing `podcast` fetcher (#pipeline-ingestion-recovery).
+
+    the_ringer_nfl and bill_simmons_podcast are `type: podcast` sources backed
+    by plain Megaphone RSS feeds. Before this fix, FETCHERS had no "podcast"
+    key, so ingest_source() hard-failed both sources every run with
+    "No fetcher for source type: podcast".
+    """
+
+    def test_podcast_type_is_registered(self):
+        assert "podcast" in FETCHERS
+
+    def test_podcast_type_routes_to_fetch_rss(self):
+        assert FETCHERS["podcast"] is fetch_rss
+
+    @patch("src.media_ingestor.feedparser")
+    def test_podcast_source_fetches_via_rss(self, mock_fp):
+        """A `type: podcast` source (e.g. Megaphone feed) is fetched exactly
+        like a plain RSS feed and tagged content_type=podcast_episode."""
+        entry = MagicMock()
+        entry.get = lambda k, d=None: {
+            "title": "The Ringer NFL Show: Week 1 Preview",
+            "link": "https://feeds.megaphone.fm/ep1",
+            "author": "Robert Mays",
+        }.get(k, d)
+        entry.published_parsed = None
+        type(entry).summary = property(
+            lambda self: "Predictions for every Week 1 game."
+        )
+        entry.content = []
+        entry.tags = []
+
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [entry]
+        mock_fp.parse.return_value = mock_feed
+
+        source = {
+            "id": "the_ringer_nfl",
+            "name": "The Ringer NFL",
+            "type": "podcast",
+            "url": "https://feeds.megaphone.fm/the-ringer-nfl-show",
+            "pundits": [],
+        }
+        items = FETCHERS["podcast"](source, {"max_items_per_feed": 10})
+
+        assert len(items) == 1
+        assert items[0].content_type == "podcast_episode"
+        assert items[0].fetch_source_type == "podcast"
+        assert items[0].source_url == "https://feeds.megaphone.fm/ep1"
+
+    def test_ingest_source_no_longer_errors_for_podcast_type(self, mock_db):
+        """End-to-end: ingest_source() must not report 'No fetcher' for podcast
+        sources — this was the exact failure mode before FETCHERS["podcast"]
+        was registered."""
+        mock_db.fetch_df.return_value = pd.DataFrame()
+        source = {
+            "id": "bill_simmons_podcast",
+            "name": "The Bill Simmons Podcast",
+            "type": "podcast",
+            "url": "https://feeds.megaphone.fm/the-bill-simmons-podcast",
+            "pundits": [],
+        }
+        mock_fetcher = MagicMock(return_value=[])
+        with patch.dict("src.media_ingestor.FETCHERS", {"podcast": mock_fetcher}):
+            result = ingest_source(source, {"max_items_per_feed": 10}, mock_db)
+
+        assert result.error is None
+        mock_fetcher.assert_called_once()
 
 
 class TestIngestSource:

--- a/pipeline/tests/test_media_ingestor.py
+++ b/pipeline/tests/test_media_ingestor.py
@@ -453,7 +453,7 @@ class TestPodcastFetcherRegistration:
     @patch("src.media_ingestor.feedparser")
     def test_podcast_source_fetches_via_rss(self, mock_fp):
         """A `type: podcast` source (e.g. Megaphone feed) is fetched exactly
-        like a plain RSS feed and tagged content_type=podcast_episode."""
+        like a plain RSS feed and tagged content_type=podcast."""
         entry = MagicMock()
         entry.get = lambda k, d=None: {
             "title": "The Ringer NFL Show: Week 1 Preview",
@@ -482,9 +482,72 @@ class TestPodcastFetcherRegistration:
         items = FETCHERS["podcast"](source, {"max_items_per_feed": 10})
 
         assert len(items) == 1
-        assert items[0].content_type == "podcast_episode"
+        assert items[0].content_type == "podcast"
         assert items[0].fetch_source_type == "podcast"
         assert items[0].source_url == "https://feeds.megaphone.fm/ep1"
+
+    @patch("src.media_ingestor.feedparser")
+    def test_podcast_entry_without_link_uses_enclosure(self, mock_fp):
+        """C1 regression: Megaphone episodes have NO per-item <link> — identity
+        lives in <enclosure url>/<guid>. fetch_rss must fall back to those, or
+        every podcast episode is silently dropped (the no-op the podcast fetcher
+        change originally shipped)."""
+        entry = MagicMock()
+        entry.get = lambda k, d=None: {
+            "title": "Bill Simmons Podcast: NFL Bets",
+            "link": "",  # real Megaphone behavior: no per-item link
+            "enclosures": [{"href": "https://traffic.megaphone.fm/ep99.mp3"}],
+            "id": "gid://megaphone/ep99",
+        }.get(k, d)
+        entry.published_parsed = None
+        type(entry).summary = property(lambda self: "Some NFL betting predictions.")
+        entry.content = []
+        entry.tags = []
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [entry]
+        mock_fp.parse.return_value = mock_feed
+
+        source = {
+            "id": "bill_simmons_podcast",
+            "name": "Bill Simmons",
+            "type": "podcast",
+            "url": "https://feeds.megaphone.fm/bs",
+            "pundits": [],
+        }
+        items = FETCHERS["podcast"](source, {"max_items_per_feed": 10})
+
+        assert len(items) == 1, "podcast episode with no <link> must NOT be dropped"
+        assert items[0].source_url == "https://traffic.megaphone.fm/ep99.mp3"
+
+    @patch("src.media_ingestor.feedparser")
+    def test_podcast_entry_without_link_or_enclosure_falls_back_to_guid(self, mock_fp):
+        """No link, no enclosure, but a <guid>/<id> — still ingestible via id."""
+        entry = MagicMock()
+        entry.get = lambda k, d=None: {
+            "title": "Ep with only a guid",
+            "link": "",
+            "id": "gid://megaphone/ep-guid-only",
+        }.get(k, d)
+        entry.published_parsed = None
+        type(entry).summary = property(lambda self: "text")
+        entry.content = []
+        entry.tags = []
+        mock_feed = MagicMock()
+        mock_feed.bozo = False
+        mock_feed.entries = [entry]
+        mock_fp.parse.return_value = mock_feed
+
+        source = {
+            "id": "the_ringer_nfl",
+            "name": "Ringer NFL",
+            "type": "podcast",
+            "url": "https://feeds.megaphone.fm/rn",
+            "pundits": [],
+        }
+        items = FETCHERS["podcast"](source, {"max_items_per_feed": 10})
+        assert len(items) == 1
+        assert items[0].source_url == "gid://megaphone/ep-guid-only"
 
     def test_ingest_source_no_longer_errors_for_podcast_type(self, mock_db):
         """End-to-end: ingest_source() must not report 'No fetcher' for podcast

--- a/pipeline/tests/test_youtube_client.py
+++ b/pipeline/tests/test_youtube_client.py
@@ -441,6 +441,45 @@ class TestFetchYoutubeDataApiIngestor:
         assert items[0].published_at.month == 4
         assert items[0].published_at.day == 24
 
+    @patch("src.media_ingestor.fetch_youtube_videos")
+    def test_keyword_filter_skips_non_matching_videos(self, mock_fetch):
+        """nouriel_roubini (and similar multi-guest channels) rely on
+        keyword_filter to scope a channel-wide feed down to relevant
+        appearances — this must keep working after switching from
+        youtube_transcript to youtube_data_api (#pipeline-ingestion-recovery)."""
+        from src.media_ingestor import fetch_youtube_data_api
+
+        source_with_filter = {
+            **self.YOUTUBE_SOURCE,
+            "keyword_filter": ["Roubini", "Dr. Doom"],
+        }
+        mock_fetch.return_value = [
+            {
+                "video_id": "match123456",
+                "title": "Nouriel Roubini on the global economy",
+                "description": "Dr. Doom joins to discuss recession risk",
+                "published_at": "2026-04-28T12:00:00Z",
+                "channel_id": "UCa5oCHMV7ImHb6FxJGqz9cQ",
+                "channel_title": "Bloomberg Television",
+                "url": "https://www.youtube.com/watch?v=match123456",
+            },
+            {
+                "video_id": "nomatch12345",
+                "title": "Markets close higher on Fed news",
+                "description": "A recap of today's trading session",
+                "published_at": "2026-04-28T12:00:00Z",
+                "channel_id": "UCa5oCHMV7ImHb6FxJGqz9cQ",
+                "channel_title": "Bloomberg Television",
+                "url": "https://www.youtube.com/watch?v=nomatch12345",
+            },
+        ]
+
+        with patch.dict(os.environ, {"YOUTUBE_API_KEY": "test_key"}):
+            items = fetch_youtube_data_api(source_with_filter, self.DEFAULTS)
+
+        assert len(items) == 1
+        assert items[0].source_url == "https://www.youtube.com/watch?v=match123456"
+
     def test_no_channel_id_anywhere_returns_empty(self):
         from src.media_ingestor import fetch_youtube_data_api
 


### PR DESCRIPTION
Pipeline-ingestion incident recovery (after #1169/#1171 fixed the migration step). Root cause of "0 resolutions" was: extraction hit the Gemini free-tier 20 req/day cap → 0 utterances → the extraction-health gate skipped **Resolve** (even though resolving prior PENDING predictions doesn't need today's extraction).

## Fixes
1. **Decouple Resolve from the extraction gate** — `Resolve predictions` now runs `if: always() && steps.install_deps.outcome == 'success' && auth not failed`. A dry/quota-limited extraction no longer blocks grading prior predictions.
2. **Register the `podcast` fetcher** — `FETCHERS["podcast"] = fetch_rss` (Megaphone is plain RSS); fixes the_ringer_nfl / bill_simmons_podcast.
3. **Feeds** — repoint/disable dead `ringer_nba` + `epsilon_theory`; switch the 6 `youtube_transcript` sources to `youtube_data_api` (feeds.xml is IP-blocked on GH-hosted runners); wire `YOUTUBE_API_KEY` with graceful-degrade (warn + return `[]` if unset).
4. **Gemini quota guard** — stop the batch on the first RESOURCE_EXHAUSTED/429 instead of burning the rest of `--limit`; `--limit` now settable via the `EXTRACTION_LIMIT` repo var.

## Verification
Feed/ingestion test files fully green (101 passed); +8 new passing tests (incl. quota-stop behavior). No net-new failures vs main — the 11 pre-existing `test_assertion_extractor.py` failures (stance/run-write) are red on main independently.

## Needs from Andrew (flagged, non-blocking to merge)
- Add repo secret **`YOUTUBE_API_KEY`** for the YouTube sources to actually pull (else they graceful-degrade to empty).
- **Upgrade off the Gemini free tier** — the quota guard is a mitigation, not a cure; 20 req/day caps extraction volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwhbCT9xrEJzKy3qZndPTA