### PR TITLE
fix(api): make /v1/pundits/ resolved-claims + published gates overridable

### DIFF
--- a/pipeline/api/pundit_router.py
+++ b/pipeline/api/pundit_router.py
@@ -277,19 +277,55 @@ def list_pundits(
         le=1.0,
         description="Filter predictions by minimum quality score (0.0–1.0).",
     ),
+    min_resolved_claims: Optional[int] = Query(
+        default=None,
+        ge=0,
+        description=(
+            "Override the minimum resolved-claims threshold a pundit must "
+            "clear to appear in results. Omit to use the server default "
+            "(MIN_RESOLVED_CLAIMS env var, currently "
+            f"{os.environ.get('MIN_RESOLVED_CLAIMS', '5')}). Pass 0 for an "
+            "unfiltered list — callers that already apply their own volume "
+            "floor (e.g. min-picks + Wilson-score sort) client-side should "
+            "do this (Issue #1178)."
+        ),
+    ),
+    published_only: Optional[bool] = Query(
+        default=None,
+        description=(
+            "Override the tier-1 'published' gate. Omit to use the server "
+            "default (True). Pass false to include every pundit with ledger "
+            "activity, not just the curated tier-1 list (Issue #1178)."
+        ),
+    ),
     db: DBManager = Depends(get_db),
 ) -> Dict[str, Any]:
     """
     Returns all pundits with aggregate accuracy stats.
     Accepts ?min_quality=0.7 to compute stats using only high-quality predictions.
+
+    By default this endpoint applies two gates inherited from Issue #830:
+    published_only=True (tier-1 curated list) and a resolved-claims floor
+    (MIN_RESOLVED_CLAIMS, default 5). Both are overridable per-request via
+    min_resolved_claims / published_only so a caller that wants the complete,
+    unfiltered ledger (and applies its own filtering) isn't silently capped —
+    see Issue #1178, where the site's own "Full Ledger" view had no way to
+    ask for an unfiltered pull and so under-reported the pundit field.
     """
     try:
-        min_resolved = int(os.environ.get("MIN_RESOLVED_CLAIMS", "5"))
+        min_resolved = (
+            min_resolved_claims
+            if min_resolved_claims is not None
+            else int(os.environ.get("MIN_RESOLVED_CLAIMS", "5"))
+        )
+        effective_published_only = (
+            published_only if published_only is not None else True
+        )
         df = get_pundit_accuracy_summary(
             db=db,
             min_quality=min_quality,
             min_resolved_claims=min_resolved,
-            published_only=True,
+            published_only=effective_published_only,
         )
 
         # Left-join calibration metrics (brier_score, overconfidence_score)

--- a/pipeline/tests/test_adjudication_830.py
+++ b/pipeline/tests/test_adjudication_830.py
@@ -353,6 +353,57 @@ class TestApiMinClaimsGuard:
             assert call_kwargs is not None, "get_pundit_accuracy_summary was not called"
             assert call_kwargs.kwargs.get("min_resolved_claims") == 5
 
+    def test_list_pundits_query_params_override_defaults(self):
+        """Issue #1178: ?min_resolved_claims=0&published_only=false bypasses
+        both gates so a caller that does its own client-side filtering (the
+        site's own ledger page + leaderboard preview) can request the full,
+        unfiltered pundit list instead of being silently capped at the
+        tier-1 / 5-resolved defaults."""
+        import unittest.mock as mock
+
+        with (
+            mock.patch("src.db_manager.DBManager._initialize_connection"),
+            mock.patch("api.pundit_router.get_pundit_accuracy_summary") as mock_summary,
+        ):
+            from api.main import app
+            from api.api_key_auth import verify_api_key
+            from api.pundit_router import get_db
+            from fastapi.testclient import TestClient
+
+            mock_summary.return_value = pd.DataFrame()
+
+            stub_key = {
+                "tier": "pro",
+                "user_id": "u1",
+                "key_id": "k1",
+                "status": "active",
+                "scopes": [],
+                "name": "T",
+                "created_at": None,
+                "last_used_at": None,
+                "key_last_four": "test",
+            }
+            mock_db_inst = MagicMock()
+            mock_db_inst.project_id = "test-project"
+            mock_db_inst.dataset_id = "nfl_dead_money"
+            mock_db_inst.client.query.return_value = MagicMock(
+                to_dataframe=lambda: pd.DataFrame()
+            )
+
+            app.dependency_overrides[get_db] = lambda: mock_db_inst
+            app.dependency_overrides[verify_api_key] = lambda: stub_key
+
+            with TestClient(app) as c:
+                resp = c.get("/v1/pundits/?min_resolved_claims=0&published_only=false")
+
+            app.dependency_overrides.clear()
+
+            assert resp.status_code == 200
+            call_kwargs = mock_summary.call_args
+            assert call_kwargs is not None, "get_pundit_accuracy_summary was not called"
+            assert call_kwargs.kwargs.get("min_resolved_claims") == 0
+            assert call_kwargs.kwargs.get("published_only") is False
+
 
 # ---------------------------------------------------------------------------
 # 5. publish_tier1_pundits seed script

--- a/web/app/api/ledger/pundits/route.ts
+++ b/web/app/api/ledger/pundits/route.ts
@@ -102,7 +102,19 @@ export async function GET(req: Request) {
         }
 
         const data = await res.json();
-        const pundits = (data.pundits || []).map(normalizePundit);
+        // Drop identity-less rows before they reach the UI. The unfiltered
+        // backend pull (min_resolved_claims=0&published_only=false above)
+        // surfaces ledger rows whose pundit_id is NULL ("Unknown"/null-named
+        // aggregation artifacts). Those rows break React keys (several rows
+        // share the null id), render as "Unknown" cards, and link to a dead
+        // /pundits/null detail page. The client-side volume floors don't
+        // catch them because some have >= 5 resolved claims.
+        const pundits = (data.pundits || [])
+            .filter(
+                (p: Record<string, unknown>) =>
+                    typeof p.pundit_id === "string" && p.pundit_id.length > 0
+            )
+            .map(normalizePundit);
 
         // Inject honeypot fields at the top level to fingerprint scrapers.
         // Issue: #884

--- a/web/app/api/ledger/pundits/route.ts
+++ b/web/app/api/ledger/pundits/route.ts
@@ -62,6 +62,20 @@ export async function GET(req: Request) {
     if (backendUrl.searchParams.get("sport") === "ALL") {
         backendUrl.searchParams.delete("sport");
     }
+    // Request the full, unfiltered pundit list from the backend (Issue #1178).
+    // /v1/pundits/ defaults to published_only=True + a 5-resolved-claims floor
+    // (Issue #830), which collapsed the site's "Full Ledger" view from 43
+    // pundits to 3. Every consumer of this route already applies its own
+    // volume floor + sort client-side (ledger/page.tsx's HOF_MIN_RESOLVED /
+    // MIN_RESOLVED_FOR_RANK, pundit-leaderboard-preview.tsx's MIN_PICKS +
+    // Wilson-score sort), so the backend gate is redundant here and only
+    // hides real data. Don't clobber an explicit override a caller sends.
+    if (!backendUrl.searchParams.has("min_resolved_claims")) {
+        backendUrl.searchParams.set("min_resolved_claims", "0");
+    }
+    if (!backendUrl.searchParams.has("published_only")) {
+        backendUrl.searchParams.set("published_only", "false");
+    }
 
     try {
         // Cache the backend fetch for 5 min so the expensive upstream call is


### PR DESCRIPTION
## Summary

Closes part of #1178 — the "43 pundits in snapshot vs 3 live" symptom (root cause A). Does **not** fix the second symptom in that issue (`total_resolved: 0` on `/api/ledger/resolution-stats`), which is a separate, unrelated code path — proposed for approval in a comment on #1178 instead of guessed at here.

## Root cause (verified against live BigQuery + live prod, not guessed)

`list_pundits()` (`pipeline/api/pundit_router.py`) hardcodes two gates when calling `get_pundit_accuracy_summary()`:
- `published_only=True` — INNER JOINs `nfl_dead_money.pundit_registry` on `published = TRUE`, restricting results to the static 23-pundit tier-1 curated list (of 161 registry rows / 47 distinct pundits with real ledger activity).
- `min_resolved_claims=int(os.environ.get("MIN_RESOLVED_CLAIMS", "5"))` — a `HAVING COUNTIF(resolved) >= 5` floor.

Neither is exposed as a request parameter, so no caller — including the site's own "Full Ledger" tab, which is supposed to show everything with no resolved-count filter — can ask for an unfiltered pull.

Reproduced the exact query live against `cap-alpha-protocol`:
- With both gates (today's default): **3 rows** — `espn_nfl_staff`, `pat_mcafee`, `field_yates` — `resolved_count` sums to **53**, matching the issue's reported figures exactly, and matching `curl https://cap-alpha.co/api/ledger/pundits?limit=100` live right now.
- With both gates dropped: **50 rows**.
- The committed snapshot (`web/lib/data/leaderboard-snapshot.json`, generated 2026-06-17 via an unfiltered ad-hoc BigQuery query) has **43** pundits — consistent with an unfiltered pull at that time, not with either backend gate.

Checked whether recent merged work is implicated (issue explicitly flagged this as unverified): `git show` on #1167 (`4807f085`) shows it only touches `get_pending_predictions` / draft-pick / season_year logic in `resolution_engine.py`, not `get_pundit_accuracy_summary`. #1172 and #1175 only touch `.github/workflows/pundit_pipeline.yml` and `media_ingestor.py`. **None of #1167/#1172/#1175 touch this gating logic** — it's unchanged since #830 (`95002309`), well before this month's work.

Also confirmed the frontend already does its own client-side volume-floor + sort for every view that needs one (`web/app/ledger/page.tsx`: `HOF_MIN_RESOLVED=5`, `MIN_RESOLVED_FOR_RANK=5`, `total_predictions>=10`; `web/components/pundit-leaderboard-preview.tsx`: `MIN_PICKS=5` + Wilson-score sort + staff-bucket exclusion). The backend's own hardcoded gate is redundant with, and more restrictive than, what every consumer already implements — it just silently caps the pool those client filters get to work with.

## Fix

- `pipeline/api/pundit_router.py`: add optional `min_resolved_claims` / `published_only` query params to `GET /v1/pundits/`. Both default to `None`, which falls back to the exact previous behavior (`MIN_RESOLVED_CLAIMS` env var, `published_only=True`) — **zero behavior change for any existing API caller** that doesn't pass them. Existing test asserting default `min_resolved_claims == 5` (`test_list_pundits_passes_min_resolved_5`) passes unmodified.
- `web/app/api/ledger/pundits/route.ts`: the internal Next.js proxy (used only by cap-alpha.co itself) now explicitly requests `min_resolved_claims=0&published_only=false`, so the site gets the full, real pundit list and its existing client-side filtering does the rest.
- `pipeline/tests/test_adjudication_830.py`: added `test_list_pundits_query_params_override_defaults` asserting the override params propagate correctly.

## Test plan

- [x] `pytest pipeline/tests/test_adjudication_830.py -v` — 19/19 pass, including the new override test and the two pre-existing default-behavior tests (unmodified, still green).
- [x] `ruff check` / `ruff format --check` clean on both touched Python files.
- [x] Live BigQuery sanity check: `get_pundit_accuracy_summary(min_resolved_claims=0, published_only=False)` → 50 rows; default params → 3 rows (matches prod today).
- [ ] Post-merge: confirm `https://cap-alpha.co/api/ledger/pundits?limit=100` returns the full pundit set and the `/ledger` "Full Ledger" tab renders more than 3 pundits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwhbCT9xrEJzKy3qZndPTA