### PR TITLE
Harden pipeline: gate Resolve on SDIO refresh + guid-first podcast identity (#1174)

### DIFF
--- a/.github/workflows/pundit_pipeline.yml
+++ b/.github/workflows/pundit_pipeline.yml
@@ -142,6 +142,7 @@ jobs:
           python3 scripts/check_extraction_health.py --window-minutes 120 --min-count 1
 
       - name: Refresh SportsDataIO draft data
+        id: refresh_sdio
         # H1 (incident review): gated like Resolve below, NOT behind the extraction
         # verify step. Resolve grades draft_pick/fa_signing/game_outcome against
         # bronze_sportsdataio_* — on a quota/verify-fail day this refresh must still
@@ -169,12 +170,20 @@ jobs:
         # environment actually being usable (deps installed, GCP auth
         # succeeded/was applicable) so Resolve still has working GCP
         # creds/PYTHONPATH; NOT gated on Ingest/Seed/Extract/Verify outcome.
+        #
+        # #1174: DO gate on the SportsDataIO refresh step. If that refresh FAILS
+        # (SDIO outage / bad key), the bronze_sportsdataio_* snapshots Resolve
+        # grades draft_pick/fa_signing/game_outcome against are stale, which is the
+        # exact false-INCORRECT mechanism the refresh step's H1 comment cites. A
+        # 'skipped' refresh (earlier gate not met) is still tolerated — only an
+        # actual 'failure' blocks Resolve.
         if: |
           !cancelled() &&
           steps.install_deps.outcome == 'success' &&
           steps.apply_migrations.outcome == 'success' &&
           steps.auth_wif.outcome != 'failure' &&
-          steps.auth_json.outcome != 'failure'
+          steps.auth_json.outcome != 'failure' &&
+          steps.refresh_sdio.outcome != 'failure'
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           # #1131: make GEMINI_API_KEY available in the resolve step so the

--- a/pipeline/src/media_ingestor.py
+++ b/pipeline/src/media_ingestor.py
@@ -312,6 +312,10 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
     for entry in feed.entries[:max_items]:
         title = entry.get("title", "")
         link = entry.get("link", "")
+        # hash_key is the durable dedup identity; source_url (= link) is what we
+        # store/display. For normal feeds they're the same stable per-item <link>.
+        guid = entry.get("id", "")
+        hash_key = link
         if not link:
             # C1 (incident review): podcast feeds (Megaphone etc.) commonly have
             # no per-item <link> — episode identity lives in <enclosure url> or
@@ -321,7 +325,14 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
             if enclosures and enclosures[0].get("href"):
                 link = enclosures[0]["href"]
             else:
-                link = entry.get("id", "")
+                link = guid
+            # #1174 (LOW, from #1172 review): the enclosure URL carries an
+            # ad-measurement prefix (pdst.fm/...) that changes if the publisher
+            # swaps analytics providers, which would break dedup identity vs
+            # history. Prefer the stable <guid> for the hash key; fall back to the
+            # enclosure URL only when there's no guid. Display URL stays the
+            # enclosure so the episode remains playable.
+            hash_key = guid or link
         if not link:
             continue
 
@@ -360,7 +371,7 @@ def fetch_rss(source: dict, defaults: dict) -> list[MediaItem]:
         pundit_id, pundit_name, match_method = match_pundit(
             author, pundits, raw_text=raw_text, source=source
         )
-        content_hash = compute_content_hash(link, title)
+        content_hash = compute_content_hash(hash_key, title)
 
         content_type = "article"
         if source.get("type") == "youtube_rss":

--- a/pipeline/tests/test_media_ingestor.py
+++ b/pipeline/tests/test_media_ingestor.py
@@ -521,6 +521,53 @@ class TestPodcastFetcherRegistration:
         assert items[0].source_url == "https://traffic.megaphone.fm/ep99.mp3"
 
     @patch("src.media_ingestor.feedparser")
+    def test_podcast_content_hash_is_stable_across_enclosure_prefix_change(
+        self, mock_fp
+    ):
+        """#1174: the enclosure URL has a volatile ad-measurement prefix
+        (pdst.fm/... etc.). The dedup content_hash must key off the stable <guid>,
+        so the SAME episode does not re-ingest as new when the publisher swaps
+        analytics providers. source_url still displays the (new) enclosure URL."""
+
+        def _one_item(enclosure_href):
+            entry = MagicMock()
+            entry.get = lambda k, d=None: {
+                "title": "Bill Simmons Podcast: NFL Bets",
+                "link": "",
+                "enclosures": [{"href": enclosure_href}],
+                "id": "gid://megaphone/ep99",  # stable guid across both fetches
+            }.get(k, d)
+            entry.published_parsed = None
+            type(entry).summary = property(lambda self: "Some NFL betting predictions.")
+            entry.content = []
+            entry.tags = []
+            mock_feed = MagicMock()
+            mock_feed.bozo = False
+            mock_feed.entries = [entry]
+            mock_fp.parse.return_value = mock_feed
+            source = {
+                "id": "bill_simmons_podcast",
+                "name": "Bill Simmons",
+                "type": "podcast",
+                "url": "https://feeds.megaphone.fm/bs",
+                "pundits": [],
+            }
+            return FETCHERS["podcast"](source, {"max_items_per_feed": 10})[0]
+
+        old = _one_item("https://pdst.fm/e/traffic.megaphone.fm/ep99.mp3")
+        new = _one_item("https://chtbl.com/track/XYZ/traffic.megaphone.fm/ep99.mp3")
+
+        assert old.content_hash == new.content_hash, (
+            "content_hash must follow the stable <guid>, not the volatile "
+            "enclosure prefix — otherwise a provider swap re-ingests history"
+        )
+        # display URL still reflects the current enclosure so the episode plays
+        assert (
+            new.source_url
+            == "https://chtbl.com/track/XYZ/traffic.megaphone.fm/ep99.mp3"
+        )
+
+    @patch("src.media_ingestor.feedparser")
     def test_podcast_entry_without_link_or_enclosure_falls_back_to_guid(self, mock_fp):
         """No link, no enclosure, but a <guid>/<id> — still ingestible via id."""
         entry = MagicMock()


### PR DESCRIPTION
Closes #1174 — the two non-blocking findings from the #1172 round-2 adversarial review.

## MEDIUM — Resolve ungated on SportsDataIO refresh outcome
#1172 decoupled Resolve from extraction failures so grading proceeds during a Gemini-quota day. Side effect: if the **SportsDataIO refresh step itself** fails (SDIO outage / bad key), Resolve still ran against stale `bronze_sportsdataio_*` — the exact false-INCORRECT mechanism the refresh step's own H1 comment cites.

**Fix:** `id: refresh_sdio` on the refresh step + `steps.refresh_sdio.outcome != 'failure'` on Resolve's `if:`. A `skipped` refresh (an earlier gate not met) stays tolerated; only an actual `failure` blocks Resolve.

## LOW — durable podcast dedup identity
Podcast `content_hash` keyed off the enclosure URL, whose ad-measurement prefix (`pdst.fm/...`) changes if the publisher swaps analytics providers → dedup identity breaks vs history. Now hashes off the stable `<guid>`; enclosure URL stays as the display `source_url`. **Article feeds are unchanged** (still hash on `<link>`), so no dedup break there. One-time, minimal re-ingest of the just-recovered podcast window is expected and acceptable (history is tiny — best time to switch).

## Tests
- New `test_podcast_content_hash_is_stable_across_enclosure_prefix_change`: same `<guid>`, different enclosure prefix → identical `content_hash`, display URL follows the new enclosure.
- `test_media_ingestor.py`: **75 passed** locally.

## Review
Adversarial Fable review requested per loop protocol; self-merge on green + clean per cap-alpha merge authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)